### PR TITLE
Add KeywordLabeler app configuration

### DIFF
--- a/.github/keylabeler.yml
+++ b/.github/keylabeler.yml
@@ -1,0 +1,20 @@
+# KeywordLabeler app configuration. For more information check:
+# https://github.com/ZeWaka/KeywordLabeler#readme
+
+# Determines if we search the title (optional). Defaults to true.
+matchTitle: true
+
+# Determines if we search the body (optional). Defaults to true.
+matchBody: true
+
+# Determines if label matching is case sensitive (optional). Defaults to true.
+caseSensitive: true
+
+# Explicit keyword mappings to labels. Form of match:label. Required.
+labelMappings:
+  "part:data-pipeline": "part:data-pipeline"
+  "part:docs": "part:docs"
+  "part:power-distribution": "part:power-distribution"
+  "part:tests": "part:tests"
+  "part:tooling": "part:tooling"
+  "part:❓": "part:❓"


### PR DESCRIPTION
This app automatically adds labels based on keywords found in the title and description of an issue. For more information check: https://github.com/ZeWaka/KeywordLabeler#readme
