### PR TITLE
Resampling actor

### DIFF
--- a/src/frequenz/sdk/data_ingestion/resampling/__init__.py
+++ b/src/frequenz/sdk/data_ingestion/resampling/__init__.py
@@ -1,0 +1,9 @@
+"""
+Tools for resampling streamed component data.
+
+Copyright
+Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+
+License
+MIT
+"""

--- a/src/frequenz/sdk/data_ingestion/resampling/resampler.py
+++ b/src/frequenz/sdk/data_ingestion/resampling/resampler.py
@@ -1,0 +1,170 @@
+"""
+Interface for a class that will implement the resampling logic.
+
+Copyright
+Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+
+License
+MIT
+"""
+import logging
+from abc import ABC, abstractmethod
+from datetime import datetime
+from typing import List
+
+from frequenz.sdk.data_ingestion.resampling.ring_buffer import DataPoint
+from frequenz.sdk.microgrid import Component, ComponentCategory
+
+logger = logging.Logger(__name__)
+
+
+class Resampler(ABC):
+    """Resampler interface."""
+
+    def resample_component_data(  # pylint: disable=too-many-arguments
+        self,
+        component: Component,
+        data_points: List[DataPoint],
+        resampling_window_start: datetime,
+        resampling_frequency: float,
+        max_component_data_delay: float = 5.0,
+    ) -> DataPoint:
+        """Delegate resampling of data points based on the component category.
+
+        Args:
+            component: component that the data points belong to
+            data_points: data points for a single battery from the ring buffer.
+            resampling_window_start: timestamp of the beginning of the resampling window.
+            resampling_frequency: what frequency should the original data points be
+                converted to
+            max_component_data_delay: amount of time in seconds describing how much
+                delayed data points in the ring buffer for `component_d` can be to still
+                be considered accurate enough for resampling
+
+        Returns:
+            Data points for a given battery resampled into a single sample.
+
+        Raises:
+            ValueError: if category of any component in the microgrid is not supported
+        """
+        if component.category == ComponentCategory.BATTERY:
+            return self.resample_battery_data(
+                data_points=data_points,
+                resampling_window_start=resampling_window_start,
+                resampling_frequency=resampling_frequency,
+                max_component_data_delay=max_component_data_delay,
+            )
+        if component.category == ComponentCategory.METER:
+            return self.resample_meter_data(
+                data_points=data_points,
+                resampling_window_start=resampling_window_start,
+                resampling_frequency=resampling_frequency,
+                max_component_data_delay=max_component_data_delay,
+            )
+        if component.category == ComponentCategory.INVERTER:
+            return self.resample_inverter_data(
+                data_points=data_points,
+                resampling_window_start=resampling_window_start,
+                resampling_frequency=resampling_frequency,
+                max_component_data_delay=max_component_data_delay,
+            )
+        if component.category == ComponentCategory.EV_CHARGER:
+            return self.resample_ev_charger_data(
+                data_points=data_points,
+                resampling_window_start=resampling_window_start,
+                resampling_frequency=resampling_frequency,
+                max_component_data_delay=max_component_data_delay,
+            )
+        raise ValueError(f"Unsupported component category: {component.category}")
+
+    @abstractmethod
+    def resample_battery_data(
+        self,
+        data_points: List[DataPoint],
+        resampling_window_start: datetime,
+        resampling_frequency: float,
+        max_component_data_delay: float = 5.0,
+    ) -> DataPoint:
+        """Resample battery data.
+
+        Args:
+            data_points: Data points for a single battery from the ring buffer.
+            resampling_window_start: timestamp of the beginning of the resampling window.
+            resampling_frequency: what frequency should the original data points be
+                converted to
+            max_component_data_delay: amount of time in seconds describing how much
+                delayed data points in the ring buffer for `component_d` can be to still
+                be considered accurate enough for resampling
+
+        Returns:
+            Data points for a given battery resampled into a single sample.
+        """
+
+    @abstractmethod
+    def resample_meter_data(
+        self,
+        data_points: List[DataPoint],
+        resampling_window_start: datetime,
+        resampling_frequency: float,
+        max_component_data_delay: float = 5.0,
+    ) -> DataPoint:
+        """Resample meter data.
+
+        Args:
+            data_points: Data points for a single meter from the ring buffer.
+            resampling_window_start: timestamp of the beginning of the resampling window.
+            resampling_frequency: what frequency should the original data points be
+                converted to
+            max_component_data_delay: amount of time in seconds describing how much
+                delayed data points in the ring buffer for `component_d` can be to still
+                be considered accurate enough for resampling
+
+        Returns:
+            Data points for a given meter resampled into a single sample.
+        """
+
+    @abstractmethod
+    def resample_inverter_data(
+        self,
+        data_points: List[DataPoint],
+        resampling_window_start: datetime,
+        resampling_frequency: float,
+        max_component_data_delay: float = 5.0,
+    ) -> DataPoint:
+        """Resample inverter data.
+
+        Args:
+            data_points: Data points for a single inverter from the ring buffer.
+            resampling_window_start: timestamp of the beginning of the resampling window.
+            resampling_frequency: what frequency should the original data points be
+                converted to
+            max_component_data_delay: amount of time in seconds describing how much
+                delayed data points in the ring buffer for `component_d` can be to still
+                be considered accurate enough for resampling
+
+        Returns:
+            Data points for a given inverter resampled into a single sample.
+        """
+
+    @abstractmethod
+    def resample_ev_charger_data(
+        self,
+        data_points: List[DataPoint],
+        resampling_window_start: datetime,
+        resampling_frequency: float,
+        max_component_data_delay: float = 5.0,
+    ) -> DataPoint:
+        """Resample EV charger data.
+
+        Args:
+            data_points: Data points for a single EV charger from the ring buffer.
+            resampling_window_start: timestamp of the beginning of the resampling window.
+            resampling_frequency: what frequency should the original data points be
+                converted to
+            max_component_data_delay: amount of time in seconds describing how much
+                delayed data points in the ring buffer for `component_d` can be to still
+                be considered accurate enough for resampling
+
+        Returns:
+            Data points for a given EV charger resampled into a single sample.
+        """

--- a/src/frequenz/sdk/data_ingestion/resampling/resampling_actor.py
+++ b/src/frequenz/sdk/data_ingestion/resampling/resampling_actor.py
@@ -1,0 +1,181 @@
+"""
+Actor for combining and resampling stream data from different components.
+
+Copyright
+Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+
+License
+MIT
+"""
+import logging
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List, Set
+
+from frequenz.channels import Merge, Receiver, Select, Sender, Timer
+
+from frequenz.sdk.actor.decorator import actor
+from frequenz.sdk.data_ingestion.resampling.resampler import Resampler
+from frequenz.sdk.data_ingestion.resampling.ring_buffer import DataPoint, RingBuffer
+from frequenz.sdk.microgrid import Component, ComponentCategory, InverterData
+from frequenz.sdk.microgrid.client import MicrogridApiClient
+
+logger = logging.Logger(__name__)
+
+MAX_BUFFER_SIZE = 1000
+
+
+async def generate_component_data_receivers(
+    microgrid_client: MicrogridApiClient,
+) -> Dict[ComponentCategory, Receiver[Dict[str, Any]]]:
+    """Generate receivers for all components grouped by component category.
+
+    Group all components by `ComponentCategory` and create a receiver for each group
+        to collect data from the components belonging to that group.
+
+    Args:
+        microgrid_client: microgrid client
+
+    Returns:
+        Receiver of the data per each component category.
+
+    Raises:
+        ValueError: if category of any component in the microgrid is not supported
+    """
+    grouped_components: Dict[ComponentCategory, Set[Component]] = {}
+    microgrid_components = await microgrid_client.components()
+    for component in microgrid_components:
+        if component.category not in grouped_components:
+            grouped_components[component.category] = set()
+        grouped_components[component.category].add(component)
+
+    receiver_groups: Dict[ComponentCategory, Receiver[Dict[str, Any]]] = {}
+
+    for category, components in grouped_components.items():
+        receivers: List[Any] = []
+        for component in components:
+            component_id = component.component_id
+            if category == ComponentCategory.BATTERY:
+                battery_receiver = await microgrid_client.battery_data(component_id)
+                receivers.append(battery_receiver)
+            elif category == ComponentCategory.INVERTER:
+                inverter_receiver: Receiver[
+                    InverterData
+                ] = await microgrid_client.inverter_data(component_id)
+                receivers.append(inverter_receiver)
+            elif category == ComponentCategory.EV_CHARGER:
+                ev_charger_receiver = await microgrid_client.ev_charger_data(
+                    component_id
+                )
+                receivers.append(ev_charger_receiver)
+            elif category in {
+                ComponentCategory.METER,
+                ComponentCategory.CHP,
+                ComponentCategory.PV_ARRAY,
+            }:
+                meter_receiver = await microgrid_client.meter_data(component_id)
+                receivers.append(meter_receiver)
+            else:
+                raise ValueError(f"Unsupported component category: {category}")
+
+        receiver_groups[category] = Merge(*receivers)
+
+    return receiver_groups
+
+
+@actor
+class ResamplingActor:
+    """Actor for receiving and resampling component data."""
+
+    def __init__(  # pylint: disable=too-many-arguments
+        self,
+        microgrid_client: MicrogridApiClient,
+        components: Set[Component],
+        resampling_sink: Sender[DataPoint],
+        resampling_frequency: float,
+        resampler: Resampler,
+        buffer_size: int,
+        max_component_data_delay: float = 5.0,
+    ) -> None:
+        """Initialize ResamplingActor actor.
+
+        Args:
+            microgrid_client: microgrid client
+            components: set of components in the microgrid
+            resampling_sink: sink to be sent the samples
+            resampling_frequency: what frequency should the original data points be
+                converted to
+            resampler: class that implements the `Resampler` interface
+            buffer_size: max number of data points to be stored per each component
+            max_component_data_delay: data points with a bigger delay shouldn't be
+                used to extrapolate values and NaN should be returned instead
+
+        Raises:
+            ValueError: if provided `buffer_size` is smaller than 0 or greater than
+                `MAX_BUFFER_SIZE`
+        """
+        self.microgrid_client = microgrid_client
+        self.resampling_sink = resampling_sink
+        self.resampler = resampler
+
+        if buffer_size < 0 or buffer_size > MAX_BUFFER_SIZE:
+            raise ValueError(
+                f"Buffer size must be an integer in the (0, {MAX_BUFFER_SIZE}) range."
+            )
+
+        self.ring_buffer = RingBuffer(size=buffer_size, components=components)
+        self.component_category_mapping: Dict[int, ComponentCategory] = {
+            component.component_id: component.category for component in components
+        }
+        self.resampling_frequency = resampling_frequency
+        self.max_component_data_delay = max_component_data_delay
+
+    def resample(self) -> List[DataPoint]:
+        """Resample the component data in the ring buffer.
+
+        Returns:
+            Resampled data points.
+
+        Raises:
+            ValueError: if category of any component in the microgrid is not supported
+        """
+        samples: List[DataPoint] = []
+        now = datetime.utcnow()
+        now = now.replace(tzinfo=timezone.utc)
+        resampling_window_start = now - timedelta(seconds=self.resampling_frequency)
+
+        for component_id, deque_items in self.ring_buffer.items():
+            component_category = self.component_category_mapping.get(component_id)
+            if component_category is None:
+                raise ValueError(
+                    f"Unsupported component category encountered "
+                    f"for component: {component_id}"
+                )
+
+            self.resampler.resample_component_data(
+                component=Component(component_id, component_category),
+                data_points=list(deque_items),
+                resampling_window_start=resampling_window_start,
+                resampling_frequency=self.resampling_frequency,
+                max_component_data_delay=self.max_component_data_delay,
+            )
+
+        return samples
+
+    async def run(self) -> None:
+        """Run the actor."""
+        while True:
+            receivers = await generate_component_data_receivers(
+                microgrid_client=self.microgrid_client
+            )
+
+            select = Select(
+                component_data_receiver=Merge(*receivers.values()),
+                resample_timer=Timer(self.resampling_frequency),
+            )
+            while await select.ready():
+                if msg := select.component_data_receiver:
+                    self.ring_buffer.insert(component_data=msg.inner)
+                elif _ := select.resample_timer:
+                    samples = self.resample()
+                    for sample in samples:
+                        await self.resampling_sink.send(sample)

--- a/src/frequenz/sdk/data_ingestion/resampling/ring_buffer.py
+++ b/src/frequenz/sdk/data_ingestion/resampling/ring_buffer.py
@@ -1,0 +1,121 @@
+"""
+Ring buffer for storing ordered streamed component data for resampling purposes.
+
+Copyright
+Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+
+License
+MIT
+"""
+import datetime
+import logging
+from collections import deque
+from dataclasses import dataclass
+from typing import Deque, Dict, ItemsView, Set
+
+from frequenz.sdk.microgrid import Component
+
+logger = logging.Logger(__name__)
+
+MAX_BUFFER_SIZE = 1000
+
+
+@dataclass
+class DataPoint:
+    """DataPoint class to be replaced by ComponentData dataclass."""
+
+    component_id: int
+    timestamp: datetime.datetime
+
+
+class RingBuffer:
+    """Ring buffer for storing data points with component data."""
+
+    def __init__(  # pylint: disable=too-many-arguments
+        self,
+        size: int,
+        components: Set[Component],
+    ) -> None:
+        """Initialize RingBuffer.
+
+        Args:
+            size: max number of data points to be stored per each component
+            components: set of components in the microgrid
+
+        Raises:
+            ValueError: if provided `buffer_size` is smaller than 0 or greater than
+                `MAX_BUFFER_SIZE`
+        """
+        if size < 0 or size > MAX_BUFFER_SIZE:
+            raise ValueError(
+                f"Buffer size must be an integer in the (0, {MAX_BUFFER_SIZE}) range."
+            )
+
+        self._size = size
+        self._buffer: Dict[int, Deque[DataPoint]] = {
+            component.component_id: deque(maxlen=size) for component in components
+        }
+
+    @staticmethod
+    def _find_new_data_point_index(
+        data_points: Deque[DataPoint], new_data_point: DataPoint
+    ) -> int:
+        """Find the appropriate index in the ring buffer to insert a new data point.
+
+        To preserve order in the ring buffer, new data points have to inserted into
+            the right position.
+
+        Args:
+            data_points: list of existing data points for a single component
+            new_data_point: new data point for a single component
+
+        Returns:
+            Index where the new data point should be inserted.
+        """
+        for index, data_point in enumerate(data_points):
+            if data_point.timestamp > new_data_point.timestamp:
+                return index
+        return len(data_points)
+
+    def items(self) -> ItemsView[int, Deque[DataPoint]]:
+        """Get all the items in the ring buffer.
+
+        Returns:
+            All the items in the ring buffer.
+        """
+        return self._buffer.items()
+
+    def insert(self, component_data: DataPoint) -> None:
+        """Insert the latest data from a single component into the ring buffer.
+
+        The order of data points in the ring buffer per component is preserved after
+            inserting the new data point.
+
+        Args:
+            component_data: microgrid client
+
+        Raises:
+            ValueError: if provided `component_data` is missing component ID
+        """
+        component_id = component_data.component_id
+        if component_id is None:
+            raise ValueError(
+                f"Component ID missing in component data: {component_data}"
+            )
+
+        if len(self._buffer[component_id]) >= self._size:
+            self._buffer[component_id].popleft()
+
+        if len(self._buffer[component_id]) == 0:
+            self._buffer[component_id].append(component_data)
+        else:
+            latest_data_point = self._buffer[component_id][-1]
+
+            if component_data.timestamp >= latest_data_point.timestamp:
+                self._buffer[component_id].append(component_data)
+            else:
+                index = RingBuffer._find_new_data_point_index(
+                    data_points=self._buffer[component_id],
+                    new_data_point=component_data,
+                )
+                self._buffer[component_id].insert(index, component_data)

--- a/tests/data_ingestion/test_ring_buffer.py
+++ b/tests/data_ingestion/test_ring_buffer.py
@@ -1,0 +1,120 @@
+"""
+Test for the `RingBuffer`
+
+Copyright
+Copyright © 2021 Frequenz Energy-as-a-Service GmbH
+
+License
+MIT
+"""
+import datetime
+
+from frequenz.sdk.data_ingestion.resampling.ring_buffer import DataPoint, RingBuffer
+from frequenz.sdk.microgrid import Component, ComponentCategory
+
+now = datetime.datetime.utcnow()
+timestamp = now.replace(tzinfo=datetime.timezone.utc)
+
+
+def test_ring_buffer_insert() -> None:
+    """Check if ComponentData is properly inserted into the ring buffer"""
+
+    components = {Component(component_id=0, category=ComponentCategory.BATTERY)}
+
+    ring_buffer = RingBuffer(size=5, components=components)
+
+    items = [
+        DataPoint(component_id=0, timestamp=timestamp + datetime.timedelta(seconds=i))
+        for i in range(5)
+    ]
+
+    for item in items:
+        ring_buffer.insert(item)
+
+    for _, data_points in ring_buffer.items():
+        assert items == list(data_points)
+
+
+def test_ring_buffer_size() -> None:
+    """Check if ring buffer size limit is properly applied"""
+
+    components = {Component(component_id=0, category=ComponentCategory.BATTERY)}
+
+    buffer_size = 5
+
+    ring_buffer = RingBuffer(size=buffer_size, components=components)
+
+    items = [
+        DataPoint(component_id=0, timestamp=timestamp + datetime.timedelta(seconds=i))
+        for i in range(100)
+    ]
+
+    for item in items:
+        ring_buffer.insert(item)
+
+    for _, data_points in ring_buffer.items():
+        assert len(data_points) == buffer_size
+        assert list(data_points) == items[-buffer_size:]
+
+
+def test_ring_buffer_size_multiple_components() -> None:
+    """Check if ring buffer size limit is properly applied for multiple components"""
+
+    components = {
+        Component(component_id=i, category=ComponentCategory.BATTERY)
+        for i in range(100)
+    }
+
+    buffer_size = 10
+
+    ring_buffer = RingBuffer(size=buffer_size, components=components)
+
+    items = [
+        DataPoint(
+            component_id=component.component_id,
+            timestamp=timestamp + datetime.timedelta(seconds=i),
+        )
+        for i in range(100)
+        for component in components
+    ]
+
+    for item in items:
+        ring_buffer.insert(item)
+
+    total_ring_buffer_size = 0
+    for _, data_points in ring_buffer.items():
+        total_ring_buffer_size += len(data_points)
+        assert len(data_points) == buffer_size
+    assert total_ring_buffer_size == len(components) * buffer_size
+
+
+def test_ring_buffer_insert_order() -> None:
+    """Check if an item "from the past" is inserted in order into the ring buffer."""
+
+    components = {Component(component_id=0, category=ComponentCategory.BATTERY)}
+
+    ring_buffer = RingBuffer(size=11, components=components)
+
+    items = [
+        DataPoint(component_id=0, timestamp=timestamp + datetime.timedelta(seconds=i))
+        for i in range(10)
+    ]
+
+    for item in items:
+        ring_buffer.insert(item)
+
+    for _, data_points in ring_buffer.items():
+        assert len(data_points) == 10
+        assert list(data_points) == items
+
+    delayed_item = DataPoint(
+        component_id=0, timestamp=timestamp + datetime.timedelta(seconds=5)
+    )
+
+    ring_buffer.insert(delayed_item)
+
+    items.insert(5, delayed_item)
+
+    for _, data_points in ring_buffer.items():
+        assert len(data_points) == 11
+        assert list(data_points) == items


### PR DESCRIPTION
Initial implementation of the `ResamplingActor`.

- no reference to the `ComponentGraph` anymore as it is not needed for resampling
- `RingBuffer` will keep data points per component in sorted order and discard the oldest one to make room for the new one
- extrapolation logic to be provided from outside of `ResamplingActor` (conformance to `Resampler` interface is required, not sure if this is how it should look like, but didn't want to pass 4 separate methods to the `ResamplingActor` constructor)
- `DataPoint` class to be replaced by the `ComponentData` class from https://github.com/frequenz-floss/frequenz-sdk-python/pull/4