### PR TITLE
ChannelRegistry improvements

### DIFF
--- a/src/frequenz/sdk/actor/channel_registry.py
+++ b/src/frequenz/sdk/actor/channel_registry.py
@@ -19,8 +19,13 @@ class ChannelRegistry:
     between each other.  Channels are identified by string names.
     """
 
-    def __init__(self) -> None:
-        """Create a `ChannelRegistry` instance."""
+    def __init__(self, *, name: str) -> None:
+        """Create a `ChannelRegistry` instance.
+
+        Args:
+            name: A unique name for the registry.
+        """
+        self._name = name
         self._channels: Dict[str, Broadcast[Any]] = {}
 
     def get_sender(self, key: str) -> Sender[Any]:
@@ -33,7 +38,7 @@ class ChannelRegistry:
             A sender to a dynamically created channel with the given key.
         """
         if key not in self._channels:
-            self._channels[key] = Broadcast(f"dynamic-channel-{key}")
+            self._channels[key] = Broadcast(f"{self._name}-{key}")
         return self._channels[key].get_sender()
 
     def get_receiver(self, key: str) -> Receiver[Any]:
@@ -46,5 +51,5 @@ class ChannelRegistry:
             A receiver for a dynamically created channel with the given key.
         """
         if key not in self._channels:
-            self._channels[key] = Broadcast(f"dynamic-channel-{key}")
+            self._channels[key] = Broadcast(f"{self._name}-{key}")
         return self._channels[key].get_receiver()

--- a/src/frequenz/sdk/actor/channel_registry.py
+++ b/src/frequenz/sdk/actor/channel_registry.py
@@ -7,25 +7,23 @@ License
 MIT
 """
 
-from typing import Any, Dict, Generic, TypeVar
+from typing import Any, Dict
 
 from frequenz.channels import Broadcast, Receiver, Sender
 
-T = TypeVar("T")
 
-
-class ChannelRegistry(Generic[T]):
+class ChannelRegistry:
     """Dynamically creates, own and provide access to channels.
 
     It can be used by actors to dynamically establish a communication channel
-    between each other.  Channels are identified by hashable key objects.
+    between each other.  Channels are identified by string names.
     """
 
     def __init__(self) -> None:
         """Create a `ChannelRegistry` instance."""
-        self._channels: Dict[T, Broadcast[Any]] = {}
+        self._channels: Dict[str, Broadcast[Any]] = {}
 
-    def get_sender(self, key: T) -> Sender[Any]:
+    def get_sender(self, key: str) -> Sender[Any]:
         """Get a sender to a dynamically created channel with the given key.
 
         Args:
@@ -38,7 +36,7 @@ class ChannelRegistry(Generic[T]):
             self._channels[key] = Broadcast(f"dynamic-channel-{key}")
         return self._channels[key].get_sender()
 
-    def get_receiver(self, key: T) -> Receiver[Any]:
+    def get_receiver(self, key: str) -> Receiver[Any]:
         """Get a receiver to a dynamically created channel with the given key.
 
         Args:

--- a/tests/actor/test_channel_registry.py
+++ b/tests/actor/test_channel_registry.py
@@ -10,9 +10,9 @@ MIT
 from frequenz.sdk.actor import ChannelRegistry
 
 
-async def test_channel_registry_with_string() -> None:
+async def test_channel_registry() -> None:
     """Tests for ChannelRegistry, with string as key type."""
-    reg = ChannelRegistry[str]()
+    reg = ChannelRegistry()
 
     sender20 = reg.get_sender("20-hello")
     receiver20 = reg.get_receiver("20-hello")

--- a/tests/actor/test_channel_registry.py
+++ b/tests/actor/test_channel_registry.py
@@ -12,7 +12,7 @@ from frequenz.sdk.actor import ChannelRegistry
 
 async def test_channel_registry() -> None:
     """Tests for ChannelRegistry, with string as key type."""
-    reg = ChannelRegistry()
+    reg = ChannelRegistry(name="test-registry")
 
     sender20 = reg.get_sender("20-hello")
     receiver20 = reg.get_receiver("20-hello")


### PR DESCRIPTION
1. Remove generic key support in ChannelRegistry and use only strings
2. Add a `name` parameter for the ChannelRegistry class, and use it as a channel name prefix.
