### PR TITLE
Add a resampling actor

### DIFF
--- a/examples/sdk_resampling_example.py
+++ b/examples/sdk_resampling_example.py
@@ -1,0 +1,98 @@
+"""Frequenz Python SDK resampling example.
+
+Copyright
+Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+
+License
+MIT
+"""
+
+import asyncio
+
+from frequenz.channels import Broadcast, MergeNamed
+
+from frequenz.sdk.actor import ChannelRegistry
+from frequenz.sdk.actor.data_sourcing import DataSourcingActor
+from frequenz.sdk.data_ingestion.resampling.component_metrics_resampling_actor import (
+    ComponentMetricsResamplingActor,
+)
+from frequenz.sdk.data_pipeline import ComponentMetricId, ComponentMetricRequest
+from frequenz.sdk.microgrid import ComponentCategory, microgrid_api
+
+HOST = "microgrid.sandbox.api.frequenz.io"
+PORT = 61060
+
+
+async def run() -> None:
+    """Run main functions that initializes and creates everything."""
+    await microgrid_api.initialize(HOST, PORT)
+
+    channel_registry = ChannelRegistry(name="Microgrid Channel Registry")
+
+    # Create a channels for sending/receiving subscription requests
+    data_source_request_channel = Broadcast[ComponentMetricRequest](
+        "Data Source Request Channel"
+    )
+    data_source_request_sender = data_source_request_channel.get_sender()
+    data_source_request_receiver = data_source_request_channel.get_receiver()
+
+    resampling_actor_request_channel = Broadcast[ComponentMetricRequest](
+        "Resampling Actor Request Channel"
+    )
+    resampling_actor_request_sender = resampling_actor_request_channel.get_sender()
+    resampling_actor_request_receiver = resampling_actor_request_channel.get_receiver()
+
+    # Instantiate a data sourcing actor
+    _data_sourcing_actor = DataSourcingActor(
+        request_receiver=data_source_request_receiver, registry=channel_registry
+    )
+
+    # Instantiate a resampling actor
+    _resampling_actor = ComponentMetricsResamplingActor(
+        channel_registry=channel_registry,
+        subscription_sender=data_source_request_sender,
+        subscription_receiver=resampling_actor_request_receiver,
+        resampling_period_s=1.0,
+    )
+
+    components = await microgrid_api.get().microgrid_api_client.components()
+    battery_ids = [
+        comp.component_id
+        for comp in components
+        if comp.category == ComponentCategory.BATTERY
+    ]
+
+    # Create subscription requests for each time series id
+    subscription_requests = [
+        ComponentMetricRequest(
+            namespace="Resampling",
+            component_id=component_id,
+            metric_id=ComponentMetricId.SOC,
+            start_time=None,
+        )
+        for component_id in battery_ids
+    ]
+
+    # Send the subscription requests
+    await asyncio.gather(
+        *[
+            resampling_actor_request_sender.send(request)
+            for request in subscription_requests
+        ]
+    )
+
+    # Store sample receivers for each subscription
+    sample_receiver = MergeNamed(
+        **{
+            channel_name: channel_registry.get_receiver(channel_name)
+            for channel_name in map(
+                lambda req: req.get_channel_name(), subscription_requests
+            )
+        }
+    )
+
+    async for channel_name, msg in sample_receiver:
+        print(msg)
+
+
+asyncio.run(run())

--- a/noxfile.py
+++ b/noxfile.py
@@ -5,7 +5,7 @@ import nox
 FMT_DEPS = ["black", "isort"]
 LINT_DEPS = ["mypy", "pylint"]
 DOCSTRING_DEPS = ["pydocstyle", "darglint"]
-PYTEST_DEPS = ["pytest", "pytest-cov", "pytest-mock", "pytest-asyncio"]
+PYTEST_DEPS = ["pytest", "pytest-cov", "pytest-mock", "pytest-asyncio", "time-machine"]
 
 
 def source_file_paths(session: nox.Session) -> List[str]:

--- a/src/frequenz/sdk/data_ingestion/resampling/component_metric_group_resampler.py
+++ b/src/frequenz/sdk/data_ingestion/resampling/component_metric_group_resampler.py
@@ -1,0 +1,108 @@
+"""
+ComponentMetricGroupResampler class that delegates resampling to individual resamplers.
+
+Copyright
+Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+
+License
+MIT
+"""
+import logging
+from datetime import datetime
+from typing import Dict, Generator, Tuple
+
+import pytz
+
+from ...data_pipeline import Sample
+from .component_metric_resampler import ComponentMetricResampler, ResamplingFunction
+
+logger = logging.Logger(__name__)
+
+
+class ComponentMetricGroupResampler:
+    """Class that delegates resampling to individual component metric resamplers."""
+
+    def __init__(
+        self,
+        *,
+        resampling_period_s: float,
+        initial_resampling_function: ResamplingFunction,
+        max_data_age_in_periods: float = 3.0,
+    ) -> None:
+        """Initialize the ComponentMetricGroupResampler.
+
+        Args:
+            resampling_period_s: value describing how often resampling should be
+                performed, in seconds
+            initial_resampling_function: function to be applied to a sequence of
+                samples within a resampling period to produce a single output sample
+            max_data_age_in_periods: max age that samples shouldn't exceed in order
+                to be used in the resampling function
+        """
+        self._resampling_period_s = resampling_period_s
+        self._max_data_age_in_periods: float = max_data_age_in_periods
+        self._initial_resampling_function: ResamplingFunction = (
+            initial_resampling_function
+        )
+        self._resamplers: Dict[str, ComponentMetricResampler] = {}
+
+    def add_time_series(self, time_series_id: str) -> None:
+        """Create a new resampler for a specific time series.
+
+        If resampler already exists for the provided `time_series_id`, it will be used
+            without creating a new one.
+
+        Args:
+            time_series_id: time series id
+        """
+        if time_series_id in self._resamplers:
+            return
+
+        self._resamplers[time_series_id] = ComponentMetricResampler(
+            resampling_period_s=self._resampling_period_s,
+            max_data_age_in_periods=self._max_data_age_in_periods,
+            resampling_function=self._initial_resampling_function,
+        )
+
+    def remove_timeseries(self, time_series_id: str) -> None:
+        """Remove a resampler for a specific time series.
+
+        Args:
+            time_series_id: time series id, for which to remove the resampler
+
+        Raises:
+            KeyError: if resampler for the provided timer_series_id doesn't exist
+        """
+        try:
+            del self._resamplers[time_series_id]
+        except KeyError as err:
+            raise KeyError(
+                f"No resampler for time series {time_series_id} found!"
+            ) from err
+
+    def add_sample(self, time_series_id: str, sample: Sample) -> None:
+        """Add a sample for a specific time series.
+
+        Args:
+            time_series_id: time series id, which the sample should be added to
+            sample: sample to be added
+
+        Raises:
+            KeyError: if resampler for the provided timer_series_id doesn't exist
+        """
+        try:
+            self._resamplers[time_series_id].add_sample(sample)
+        except KeyError as err:
+            raise KeyError(
+                f"No resampler for time series {time_series_id} found!"
+            ) from err
+
+    def resample(self) -> Generator[Tuple[str, Sample], None, None]:
+        """Resample samples for all time series.
+
+        Yields:
+            iterator of time series ids and their newly resampled samples
+        """
+        now = datetime.now(tz=pytz.UTC)
+        for time_series_id, resampler in self._resamplers.items():
+            yield time_series_id, Sample(timestamp=now, value=resampler.resample())

--- a/src/frequenz/sdk/data_ingestion/resampling/component_metric_resampler.py
+++ b/src/frequenz/sdk/data_ingestion/resampling/component_metric_resampler.py
@@ -1,0 +1,97 @@
+"""
+ComponentMetricResampler class for resampling individual metrics.
+
+Copyright
+Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+
+License
+MIT
+"""
+import logging
+from collections import deque
+from datetime import datetime, timedelta
+from typing import Callable, Deque, Optional, Sequence
+
+import pytz
+
+from ...data_pipeline import Sample
+
+logger = logging.Logger(__name__)
+
+
+ResamplingFunction = Callable[[Sequence[Sample], float], float]
+
+
+class ComponentMetricResampler:
+    """Resampler for a single metric of a specific component, e.g. 123_active_power."""
+
+    def __init__(
+        self,
+        resampling_period_s: float,
+        max_data_age_in_periods: float,
+        resampling_function: ResamplingFunction,
+    ) -> None:
+        """Initialize the ComponentMetricResampler.
+
+        Args:
+            resampling_period_s: value describing how often resampling should be
+                performed, in seconds
+            max_data_age_in_periods: max age that samples shouldn't exceed in order
+                to be used in the resampling function
+            resampling_function: function to be applied to a sequence of samples within
+                a resampling period to produce a single output sample
+        """
+        self._resampling_period_s = resampling_period_s
+        self._max_data_age_in_periods: float = max_data_age_in_periods
+        self._buffer: Deque[Sample] = deque()
+        self._resampling_function: ResamplingFunction = resampling_function
+
+    def add_sample(self, sample: Sample) -> None:
+        """Add a new sample.
+
+        Args:
+            sample: sample to be added to the buffer
+        """
+        self._buffer.append(sample)
+
+    def remove_outdated_samples(self, threshold: datetime) -> None:
+        """Remove samples that are older than the provided time threshold.
+
+        It is assumed that items in the buffer are in a sorted order (ascending order
+        by timestamp).
+
+        The removal works by traversing the buffer starting from the oldest sample
+        (smallest timestamp) and comparing sample's timestamp with the threshold.
+        If the sample's threshold is smaller than `threshold`, it means that the
+        sample is outdated and it is removed from the buffer. This continues until
+        the first sample that is with timestamp greater or equal to `threshold` is
+        encountered, then buffer is considered up to date.
+
+        Args:
+            threshold: samples whose timestamp is older than the threshold are
+                considered outdated and should be remove from the buffer
+        """
+        while self._buffer:
+            sample: Sample = self._buffer[0]
+            if sample.timestamp >= threshold:
+                return
+
+            self._buffer.popleft()
+
+    def resample(self) -> Optional[float]:
+        """Resample samples from the buffer and produce a single sample.
+
+        Returns:
+            Samples resampled into a single sample or `None` if the
+                `resampling_function` cannot produce a valid Sample.
+        """
+        # It might be better to provide `now` from the outside so that all
+        # individual resamplers use the same `now`
+        now = datetime.now(tz=pytz.UTC)
+        threshold = now - timedelta(
+            seconds=self._max_data_age_in_periods * self._resampling_period_s
+        )
+        self.remove_outdated_samples(threshold=threshold)
+        if len(self._buffer) == 0:
+            return None
+        return self._resampling_function(self._buffer, self._resampling_period_s)

--- a/src/frequenz/sdk/data_ingestion/resampling/component_metrics_resampling_actor.py
+++ b/src/frequenz/sdk/data_ingestion/resampling/component_metrics_resampling_actor.py
@@ -1,0 +1,240 @@
+"""
+ComponentMetricsResamplingActor used to subscribe for resampled component metrics.
+
+Copyright
+Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+
+License
+MIT
+"""
+import asyncio
+import dataclasses
+import logging
+import math
+from typing import Dict, Sequence
+
+from frequenz.channels import MergeNamed, Receiver, Select, Sender, Timer
+
+from ...actor import ChannelRegistry, actor
+from ...data_pipeline import ComponentMetricRequest, Sample
+from .component_metric_group_resampler import ComponentMetricGroupResampler
+from .component_metric_resampler import ResamplingFunction
+
+logger = logging.Logger(__name__)
+
+
+# pylint: disable=unused-argument
+def average(samples: Sequence[Sample], resampling_period_s: float) -> float:
+    """Calculate average of the provided values.
+
+    Args:
+        samples: sequences of samples to apply the average to
+        resampling_period_s: value describing how often resampling should be performed,
+            in seconds
+
+    Returns:
+        average of all the sample values
+
+    Raises:
+        AssertionError if there are no provided samples
+    """
+    assert len(samples) > 0, "Average cannot be given an empty list of samples"
+    values = list(sample.value for sample in samples if sample.value is not None)
+    return sum(values) / len(values)
+
+
+@actor
+class ComponentMetricsResamplingActor:
+    """ComponentMetricsResamplingActor used to ingest component data and resample it."""
+
+    def __init__(  # pylint: disable=too-many-arguments
+        self,
+        channel_registry: ChannelRegistry,
+        subscription_sender: Sender[ComponentMetricRequest],
+        subscription_receiver: Receiver[ComponentMetricRequest],
+        resampling_period_s: float = 0.2,
+        max_data_age_in_periods: float = 3.0,
+        resampling_function: ResamplingFunction = average,
+    ) -> None:
+        """Initialize the ComponentMetricsResamplingActor.
+
+        Args:
+            channel_registry: global channel registry used for receiving component
+                data from DataSource and for sending resampled samples downstream
+            subscription_sender: channel for sending component metric requests to the
+                DataSourcing actor
+            subscription_receiver: channel for receiving component metric requests
+            resampling_period_s: value describing how often resampling should be
+                performed, in seconds
+            max_data_age_in_periods: max age that samples shouldn't exceed in order
+                to be used in the resampling function
+            resampling_function: function to be applied to a sequence of samples within
+                a resampling period to produce a single output sample
+
+        Example:
+        ```python
+        async def run() -> None:
+            await microgrid_api.initialize(HOST, PORT)
+
+            channel_registry = ChannelRegistry(name="Microgrid Channel Registry")
+
+            data_source_request_channel = Broadcast[ComponentMetricRequest](
+                "Data Source Request Channel"
+            )
+            data_source_request_sender = data_source_request_channel.get_sender()
+            data_source_request_receiver = data_source_request_channel.get_receiver()
+
+            resampling_actor_request_channel = Broadcast[ComponentMetricRequest](
+                "Resampling Actor Request Channel"
+            )
+            resampling_actor_request_sender = resampling_actor_request_channel.get_sender()
+            resampling_actor_request_receiver = resampling_actor_request_channel.get_receiver()
+
+            _data_sourcing_actor = DataSourcingActor(
+                request_receiver=data_source_request_receiver, registry=channel_registry
+            )
+
+            _resampling_actor = ComponentMetricsResamplingActor(
+                channel_registry=channel_registry,
+                subscription_sender=data_source_request_sender,
+                subscription_receiver=resampling_actor_request_receiver,
+                resampling_period_s=1.0,
+            )
+
+            components = await microgrid_api.get().microgrid_api_client.components()
+            battery_ids = [
+                comp.component_id
+                for comp in components
+                if comp.category == ComponentCategory.BATTERY
+            ]
+
+            subscription_requests = [
+                ComponentMetricRequest(
+                    namespace="Resampling",
+                    component_id=component_id,
+                    metric_id=ComponentMetricId.SOC,
+                    start_time=None,
+                )
+                for component_id in battery_ids
+            ]
+
+            await asyncio.gather(
+                *[
+                    resampling_actor_request_sender.send(request)
+                    for request in subscription_requests
+                ]
+            )
+
+            sample_receiver = MergeNamed(
+                **{
+                    channel_name: channel_registry.get_receiver(channel_name)
+                    for channel_name in map(
+                        lambda req: req.get_channel_name(), subscription_requests
+                    )
+                }
+            )
+
+            async for channel_name, msg in sample_receiver:
+                print(msg)
+
+        asyncio.run(run())
+        ```
+        """
+        self._channel_registry = channel_registry
+        self._subscription_sender = subscription_sender
+        self._subscription_receiver = subscription_receiver
+        self._resampling_period_s = resampling_period_s
+        self._max_data_age_in_periods: float = max_data_age_in_periods
+        self._resampling_function: ResamplingFunction = resampling_function
+
+        self._resampler = ComponentMetricGroupResampler(
+            resampling_period_s=resampling_period_s,
+            max_data_age_in_periods=max_data_age_in_periods,
+            initial_resampling_function=resampling_function,
+        )
+
+        self._input_receivers: Dict[str, Receiver[Sample]] = {}
+        self._output_senders: Dict[str, Sender[Sample]] = {}
+        self._resampling_timer = Timer(interval=self._resampling_period_s)
+
+    async def subscribe(self, request: ComponentMetricRequest) -> None:
+        """Subscribe for data for a specific time series.
+
+        Args:
+            request: subscription request for a specific component metric
+        """
+        channel_name = request.get_channel_name()
+
+        data_source_request = dataclasses.replace(request, **dict(namespace="Source"))
+        data_source_channel_name = data_source_request.get_channel_name()
+        if channel_name not in self._input_receivers:
+            await self._subscription_sender.send(data_source_request)
+            receiver: Receiver[Sample] = self._channel_registry.get_receiver(
+                data_source_channel_name
+            )
+            self._input_receivers[data_source_channel_name] = receiver
+            self._resampler.add_time_series(time_series_id=data_source_channel_name)
+
+        if channel_name not in self._output_senders:
+            sender: Sender[Sample] = self._channel_registry.get_sender(channel_name)
+            # This means that the `sender` will be sending samples to the channel with
+            # name `channel_name` based on samples collected from the channel named
+            # `data_source_channel_name`
+            self._output_senders[data_source_channel_name] = sender
+
+    def is_sample_valid(self, sample: Sample) -> bool:
+        """Check if the provided sample is valid.
+
+        Args:
+            sample: sample to be validated
+
+        Returns:
+            True if the sample is valid, False otherwise
+        """
+        if sample.value is None or math.isnan(sample.value):
+            return False
+        return True
+
+    async def run(self) -> None:
+        """Run the actor.
+
+        Raises:
+            ConnectionError: When the provider of the subscription channel closes the
+                connection
+        """
+        while True:
+            select = Select(
+                resampling_timer=self._resampling_timer,
+                subscription_receiver=self._subscription_receiver,
+                component_data_receiver=MergeNamed(**self._input_receivers),
+            )
+            while await select.ready():
+                if _ := select.resampling_timer:
+                    awaitables = [
+                        self._output_senders[channel_name].send(sample)
+                        for channel_name, sample in self._resampler.resample()
+                    ]
+                    await asyncio.gather(*awaitables)
+                if msg := select.component_data_receiver:
+                    if msg.inner is None:
+                        # When this happens, then DataSourcingActor has closed the channel
+                        # for sending data for a specific `ComponentMetricRequest`,
+                        # which may need to be handled properly here, e.g. unsubscribe
+                        continue
+                    channel_name, sample = msg.inner
+                    if self.is_sample_valid(sample=sample):
+                        self._resampler.add_sample(
+                            time_series_id=channel_name,
+                            sample=sample,
+                        )
+                if msg := select.subscription_receiver:
+                    if msg.inner is None:
+                        raise ConnectionError(
+                            "Subscription channel connection has been closed!"
+                        )
+                    await self.subscribe(request=msg.inner)
+                    # Breaking out from the loop is required to regenerate
+                    # component_data_receivers to be able to fulfil this
+                    # subscription (later can be optimized by checking if
+                    # an output channel already existed in the `subscribe()` method)
+                    break

--- a/tests/actor/test_component_metrics_resampling_actor.py
+++ b/tests/actor/test_component_metrics_resampling_actor.py
@@ -1,0 +1,142 @@
+"""Frequenz Python SDK resampling example.
+
+Copyright
+Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+
+License
+MIT
+"""
+import time
+from typing import Iterator
+
+import grpc
+from frequenz.api.microgrid import microgrid_pb2
+from frequenz.api.microgrid.battery_pb2 import Battery
+from frequenz.api.microgrid.battery_pb2 import Data as BatteryData
+from frequenz.api.microgrid.common_pb2 import MetricAggregation
+from frequenz.api.microgrid.microgrid_pb2 import ComponentData, ComponentIdParam
+from frequenz.channels import Broadcast
+from google.protobuf.timestamp_pb2 import Timestamp  # pylint: disable=no-name-in-module
+from pytest_mock import MockerFixture
+
+from frequenz.sdk.actor import ChannelRegistry
+from frequenz.sdk.actor.data_sourcing import DataSourcingActor
+from frequenz.sdk.data_ingestion.resampling.component_metrics_resampling_actor import (
+    ComponentMetricsResamplingActor,
+)
+from frequenz.sdk.data_pipeline import ComponentMetricId, ComponentMetricRequest
+from frequenz.sdk.microgrid import microgrid_api
+from tests.test_microgrid import mock_api
+
+
+async def test_component_metrics_resampling_actor(mocker: MockerFixture) -> None:
+    """Run main functions that initializes and creates everything."""
+
+    servicer = mock_api.MockMicrogridServicer()
+
+    # pylint: disable=unused-argument
+    def get_component_data(
+        request: ComponentIdParam, context: grpc.ServicerContext
+    ) -> Iterator[ComponentData]:
+        """Return an iterator for mock ComponentData."""
+        # pylint: disable=stop-iteration-return
+
+        def next_msg(value: float) -> ComponentData:
+            timestamp = Timestamp()
+            timestamp.GetCurrentTime()
+            return ComponentData(
+                id=request.id,
+                ts=timestamp,
+                battery=Battery(
+                    data=BatteryData(
+                        soc=MetricAggregation(avg=value),
+                    )
+                ),
+            )
+
+        for value in [3, 6, 9]:
+            yield next_msg(value=value)
+            time.sleep(0.1)
+
+    mocker.patch.object(servicer, "GetComponentData", get_component_data)
+
+    server = mock_api.MockGrpcServer(servicer, port=57899)
+    await server.start()
+
+    servicer.add_component(1, microgrid_pb2.ComponentCategory.COMPONENT_CATEGORY_GRID)
+    servicer.add_component(
+        3, microgrid_pb2.ComponentCategory.COMPONENT_CATEGORY_JUNCTION
+    )
+    servicer.add_component(4, microgrid_pb2.ComponentCategory.COMPONENT_CATEGORY_METER)
+    servicer.add_component(7, microgrid_pb2.ComponentCategory.COMPONENT_CATEGORY_METER)
+    servicer.add_component(
+        8, microgrid_pb2.ComponentCategory.COMPONENT_CATEGORY_INVERTER
+    )
+    servicer.add_component(
+        9, microgrid_pb2.ComponentCategory.COMPONENT_CATEGORY_BATTERY
+    )
+
+    servicer.add_connection(1, 3)
+    servicer.add_connection(3, 4)
+    servicer.add_connection(3, 7)
+    servicer.add_connection(7, 8)
+    servicer.add_connection(8, 9)
+
+    await microgrid_api.initialize("[::1]", 57899)
+
+    channel_registry = ChannelRegistry(name="Microgrid Channel Registry")
+
+    data_source_request_channel = Broadcast[ComponentMetricRequest](
+        "Data Source Request Channel"
+    )
+    data_source_request_sender = data_source_request_channel.get_sender()
+    data_source_request_receiver = data_source_request_channel.get_receiver()
+
+    resampling_actor_request_channel = Broadcast[ComponentMetricRequest](
+        "Resampling Actor Request Channel"
+    )
+    resampling_actor_request_sender = resampling_actor_request_channel.get_sender()
+    resampling_actor_request_receiver = resampling_actor_request_channel.get_receiver()
+
+    DataSourcingActor(
+        request_receiver=data_source_request_receiver, registry=channel_registry
+    )
+
+    ComponentMetricsResamplingActor(
+        channel_registry=channel_registry,
+        subscription_sender=data_source_request_sender,
+        subscription_receiver=resampling_actor_request_receiver,
+        resampling_period_s=0.1,
+    )
+
+    subscription_request = ComponentMetricRequest(
+        namespace="Resampling",
+        component_id=9,
+        metric_id=ComponentMetricId.SOC,
+        start_time=None,
+    )
+
+    await resampling_actor_request_sender.send(subscription_request)
+
+    index = 0
+    expected_sample_values = [
+        3.0,
+        4.5,
+        6.0,
+        7.5,
+        9.0,
+        None,
+        None,
+        None,
+    ]
+
+    async for sample in channel_registry.get_receiver(
+        subscription_request.get_channel_name()
+    ):
+        assert sample.value == expected_sample_values[index]
+        index += 1
+        if index >= len(expected_sample_values):
+            break
+
+    await server.stop(0.1)
+    microgrid_api._MICROGRID_API = None  # pylint: disable=protected-access

--- a/tests/data_ingestion/test_group_timeseries_resampler.py
+++ b/tests/data_ingestion/test_group_timeseries_resampler.py
@@ -1,0 +1,81 @@
+"""
+Tests for the `ComponentMetricGroupResampler`
+
+Copyright
+Copyright © 2021 Frequenz Energy-as-a-Service GmbH
+
+License
+MIT
+"""
+from datetime import datetime, timedelta
+from typing import Sequence
+
+import pytz
+import time_machine
+
+from frequenz.sdk.data_ingestion.resampling.component_metric_group_resampler import (
+    ComponentMetricGroupResampler,
+)
+from frequenz.sdk.data_pipeline import Sample
+
+
+# pylint: disable=unused-argument
+def resampling_function_sum(
+    samples: Sequence[Sample], resampling_period_s: float
+) -> float:
+    """Calculate sum of the provided values.
+
+    Args:
+        samples: sequences of samples to apply the average to
+        resampling_period_s: value describing how often resampling should be performed,
+            in seconds
+
+    Returns:
+        sum of all the sample values
+
+    Raises:
+        AssertionError if there are no provided samples
+    """
+    assert len(samples) > 0, "Sum cannot be given an empty list of samples"
+    return sum(sample.value for sample in samples if sample.value is not None)
+
+
+@time_machine.travel(datetime.now())
+def test_component_metric_group_resampler() -> None:
+    """Test if resampling is properly delegated to component metric resamplers."""
+    resampler = ComponentMetricGroupResampler(
+        resampling_period_s=0.2,
+        max_data_age_in_periods=5.0,
+        initial_resampling_function=resampling_function_sum,
+    )
+
+    time_series_id_1 = "123_active_power"
+    time_series_id_2 = "99_active_power"
+
+    resampler.add_time_series(time_series_id=time_series_id_1)
+    resampler.add_time_series(time_series_id=time_series_id_2)
+
+    timestamp = datetime.now(tz=pytz.UTC)
+
+    value1 = 5.0
+    value2 = 15.0
+    value3 = 100.0
+    value4 = 999.0
+
+    sample1 = Sample(timestamp - timedelta(seconds=0.5), value=value1)
+    sample2 = Sample(timestamp - timedelta(seconds=0.7), value=value2)
+    sample3 = Sample(timestamp - timedelta(seconds=5.05), value=value3)
+    sample4 = Sample(timestamp - timedelta(seconds=0.99), value=value4)
+
+    resampler.add_sample(time_series_id=time_series_id_1, sample=sample1)
+    resampler.add_sample(time_series_id=time_series_id_1, sample=sample2)
+    resampler.add_sample(time_series_id=time_series_id_2, sample=sample3)
+    resampler.add_sample(time_series_id=time_series_id_2, sample=sample4)
+
+    resampled_samples = dict(resampler.resample())
+
+    assert resampled_samples[time_series_id_1].timestamp >= timestamp
+    assert resampled_samples[time_series_id_1].value == sum([value1, value2])
+
+    assert resampled_samples[time_series_id_2].timestamp >= timestamp
+    assert resampled_samples[time_series_id_2].value == value4

--- a/tests/data_ingestion/test_timeseries_resampler.py
+++ b/tests/data_ingestion/test_timeseries_resampler.py
@@ -1,0 +1,115 @@
+"""
+Tests for the `TimeSeriesResampler`
+
+Copyright
+Copyright © 2021 Frequenz Energy-as-a-Service GmbH
+
+License
+MIT
+"""
+from datetime import datetime, timedelta
+from typing import Sequence
+
+import pytz
+import time_machine
+
+from frequenz.sdk.data_ingestion.resampling.component_metric_resampler import (
+    ComponentMetricResampler,
+)
+from frequenz.sdk.data_pipeline import Sample
+
+
+# pylint: disable=unused-argument
+def resampling_function_sum(
+    samples: Sequence[Sample], resampling_period_s: float
+) -> float:
+    """Calculate sum of the provided values.
+
+    Args:
+        samples: sequences of samples to apply the average to
+        resampling_period_s: value describing how often resampling should be performed,
+            in seconds
+
+    Returns:
+        sum of all the sample values
+
+    Raises:
+        AssertionError if there are no provided samples
+    """
+    assert len(samples) > 0, "Avg function cannot be given an empty list of samples"
+    return sum(sample.value for sample in samples if sample.value is not None)
+
+
+@time_machine.travel(datetime.now())
+def test_component_metric_resampler_remove_outdated_samples() -> None:
+    """Test if outdated samples are being properly removed."""
+    resampler = ComponentMetricResampler(
+        resampling_period_s=0.2,
+        max_data_age_in_periods=1.0,
+        resampling_function=resampling_function_sum,
+    )
+
+    timestamp = datetime.now(tz=pytz.UTC)
+    sample1 = Sample(timestamp, value=5.0)
+    sample2 = Sample(timestamp + timedelta(seconds=1), value=12.0)
+    resampler.add_sample(sample1)
+    resampler.add_sample(sample2)
+
+    resampler.remove_outdated_samples(threshold=timestamp + timedelta(seconds=0.5))
+    assert list(resampler._buffer) == [sample2]  # pylint: disable=protected-access
+
+    resampler.remove_outdated_samples(threshold=timestamp + timedelta(seconds=1.01))
+    assert len(resampler._buffer) == 0  # pylint: disable=protected-access
+
+
+@time_machine.travel(datetime.now())
+def test_component_metric_resampler_resample() -> None:
+    """Test if resampling function works as expected."""
+    resampler = ComponentMetricResampler(
+        resampling_period_s=0.2,
+        max_data_age_in_periods=5.0,
+        resampling_function=resampling_function_sum,
+    )
+
+    timestamp = datetime.now(tz=pytz.UTC) - timedelta(seconds=0.5)
+
+    value1 = 5.0
+    value2 = 15.0
+
+    sample1 = Sample(timestamp, value=value1)
+    sample2 = Sample(timestamp, value=value2)
+
+    resampler.add_sample(sample1)
+    resampler.add_sample(sample2)
+
+    value = resampler.resample()
+    assert value is not None
+    assert value == sum([value1, value2])
+
+
+@time_machine.travel(datetime.now())
+def test_component_metric_resampler_resample_with_outdated_samples() -> None:
+    """Test that resampling function doesn't take outdated samples into account."""
+    resampler = ComponentMetricResampler(
+        resampling_period_s=0.2,
+        max_data_age_in_periods=5.0,
+        resampling_function=resampling_function_sum,
+    )
+
+    timestamp = datetime.now(tz=pytz.UTC)
+
+    value3 = 100.0
+    value1 = 5.0
+    value2 = 15.0
+
+    sample3 = Sample(timestamp - timedelta(seconds=1.01), value=value3)
+    sample1 = Sample(timestamp - timedelta(seconds=0.5), value=value1)
+    sample2 = Sample(timestamp - timedelta(seconds=0.7), value=value2)
+
+    resampler.add_sample(sample3)
+    resampler.add_sample(sample1)
+    resampler.add_sample(sample2)
+
+    value = resampler.resample()
+    assert value is not None
+    assert value == sum([value1, value2])


### PR DESCRIPTION
Summary of this PR (25.10.2022):

**Last updates:**
- removed the `DataProvider`
- removed the `core` package entirely
- removed the `Sample` class and use the one in data pipeline
- removed `subscriptions.py` entirely
- renamed `TimeSeriesResamplingActor` to `ComponentMetricsResamplingActor`
- updated `ComponentMetricsResamplingActor` to:
  - take a channel sender in the constructor to send subscriptions to the data sourcing actor
  - take a channel receiver in the constructor to receive subscriptions
  - take channel registry as a parameter for receiving component data from the data source and sending out resampled metrics
  - change the request's namespace before forwarding it to the channel registry
- updated the sdk resampling example to use the data sourcing actor `ComponentMetricRequest` class as the subscription request message

**Updates in the N -1 round:**
- added use case documentation for the `TimeSeriesResamplingActor`
- added tests
- added a simple example for using the `TimeSeriesResamplingActor` with a dummy data source (because the real one is still under construction)
- discard samples holding a `NaN` value

**Updates in the N - 2 round:**
- removal of the `RingBuffer` and using a simple `deque` in the `TimeSeriesResampler`
- removing outdated samples in the `TimeSeriesResampler`'s buffer
- renaming `IndividualTimeSeriesResampler` -> `TimeSeriesResampler` and `TimeSeriesResampler` to `GroupTimeSeriesResampler`
- addressing various comments from the reviews
