### PR TITLE
Add a logical meter implementation

### DIFF
--- a/src/frequenz/sdk/timeseries/logical_meter/__init__.py
+++ b/src/frequenz/sdk/timeseries/logical_meter/__init__.py
@@ -1,0 +1,8 @@
+# License: MIT
+# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+
+"""A logical meter for calculating high level metrics for a microgrid."""
+
+from .logical_meter import LogicalMeter
+
+__all__ = ["LogicalMeter"]

--- a/src/frequenz/sdk/timeseries/logical_meter/__init__.py
+++ b/src/frequenz/sdk/timeseries/logical_meter/__init__.py
@@ -3,6 +3,6 @@
 
 """A logical meter for calculating high level metrics for a microgrid."""
 
-from .logical_meter import LogicalMeter
+from ._logical_meter import LogicalMeter
 
 __all__ = ["LogicalMeter"]

--- a/src/frequenz/sdk/timeseries/logical_meter/_formula_builder.py
+++ b/src/frequenz/sdk/timeseries/logical_meter/_formula_builder.py
@@ -1,0 +1,99 @@
+# License: MIT
+# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+
+"""A builder for creating formula engines that operate on resampled component metrics."""
+
+
+from frequenz.channels import Receiver, Sender
+
+from ...actor import ChannelRegistry, ComponentMetricRequest
+from ...microgrid.component import ComponentMetricId
+from .._sample import Sample
+from ._formula_engine import FormulaEngine
+from ._tokenizer import Tokenizer, TokenType
+
+
+class FormulaBuilder:
+    """Provides a way to build a FormulaEngine from resampled data streams."""
+
+    def __init__(
+        self,
+        namespace: str,
+        channel_registry: ChannelRegistry,
+        resampler_subscription_sender: Sender[ComponentMetricRequest],
+        metric_id: ComponentMetricId,
+    ) -> None:
+        """Create a `FormulaBuilder` instance.
+
+        Args:
+            namespace: The unique namespace to allow reuse of streams in the data
+                pipeline.
+            channel_registry: The channel registry instance shared with the resampling
+                and the data sourcing actors.
+            resampler_subscription_sender: A sender to send metric requests to the
+                resampling actor.
+            metric_id: A metric ID to fetch for all components in this formula.
+        """
+        self._channel_registry = channel_registry
+        self._resampler_subscription_sender = resampler_subscription_sender
+        self._namespace = namespace
+        self._formula = FormulaEngine()
+        self._metric_id = metric_id
+
+    async def _get_resampled_receiver(self, component_id: int) -> Receiver[Sample]:
+        """Get a receiver with the resampled data for the given component id.
+
+        This receiver would contain data for the `metric_id` specified when creating the
+        `FormulaBuilder` instance.
+
+        Args:
+            component_id: The component id for which to get a resampled data receiver.
+
+        Returns:
+            A receiver to stream resampled data for the given component id.
+        """
+        request = ComponentMetricRequest(
+            self._namespace, component_id, self._metric_id, None
+        )
+        await self._resampler_subscription_sender.send(request)
+        return self._channel_registry.new_receiver(request.get_channel_name())
+
+    async def push_component_metric(self, component_id: int) -> None:
+        """Push a resampled component metric stream to the formula engine.
+
+        Args:
+            component_id: The component id for which to push a metric fetcher.
+        """
+        receiver = await self._get_resampled_receiver(component_id)
+        self._formula.push_metric(f"#{component_id}", receiver)
+
+    async def from_string(self, formula: str) -> FormulaEngine:
+        """Construct a `FormulaEngine` from the given formula string.
+
+        Formulas can have Component IDs that are preceeded by a pound symbol("#"), and
+        these operators: +, -, *, /, (, ).
+
+        For example, the input string: "#20 + #5" is a formula for adding metrics from
+        two components with ids 20 and 5.
+
+        Args:
+            formula: A string formula.
+
+        Returns:
+            A FormulaEngine instance corresponding to the given formula.
+
+        Raises:
+            ValueError: when there is an unknown token type.
+        """
+        tokenizer = Tokenizer(formula)
+
+        for token in tokenizer:
+            if token.type == TokenType.COMPONENT_METRIC:
+                await self.push_component_metric(int(token.value))
+            elif token.type == TokenType.OPER:
+                self._formula.push_oper(token.value)
+            else:
+                raise ValueError(f"Unknown token type: {token}")
+
+        self._formula.finalize()
+        return self._formula

--- a/src/frequenz/sdk/timeseries/logical_meter/_formula_engine.py
+++ b/src/frequenz/sdk/timeseries/logical_meter/_formula_engine.py
@@ -1,0 +1,201 @@
+# License: MIT
+# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+
+"""A formula engine that can apply formulas on streaming data."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime
+from typing import Dict, List, Optional, Set
+
+from frequenz.channels import Receiver
+
+from .._sample import Sample
+from ._formula_steps import (
+    Adder,
+    Divider,
+    FormulaStep,
+    MetricFetcher,
+    Multiplier,
+    OpenParen,
+    Subtractor,
+)
+
+_operator_precedence = {
+    "(": 0,
+    "/": 1,
+    "*": 2,
+    "-": 3,
+    "+": 4,
+    ")": 5,
+}
+
+
+class FormulaEngine:
+    """A post-fix formula engine that operates on `Sample` receivers.
+
+    Operators and metrics need to be pushed into the engine in in-fix order, and they
+    get rearranged into post-fix in the engine.  This is done using the [Shunting yard
+    algorithm](https://en.wikipedia.org/wiki/Shunting_yard_algorithm).
+
+    Example:
+        To create an engine that adds the latest entries from two receivers, the
+        following calls need to be made:
+
+        ```python
+        engine = FormulaEngine()
+        engine.push_metric("metric_1", receiver_1)
+        engine.push_oper("+")
+        engine.push_metric("metric_2", receiver_2)
+        engine.finalize()
+        ```
+
+        and then every call to `engine.apply()` would fetch a value from each receiver,
+        add the values and return the result.
+    """
+
+    def __init__(
+        self,
+    ) -> None:
+        """Create a `FormulaEngine` instance."""
+        self._steps: List[FormulaStep] = []
+        self._build_stack: List[FormulaStep] = []
+        self._metric_fetchers: Dict[str, MetricFetcher] = {}
+        self._first_run = True
+
+    def push_oper(self, oper: str) -> None:
+        """Push an operator into the engine.
+
+        Args:
+            oper: One of these strings - "+", "-", "*", "/", "(", ")"
+        """
+        if self._build_stack and oper != "(":
+            op_prec = _operator_precedence[oper]
+            while self._build_stack:
+                prev_step = self._build_stack[-1]
+                if op_prec <= _operator_precedence[repr(prev_step)]:
+                    break
+                if oper == ")" and repr(prev_step) == "(":
+                    self._build_stack.pop()
+                    break
+                if repr(prev_step) == "(":
+                    break
+                self._steps.append(prev_step)
+                self._build_stack.pop()
+
+        if oper == "+":
+            self._build_stack.append(Adder())
+        elif oper == "-":
+            self._build_stack.append(Subtractor())
+        elif oper == "*":
+            self._build_stack.append(Multiplier())
+        elif oper == "/":
+            self._build_stack.append(Divider())
+        elif oper == "(":
+            self._build_stack.append(OpenParen())
+
+    def push_metric(self, name: str, data_stream: Receiver[Sample]) -> None:
+        """Push a metric receiver into the engine.
+
+        Args:
+            name: A name for the metric.
+            data_stream: A receiver to fetch this metric from.
+        """
+        fetcher = self._metric_fetchers.setdefault(
+            name, MetricFetcher(name, data_stream)
+        )
+        self._steps.append(fetcher)
+
+    def finalize(self) -> None:
+        """Finalize the formula engine.
+
+        This function must be called before calls to `apply` can be made.
+        """
+        while self._build_stack:
+            self._steps.append(self._build_stack.pop())
+
+    async def synchronize_metric_timestamps(
+        self, metrics: Set[asyncio.Task[Optional[Sample]]]
+    ) -> datetime:
+        """Synchronize the metric streams.
+
+        For synchronised streams like data from the `ComponentMetricsResamplingActor`,
+        this a call to this function is required only once, before the first set of
+        inputs are fetched.
+
+        Args:
+            metrics: The finished tasks from the first `fetch_next` calls to all the
+                `MetricFetcher`s.
+
+        Returns:
+            The timestamp of the latest metric value.
+
+        Raises:
+            RuntimeError: when some streams have no value, or when the synchronization
+                of timestamps fails.
+        """
+        metrics_by_ts: Dict[datetime, str] = {}
+        for metric in metrics:
+            result = metric.result()
+            name = metric.get_name()
+            if result is None:
+                raise RuntimeError(f"Stream closed for component: {name}")
+            metrics_by_ts[result.timestamp] = name
+        latest_ts = max(metrics_by_ts)
+
+        # fetch the metrics with non-latest timestamps again until we have the values
+        # for the same ts for all metrics.
+        for metric_ts, name in metrics_by_ts.items():
+            if metric_ts == latest_ts:
+                continue
+            fetcher = self._metric_fetchers[name]
+            while metric_ts < latest_ts:
+                next_val = await fetcher.fetch_next()
+                assert next_val is not None
+                metric_ts = next_val.timestamp
+            if metric_ts > latest_ts:
+                raise RuntimeError(
+                    "Unable to synchronize timestamps of resampled metrics"
+                )
+        self._first_run = False
+        return latest_ts
+
+    async def apply(self) -> Sample:
+        """Fetch the latest metrics, apply the formula once and return the result.
+
+        Returns:
+            The result of the formula.
+
+        Raises:
+            RuntimeError: if some samples didn't arrive, or if formula application
+                failed.
+        """
+        eval_stack: List[float] = []
+        ready_metrics, pending = await asyncio.wait(
+            [
+                asyncio.create_task(fetcher.fetch_next(), name=name)
+                for name, fetcher in self._metric_fetchers.items()
+            ],
+            return_when=asyncio.ALL_COMPLETED,
+        )
+
+        if pending or any(res.result() is None for res in iter(ready_metrics)):
+            raise RuntimeError("Some resampled metrics didn't arrive")
+
+        if self._first_run:
+            metric_ts = await self.synchronize_metric_timestamps(ready_metrics)
+        else:
+            res = next(iter(ready_metrics)).result()
+            assert res is not None
+            metric_ts = res.timestamp
+
+        for step in self._steps:
+            step.apply(eval_stack)
+
+        # if all steps were applied and the formula was correct, there should only be a
+        # single value in the evaluation stack, and that would be the formula result.
+        if len(eval_stack) != 1:
+            raise RuntimeError("Formula application failed.")
+
+        return Sample(metric_ts, eval_stack[0])

--- a/src/frequenz/sdk/timeseries/logical_meter/_formula_steps.py
+++ b/src/frequenz/sdk/timeseries/logical_meter/_formula_steps.py
@@ -1,0 +1,188 @@
+# License: MIT
+# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+
+"""Steps for building formula engines with."""
+
+from abc import ABC, abstractmethod
+from typing import List, Optional
+
+from frequenz.channels import Receiver
+
+from .._sample import Sample
+
+
+class FormulaStep(ABC):
+    """Represents an individual step/stage in a formula.
+
+    Each step, when applied on to an evaluation stack, would pop its input parameters
+    from the stack and push its result back in.
+    """
+
+    @abstractmethod
+    def __repr__(self) -> str:
+        """Return a string representation of the step.
+
+        Returns:
+            A string representation of the step.
+        """
+
+    @abstractmethod
+    def apply(self, eval_stack: List[float]) -> None:
+        """Apply a formula operation on the eval_stack.
+
+        Args:
+            eval_stack: An evaluation stack, to apply the formula step on.
+        """
+
+
+class Adder(FormulaStep):
+    """A formula step for adding two values."""
+
+    def __repr__(self) -> str:
+        """Return a string representation of the step.
+
+        Returns:
+            A string representation of the step.
+        """
+        return "+"
+
+    def apply(self, eval_stack: List[float]) -> None:
+        """Extract two values from the stack, add them, push the result back in.
+
+        Args:
+            eval_stack: An evaluation stack, to apply the formula step on.
+        """
+        val2 = eval_stack.pop()
+        val1 = eval_stack.pop()
+        eval_stack.append(val1 + val2)
+
+
+class Subtractor(FormulaStep):
+    """A formula step for subtracting one value from another."""
+
+    def __repr__(self) -> str:
+        """Return a string representation of the step.
+
+        Returns:
+            A string representation of the step.
+        """
+        return "-"
+
+    def apply(self, eval_stack: List[float]) -> None:
+        """Extract two values from the stack, subtract them, push the result back in.
+
+        Args:
+            eval_stack: An evaluation stack, to apply the formula step on.
+        """
+        val2 = eval_stack.pop()
+        val1 = eval_stack.pop()
+        eval_stack.append(val1 - val2)
+
+
+class Multiplier(FormulaStep):
+    """A formula step for multiplying two values."""
+
+    def __repr__(self) -> str:
+        """Return a string representation of the step.
+
+        Returns:
+            A string representation of the step.
+        """
+        return "*"
+
+    def apply(self, eval_stack: List[float]) -> None:
+        """Extract two values from the stack, multiply them, push the result back in.
+
+        Args:
+            eval_stack: An evaluation stack, to apply the formula step on.
+        """
+        val2 = eval_stack.pop()
+        val1 = eval_stack.pop()
+        eval_stack.append(val1 * val2)
+
+
+class Divider(FormulaStep):
+    """A formula step for dividing one value by another."""
+
+    def __repr__(self) -> str:
+        """Return a string representation of the step.
+
+        Returns:
+            A string representation of the step.
+        """
+        return "/"
+
+    def apply(self, eval_stack: List[float]) -> None:
+        """Extract two values from the stack, divide them, push the result back in.
+
+        Args:
+            eval_stack: An evaluation stack, to apply the formula step on.
+        """
+        val2 = eval_stack.pop()
+        val1 = eval_stack.pop()
+        eval_stack.append(val1 / val2)
+
+
+class OpenParen(FormulaStep):
+    """A no-op formula step used while building a prefix formula engine.
+
+    Any OpenParen steps would get removed once a formula is built.
+    """
+
+    def __repr__(self) -> str:
+        """Return a string representation of the step.
+
+        Returns:
+            A string representation of the step.
+        """
+        return "("
+
+    def apply(self, _: List[float]) -> None:
+        """No-op."""
+
+
+class MetricFetcher(FormulaStep):
+    """A formula step for fetching a value from a metric Receiver."""
+
+    def __init__(self, name: str, stream: Receiver[Sample]) -> None:
+        """Create a `MetricFetcher` instance.
+
+        Args:
+            name: The name of the metric.
+            stream: A channel receiver from which to fetch samples.
+        """
+        self._name = name
+        self._stream = stream
+        self._next_value: Optional[Sample] = None
+
+    async def fetch_next(self) -> Optional[Sample]:
+        """Fetch the next value from the stream.
+
+        To be called before each call to `apply`.
+
+        Returns:
+            The fetched Sample.
+        """
+        self._next_value = await self._stream.receive()
+        return self._next_value
+
+    def __repr__(self) -> str:
+        """Return a string representation of the step.
+
+        Returns:
+            A string representation of the step.
+        """
+        return self._name
+
+    def apply(self, eval_stack: List[float]) -> None:
+        """Push the latest value from the stream into the evaluation stack.
+
+        Args:
+            eval_stack: An evaluation stack, to apply the formula step on.
+
+        Raises:
+            RuntimeError: No next value available to append.
+        """
+        if self._next_value is None or self._next_value.value is None:
+            raise RuntimeError("No next value available to append.")
+        eval_stack.append(self._next_value.value)

--- a/src/frequenz/sdk/timeseries/logical_meter/_logical_meter.py
+++ b/src/frequenz/sdk/timeseries/logical_meter/_logical_meter.py
@@ -1,0 +1,107 @@
+# License: MIT
+# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+
+"""A logical meter for calculating high level metrics for a microgrid."""
+
+import asyncio
+import uuid
+from typing import Dict, List
+
+from frequenz.channels import Broadcast, Receiver, Sender
+
+from ...actor import ChannelRegistry, ComponentMetricRequest
+from ...microgrid.component import ComponentMetricId
+from .._sample import Sample
+from ._formula_builder import FormulaBuilder
+from ._formula_engine import FormulaEngine
+
+
+class LogicalMeter:
+    """A logical meter for calculating high level metrics in a microgrid.
+
+    LogicalMeter can be used to run formulas on resampled component metric streams.
+
+    Formulas can have Component IDs that are preceeded by a pound symbol("#"), and these
+    operators: +, -, *, /, (, ).
+
+    For example, the input string: "#20 + #5" is a formula for adding metrics from two
+    components with ids 20 and 5.
+    """
+
+    def __init__(
+        self,
+        channel_registry: ChannelRegistry,
+        resampler_subscription_sender: Sender[ComponentMetricRequest],
+    ) -> None:
+        """Create a `LogicalMeter instance`.
+
+        Args:
+            channel_registry: A channel registry instance shared with the resampling
+                actor.
+            resampler_subscription_sender: A sender for sending metric requests to the
+                resampling actor.
+        """
+        self._channel_registry = channel_registry
+        self._resampler_subscription_sender = resampler_subscription_sender
+
+        # Use a randomly generated uuid to create a unique namespace name for the local
+        # meter to use when communicating with the resampling actor.
+        self._namespace = f"logical-meter-{uuid.uuid4()}"
+
+        self._output_channels: Dict[str, Broadcast[Sample]] = {}
+        self._tasks: List[asyncio.Task[None]] = []
+
+    async def _engine_from_formula_string(
+        self, formula: str, metric_id: ComponentMetricId
+    ) -> FormulaEngine:
+        builder = FormulaBuilder(
+            self._namespace,
+            self._channel_registry,
+            self._resampler_subscription_sender,
+            metric_id,
+        )
+        return await builder.from_string(formula)
+
+    async def _run_formula(
+        self, formula: FormulaEngine, sender: Sender[Sample]
+    ) -> None:
+        """Run the formula repeatedly and send the results to a channel.
+
+        Args:
+            formula: The formula to run.
+            sender: A sender for sending the formula results to.
+        """
+        while msg := await formula.apply():
+            await sender.send(msg)
+
+    async def start_formula(
+        self,
+        formula: str,
+        component_metric_id: ComponentMetricId,
+    ) -> Receiver[Sample]:
+        """Start execution of the given formula name.
+
+        Args:
+            formula: formula to execute.
+            component_metric_id: The metric ID to use when fetching receivers from the
+                resampling actor.
+
+        Returns:
+            A Receiver that streams values with the formulas applied.
+        """
+        channel_key = formula + component_metric_id.value
+        if channel_key in self._output_channels:
+            return self._output_channels[channel_key].new_receiver()
+
+        formula_engine = await self._engine_from_formula_string(
+            formula,
+            component_metric_id,
+        )
+        out_chan = Broadcast[Sample](channel_key)
+        self._output_channels[channel_key] = out_chan
+        self._tasks.append(
+            asyncio.create_task(
+                self._run_formula(formula_engine, out_chan.new_sender())
+            )
+        )
+        return out_chan.new_receiver()

--- a/src/frequenz/sdk/timeseries/logical_meter/_tokenizer.py
+++ b/src/frequenz/sdk/timeseries/logical_meter/_tokenizer.py
@@ -1,0 +1,170 @@
+# License: MIT
+# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+
+"""A tokenizer for data pipeline formulas."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Optional
+
+
+class StringIter:
+    """An iterator for reading characters from a string."""
+
+    def __init__(self, raw: str) -> None:
+        """Create a `StringIter` instance.
+
+        Args:
+            raw: The raw string to create the iterator out of.
+        """
+        self._raw = raw
+        self._max = len(raw)
+        self._pos = 0
+
+    @property
+    def pos(self) -> int:
+        """Return the position of the iterator in the raw string.
+
+        Returns:
+            The position of the iterator.
+        """
+        return self._pos
+
+    @property
+    def raw(self) -> str:
+        """Return the raw string the iterator is created with.
+
+        Returns:
+            The base string of the iterator.
+        """
+        return self._raw
+
+    def __iter__(self) -> StringIter:
+        """Return an iterator to this class.
+
+        Returns:
+            self.
+        """
+        return self
+
+    def __next__(self) -> str:
+        """Return the next character in the raw string, and move forward.
+
+        Returns:
+            The next character.
+
+        Raises:
+            StopIteration: when there are no more characters in the string.
+        """
+        if self._pos < self._max:
+            char = self._raw[self._pos]
+            self._pos += 1
+            return char
+        raise StopIteration()
+
+    def peek(self) -> Optional[str]:
+        """Return the next character in the raw string, without consuming it.
+
+        Returns:
+            The next character.
+        """
+        if self._pos < self._max:
+            return self._raw[self._pos]
+        return None
+
+
+class TokenType(Enum):
+    """Represents the types of tokens the Tokenizer can return."""
+
+    COMPONENT_METRIC = 0
+    OPER = 1
+
+
+@dataclass
+class Token:
+    """Represents a Token returned by the Tokenizer."""
+
+    type: TokenType
+    value: str
+
+
+class Tokenizer:
+    """A Tokenizer for breaking down a string formula into individual tokens.
+
+    Every instance is an iterator that allows us to iterate over the individual tokens
+    in the given formula.
+
+    Formulas can have Component IDs that are preceeded by a pound symbol("#"), and these
+    operators: +, -, *, /, (, ).
+
+    For example, the input string: "#20 + #5" would produce three tokens:
+     - COMPONENT_METRIC: 20
+     - OPER: +
+     - COMPONENT_METRIC: 5
+    """
+
+    def __init__(self, formula: str) -> None:
+        """Create a `Tokenizer` instance.
+
+        Args:
+            formula: The string formula to tokenize.
+        """
+        self._formula = StringIter(formula)
+
+    def _read_unsigned_int(self) -> str:
+        """Read an unsigned int from the current position in the input string.
+
+        Returns:
+            A string containing the read unsigned int value.
+
+        Raises:
+            ValueError: when there is no unsigned int at the current position.
+        """
+        first_char = True
+        result = ""
+
+        while char := self._formula.peek():
+            if not char.isdigit():
+                if first_char:
+                    raise ValueError(
+                        f"Expected an integer. got '{char}', "
+                        f"at pos {self._formula.pos} in formula {self._formula.raw}"
+                    )
+                break
+            first_char = False
+            result += char
+            next(self._formula)
+        return result
+
+    def __iter__(self) -> Tokenizer:
+        """Return an iterator to this class.
+
+        Returns:
+            self.
+        """
+        return self
+
+    def __next__(self) -> Token:
+        """Return the next token in the input string.
+
+        Returns:
+            The next token.
+
+        Raises:
+            ValueError: when there are unknown tokens in the input string.
+            StopIteration: when there are no more tokens in the input string.
+        """
+        for char in self._formula:
+            if char in (" ", "\n", "\r", "\t"):
+                continue
+            if char in ("+", "-", "*", "/", "(", ")"):
+                return Token(TokenType.OPER, char)
+            if char == "#":
+                return Token(TokenType.COMPONENT_METRIC, self._read_unsigned_int())
+            raise ValueError(
+                f"Unable to parse character '{char}' at pos: {self._formula.pos}"
+                f" in formula: {self._formula.raw}"
+            )
+        raise StopIteration()

--- a/tests/timeseries/test_formula_engine.py
+++ b/tests/timeseries/test_formula_engine.py
@@ -1,0 +1,172 @@
+# License: MIT
+# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+
+"""Tests for the FormulaEngine and the Tokenizer."""
+
+from datetime import datetime
+from typing import Dict, List, Tuple
+
+from frequenz.channels import Broadcast
+
+from frequenz.sdk.timeseries import Sample
+from frequenz.sdk.timeseries.logical_meter._formula_engine import FormulaEngine
+from frequenz.sdk.timeseries.logical_meter._tokenizer import Token, Tokenizer, TokenType
+
+
+class TestTokenizer:
+    """Tests for the Tokenizer."""
+
+    def test_1(self) -> None:
+        """Test the tokenization of the formula: "#10 + #20 - (#5 * #4)"."""
+        tokens = []
+        lexer = Tokenizer("#10 + #20 - (#5 * #4)")
+        for token in lexer:
+            tokens.append(token)
+        assert tokens == [
+            Token(TokenType.COMPONENT_METRIC, "10"),
+            Token(TokenType.OPER, "+"),
+            Token(TokenType.COMPONENT_METRIC, "20"),
+            Token(TokenType.OPER, "-"),
+            Token(TokenType.OPER, "("),
+            Token(TokenType.COMPONENT_METRIC, "5"),
+            Token(TokenType.OPER, "*"),
+            Token(TokenType.COMPONENT_METRIC, "4"),
+            Token(TokenType.OPER, ")"),
+        ]
+
+
+class TestFormulaEngine:
+    """Tests for the FormulaEngine."""
+
+    def setup(self) -> None:
+        """Initialize the channels required for a test.
+
+        Because we can't create a __init__ or multiple instances of the Test class, we
+        use the `setup` method as a constructor, and call it once before each test.
+        """
+        # pylint: disable=attribute-defined-outside-init
+        self.comp_2 = Broadcast[Sample]("")
+        self.comp_2_sender = self.comp_2.new_sender()
+
+        self.comp_4 = Broadcast[Sample]("")
+        self.comp_4_sender = self.comp_4.new_sender()
+
+        self.comp_5 = Broadcast[Sample]("")
+        self.comp_5_sender = self.comp_5.new_sender()
+        # pylint: enable=attribute-defined-outside-init
+
+    async def run_test(
+        self, formula: str, postfix: str, io_pairs: List[Tuple[List[float], float]]
+    ) -> None:
+        channels: Dict[str, Broadcast[Sample]] = {}
+        engine = FormulaEngine()
+        for token in Tokenizer(formula):
+            if token.type == TokenType.COMPONENT_METRIC:
+                if token.value not in channels:
+                    channels[token.value] = Broadcast(token.value)
+                engine.push_metric(
+                    f"#{token.value}", channels[token.value].new_receiver()
+                )
+            elif token.type == TokenType.OPER:
+                engine.push_oper(token.value)
+        engine.finalize()
+
+        assert repr(engine._steps) == postfix
+
+        now = datetime.now()
+        tests_passed = 0
+        for io_pair in io_pairs:
+            input, output = io_pair
+            [
+                await chan.new_sender().send(Sample(now, value))
+                for chan, value in zip(channels.values(), input)
+            ]
+            assert (await engine.apply()).value == output
+            tests_passed += 1
+        assert tests_passed == len(io_pairs)
+
+    async def test_simple(self) -> None:
+        """Test simple formulas."""
+        await self.run_test(
+            "#2 - #4 + #5",
+            "[#2, #4, -, #5, +]",
+            [
+                ([10.0, 12.0, 15.0], 13.0),
+                ([15.0, 17.0, 20.0], 18.0),
+            ],
+        )
+        await self.run_test(
+            "#2 + #4 - #5",
+            "[#2, #4, #5, -, +]",
+            [
+                ([10.0, 12.0, 15.0], 7.0),
+                ([15.0, 17.0, 20.0], 12.0),
+            ],
+        )
+        await self.run_test(
+            "#2 * #4 + #5",
+            "[#2, #4, *, #5, +]",
+            [
+                ([10.0, 12.0, 15.0], 135.0),
+                ([15.0, 17.0, 20.0], 275.0),
+            ],
+        )
+        await self.run_test(
+            "#2 * #4 / #5",
+            "[#2, #4, #5, /, *]",
+            [
+                ([10.0, 12.0, 15.0], 8.0),
+                ([15.0, 17.0, 20.0], 12.75),
+            ],
+        )
+        await self.run_test(
+            "#2 / #4 - #5",
+            "[#2, #4, /, #5, -]",
+            [
+                ([6.0, 12.0, 15.0], -14.5),
+                ([15.0, 20.0, 20.0], -19.25),
+            ],
+        )
+
+    async def test_compound(self) -> None:
+        """Test compound formulas."""
+        await self.run_test(
+            "#2 + #4 - #5 * #6",
+            "[#2, #4, #5, #6, *, -, +]",
+            [
+                ([10.0, 12.0, 15.0, 2.0], -8.0),
+                ([15.0, 17.0, 20.0, 1.5], 2.0),
+            ],
+        )
+        await self.run_test(
+            "#2 + (#4 - #5) * #6",
+            "[#2, #4, #5, -, #6, *, +]",
+            [
+                ([10.0, 12.0, 15.0, 2.0], 4.0),
+                ([15.0, 17.0, 20.0, 1.5], 10.5),
+            ],
+        )
+        await self.run_test(
+            "(#2 + #4 - #5) * #6",
+            "[#2, #4, #5, -, +, #6, *]",
+            [
+                ([10.0, 12.0, 15.0, 2.0], 14.0),
+                ([15.0, 17.0, 20.0, 1.5], 18.0),
+            ],
+        )
+        await self.run_test(
+            "(#2 + #4 - #5) / #6",
+            "[#2, #4, #5, -, +, #6, /]",
+            [
+                ([10.0, 12.0, 15.0, 2.0], 3.5),
+                ([15.0, 17.0, 20.0, 1.5], 8.0),
+            ],
+        )
+        await self.run_test(
+            "#2 + #4 - (#5 / #6)",
+            "[#2, #4, #5, #6, /, -, +]",
+            [
+                ([10.0, 12.0, 15.0, 2.0], 14.5),
+                ([15.0, 17.0, 20.0, 5.0], 28.0),
+            ],
+        )

--- a/tests/timeseries/test_logical_meter.py
+++ b/tests/timeseries/test_logical_meter.py
@@ -1,0 +1,181 @@
+# License: MIT
+# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+
+"""Tests for the logical meter."""
+
+import time
+from typing import Iterator, Tuple
+
+from frequenz.api.microgrid import microgrid_pb2
+from frequenz.api.microgrid.common_pb2 import AC, Metric
+from frequenz.api.microgrid.meter_pb2 import Data as MeterData
+from frequenz.api.microgrid.meter_pb2 import Meter
+from frequenz.api.microgrid.microgrid_pb2 import ComponentData, ComponentIdParam
+from frequenz.channels import Broadcast, Sender
+from google.protobuf.timestamp_pb2 import Timestamp  # pylint: disable=no-name-in-module
+from grpc.aio import grpc
+from pytest_mock import MockerFixture
+
+from frequenz.sdk import microgrid
+from frequenz.sdk.actor import (
+    ChannelRegistry,
+    ComponentMetricRequest,
+    ComponentMetricsResamplingActor,
+    DataSourcingActor,
+)
+from frequenz.sdk.microgrid.component import ComponentMetricId
+from frequenz.sdk.timeseries.logical_meter import LogicalMeter
+from frequenz.sdk.timeseries.logical_meter._formula_builder import FormulaBuilder
+from tests.microgrid import mock_api
+
+
+class TestLogicalMeter:
+    """Tests for the logical meter."""
+
+    async def setup(
+        self, mocker: MockerFixture
+    ) -> Tuple[Sender[ComponentMetricRequest], ChannelRegistry]:
+        """Initialize a mock microgrid api for a test.
+
+        Because we can't create a __init__ or multiple instances of the Test class, we
+        use the `setup` method as a constructor, and call it once before each test.
+        """
+        microgrid._microgrid._MICROGRID = None  # pylint: disable=protected-access
+        servicer = mock_api.MockMicrogridServicer()
+
+        # pylint: disable=unused-argument
+        def get_component_data(
+            request: ComponentIdParam, context: grpc.ServicerContext
+        ) -> Iterator[ComponentData]:
+            """Return an iterator for mock ComponentData."""
+            # pylint: disable=stop-iteration-return
+
+            def next_msg(value: float) -> ComponentData:
+                timestamp = Timestamp()
+                timestamp.GetCurrentTime()
+                return ComponentData(
+                    id=request.id,
+                    ts=timestamp,
+                    meter=Meter(
+                        data=MeterData(ac=AC(power_active=Metric(value=value)))
+                    ),
+                )
+
+            for value in range(1, 10):
+                yield next_msg(value=value + request.id)
+                time.sleep(0.1)
+
+        mocker.patch.object(servicer, "GetComponentData", get_component_data)
+
+        servicer.add_component(
+            1, microgrid_pb2.ComponentCategory.COMPONENT_CATEGORY_GRID
+        )
+        servicer.add_component(
+            3, microgrid_pb2.ComponentCategory.COMPONENT_CATEGORY_JUNCTION
+        )
+        servicer.add_component(
+            4, microgrid_pb2.ComponentCategory.COMPONENT_CATEGORY_METER
+        )
+        servicer.add_component(
+            7, microgrid_pb2.ComponentCategory.COMPONENT_CATEGORY_METER
+        )
+        servicer.add_component(
+            8, microgrid_pb2.ComponentCategory.COMPONENT_CATEGORY_INVERTER
+        )
+        servicer.add_component(
+            9, microgrid_pb2.ComponentCategory.COMPONENT_CATEGORY_BATTERY
+        )
+
+        servicer.add_connection(1, 3)
+        servicer.add_connection(3, 4)
+        servicer.add_connection(3, 7)
+        servicer.add_connection(7, 8)
+        servicer.add_connection(8, 9)
+
+        # pylint: disable=attribute-defined-outside-init
+        self.server = mock_api.MockGrpcServer(servicer, port=57891)
+        # pylint: enable=attribute-defined-outside-init
+        await self.server.start()
+
+        await microgrid.initialize("[::1]", 57891)
+
+        channel_registry = ChannelRegistry(name="Microgrid Channel Registry")
+
+        data_source_request_channel = Broadcast[ComponentMetricRequest](
+            "Data Source Request Channel"
+        )
+        data_source_request_sender = data_source_request_channel.new_sender()
+        data_source_request_receiver = data_source_request_channel.new_receiver()
+
+        resampling_actor_request_channel = Broadcast[ComponentMetricRequest](
+            "Resampling Actor Request Channel"
+        )
+        resampling_actor_request_sender = resampling_actor_request_channel.new_sender()
+        resampling_actor_request_receiver = (
+            resampling_actor_request_channel.new_receiver()
+        )
+
+        DataSourcingActor(
+            request_receiver=data_source_request_receiver, registry=channel_registry
+        )
+
+        ComponentMetricsResamplingActor(
+            channel_registry=channel_registry,
+            subscription_sender=data_source_request_sender,
+            subscription_receiver=resampling_actor_request_receiver,
+            resampling_period_s=0.1,
+        )
+
+        return (resampling_actor_request_sender, channel_registry)
+
+    async def cleanup(self) -> None:
+        """Clean up after a test."""
+        await self.server.stop(0.1)
+        microgrid._microgrid._MICROGRID = None  # pylint: disable=protected-access
+
+    async def test_1(self, mocker: MockerFixture) -> None:
+        """Test the LogicalMeter with the grid power formula: "#4 + #7"."""
+        request_sender, channel_registry = await self.setup(mocker)
+        logical_meter = LogicalMeter(
+            channel_registry,
+            request_sender,
+        )
+
+        grid_power_recv = await logical_meter.start_formula(
+            "#4 + #7", ComponentMetricId.ACTIVE_POWER
+        )
+
+        # Create a `FormulaBuilder` instance, just in order to reuse its
+        # `_get_resampled_receiver` function implementation.
+
+        # pylint: disable=protected-access
+        builder = FormulaBuilder(
+            logical_meter._namespace,
+            channel_registry,
+            request_sender,
+            ComponentMetricId.ACTIVE_POWER,
+        )
+        comp_4 = await builder._get_resampled_receiver(4)
+        comp_7 = await builder._get_resampled_receiver(7)
+        # pylint: enable=protected-access
+
+        results = []
+        comp_4_data = []
+        comp_7_data = []
+        for _ in range(10):
+            val = await comp_4.receive()
+            assert val is not None and val.value is not None and val.value > 0.0
+            comp_4_data.append(val.value)
+
+            val = await comp_7.receive()
+            assert val is not None and val.value is not None and val.value > 0.0
+            comp_7_data.append(val.value)
+
+            val = await grid_power_recv.receive()
+            assert val is not None
+            results.append(val.value)
+        await self.cleanup()
+
+        assert results == [
+            val_4 + val_7 for val_4, val_7 in zip(comp_4_data, comp_7_data)
+        ]


### PR DESCRIPTION
1. Adds a formula engine for running formulas on streaming data.  This also includes a parser for the manual formulas,  and a formula builder, for connecting streams from the resampling actor, to the formula engine.
2. A logical meter implementation that provides the public API for users to get high level metrics from.

Formulas can have Component IDs that are preceeded by a pound symbol(`#`), and these operators: `+, -, *, /, (, )`.  For example, the input string: `#20 + #5` is a formula for adding metrics from two components with ids 20 and 5.

Tracked in #61 