### PR TITLE
Expose additional fields from `ComponentData` streams

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -23,6 +23,10 @@ time.
 
 <!-- Here goes the main new features and examples or instructions on how to use them -->
 
+* `MeterData` objects now expose the AC `frequency` measured by the meter.
+* `BatteryData` objects now expose the temperature of the hottest block in the
+  battery as `temperature_max`
+
 ## Bug Fixes
 
 <!-- Here goes notable bug fixes that are worth a special mention or explanation -->

--- a/src/frequenz/sdk/microgrid/component_data.py
+++ b/src/frequenz/sdk/microgrid/component_data.py
@@ -126,6 +126,8 @@ class BatteryData(ComponentData):
         power_upper_bound: the maximum charge power, in Watts, represented in the
             passive sign convention. This will be a positive number, or zero if no
             charging is possible.
+        temperature_max: the maximum temperature of all the blocks in a battery, in
+            Celcius (°C).
     """
 
     soc: float
@@ -134,6 +136,7 @@ class BatteryData(ComponentData):
     capacity: float
     power_lower_bound: float
     power_upper_bound: float
+    temperature_max: float
 
     @classmethod
     def from_proto(cls, raw: microgrid_pb.ComponentData) -> BatteryData:
@@ -154,6 +157,7 @@ class BatteryData(ComponentData):
             capacity=raw.battery.properties.capacity,
             power_lower_bound=raw.battery.data.dc.power.system_bounds.lower,
             power_upper_bound=raw.battery.data.dc.power.system_bounds.upper,
+            temperature_max=raw.battery.data.temperature.max,
         )
         battery_data._set_raw(raw=raw)
         return battery_data

--- a/src/frequenz/sdk/microgrid/component_data.py
+++ b/src/frequenz/sdk/microgrid/component_data.py
@@ -71,11 +71,13 @@ class MeterData(ComponentData):
             -ve current means supply into the grid.
         voltage_per_phase: the AC voltage in Volts (V) between the line and the neutral
             wire for phase/line 1,2 and 3 respectively.
+        frequency: the AC power frequency in Hertz (Hz).
     """
 
     active_power: float
     current_per_phase: Tuple[float, float, float]
     voltage_per_phase: Tuple[float, float, float]
+    frequency: float
 
     @classmethod
     def from_proto(cls, raw: microgrid_pb.ComponentData) -> MeterData:
@@ -101,6 +103,7 @@ class MeterData(ComponentData):
                 raw.meter.data.ac.phase_2.voltage.value,
                 raw.meter.data.ac.phase_3.voltage.value,
             ),
+            frequency=raw.meter.data.ac.frequency.value,
         )
         meter_data._set_raw(raw=raw)
         return meter_data


### PR DESCRIPTION
This PR exposes the following fields:
 - `frequency` from `MeterData` objects
 - `temperature_max` from `BatteryData` objects

This PR also temporarily switches to an older version of the channels library.