### PR TITLE
Remove requirement for inverters to have successors

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,8 +10,13 @@
 
 ## New Features
 
-<!-- Here goes the main new features and examples or instructions on how to use them -->
+- A logical meter implementation that can apply formulas on resampled component
+  data streams.
 
 ## Bug Fixes
 
-<!-- Here goes notable bug fixes that are worth a special mention or explanation -->
+- The component graph expected inverters to always have successors, and so
+  wasn't able to support PV inverters, which don't have component successors.
+  This is resolved by temporarily removing the requirement for inverters to have
+  successors.  This will be partially reverted later by expecting just battery
+  inverters to have graph successors.

--- a/src/frequenz/sdk/microgrid/_graph.py
+++ b/src/frequenz/sdk/microgrid/_graph.py
@@ -485,18 +485,6 @@ class _MicrogridComponentGraph(ComponentGraph):
                 f"{missing_predecessors}"
             )
 
-        missing_successors = list(
-            filter(
-                lambda c: sum(1 for _ in self.successors(c.component_id)) == 0,
-                intermediary_components,
-            )
-        )
-        if len(missing_successors) > 0:
-            raise InvalidGraphError(
-                "Intermediary components without graph successors: "
-                f"{missing_successors}"
-            )
-
     def _validate_junctions(self) -> None:
         """Check that junctions are configured correctly in the graph.
 

--- a/tests/microgrid/test_graph.py
+++ b/tests/microgrid/test_graph.py
@@ -1118,11 +1118,7 @@ class Test_MicrogridComponentGraph:
             ]
         )
         graph._graph.add_edges_from([(1, 3)])
-        with pytest.raises(
-            gr.InvalidGraphError,
-            match="Intermediary components without graph successors",
-        ):
-            graph._validate_intermediary_components()
+        graph._validate_intermediary_components()
 
         graph._graph.clear()
 
@@ -1134,11 +1130,7 @@ class Test_MicrogridComponentGraph:
             ]
         )
         graph._graph.add_edges_from([(1, 2), (2, 3)])
-        with pytest.raises(
-            gr.InvalidGraphError,
-            match="Intermediary components without graph successors",
-        ):
-            graph._validate_intermediary_components()
+        graph._validate_intermediary_components()
 
         # all intermediary nodes have at least one predecessor
         # and at least one successor


### PR DESCRIPTION
This is a quick fix to allow PV inverters to be present in the graph.

This will be partially reverted later by expecting battery inverters to still have graph successors.