### PR TITLE
Split the formula execution logic from the formula building logic 

### DIFF
--- a/src/frequenz/sdk/timeseries/logical_meter/_logical_meter.py
+++ b/src/frequenz/sdk/timeseries/logical_meter/_logical_meter.py
@@ -12,8 +12,8 @@ from frequenz.channels import Broadcast, Receiver, Sender
 from ...actor import ChannelRegistry, ComponentMetricRequest
 from ...microgrid.component import ComponentMetricId
 from .._sample import Sample
-from ._formula_builder import FormulaBuilder
 from ._formula_engine import FormulaEngine
+from ._resampled_formula_builder import ResampledFormulaBuilder
 
 
 class LogicalMeter:
@@ -54,7 +54,7 @@ class LogicalMeter:
     async def _engine_from_formula_string(
         self, formula: str, metric_id: ComponentMetricId, nones_are_zeros: bool
     ) -> FormulaEngine:
-        builder = FormulaBuilder(
+        builder = ResampledFormulaBuilder(
             self._namespace,
             self._channel_registry,
             self._resampler_subscription_sender,

--- a/src/frequenz/sdk/timeseries/logical_meter/_resampled_formula_builder.py
+++ b/src/frequenz/sdk/timeseries/logical_meter/_resampled_formula_builder.py
@@ -13,7 +13,7 @@ from ._formula_engine import FormulaEngine
 from ._tokenizer import Tokenizer, TokenType
 
 
-class FormulaBuilder:
+class ResampledFormulaBuilder:
     """Provides a way to build a FormulaEngine from resampled data streams."""
 
     def __init__(
@@ -23,7 +23,7 @@ class FormulaBuilder:
         resampler_subscription_sender: Sender[ComponentMetricRequest],
         metric_id: ComponentMetricId,
     ) -> None:
-        """Create a `FormulaBuilder` instance.
+        """Create a `ResampledFormulaBuilder` instance.
 
         Args:
             namespace: The unique namespace to allow reuse of streams in the data
@@ -44,7 +44,7 @@ class FormulaBuilder:
         """Get a receiver with the resampled data for the given component id.
 
         This receiver would contain data for the `metric_id` specified when creating the
-        `FormulaBuilder` instance.
+        `ResampledFormulaBuilder` instance.
 
         Args:
             component_id: The component id for which to get a resampled data receiver.

--- a/src/frequenz/sdk/timeseries/logical_meter/_resampled_formula_builder.py
+++ b/src/frequenz/sdk/timeseries/logical_meter/_resampled_formula_builder.py
@@ -9,7 +9,7 @@ from frequenz.channels import Receiver, Sender
 from ...actor import ChannelRegistry, ComponentMetricRequest
 from ...microgrid.component import ComponentMetricId
 from .._sample import Sample
-from ._formula_engine import FormulaEngine
+from ._formula_engine import FormulaBuilder, FormulaEngine
 from ._tokenizer import Tokenizer, TokenType
 
 
@@ -37,7 +37,7 @@ class ResampledFormulaBuilder:
         self._channel_registry = channel_registry
         self._resampler_subscription_sender = resampler_subscription_sender
         self._namespace = namespace
-        self._formula = FormulaEngine()
+        self._formula = FormulaBuilder()
         self._metric_id = metric_id
 
     async def _get_resampled_receiver(self, component_id: int) -> Receiver[Sample]:
@@ -105,5 +105,4 @@ class ResampledFormulaBuilder:
             else:
                 raise ValueError(f"Unknown token type: {token}")
 
-        self._formula.finalize()
-        return self._formula
+        return self._formula.build()

--- a/tests/timeseries/test_formula_engine.py
+++ b/tests/timeseries/test_formula_engine.py
@@ -9,7 +9,7 @@ from typing import Dict, List, Optional, Tuple
 from frequenz.channels import Broadcast
 
 from frequenz.sdk.timeseries import Sample
-from frequenz.sdk.timeseries.logical_meter._formula_engine import FormulaEngine
+from frequenz.sdk.timeseries.logical_meter._formula_engine import FormulaBuilder
 from frequenz.sdk.timeseries.logical_meter._tokenizer import Token, Tokenizer, TokenType
 
 
@@ -63,19 +63,19 @@ class TestFormulaEngine:
         nones_are_zeros: bool = False,
     ) -> None:
         channels: Dict[str, Broadcast[Sample]] = {}
-        engine = FormulaEngine()
+        builder = FormulaBuilder()
         for token in Tokenizer(formula):
             if token.type == TokenType.COMPONENT_METRIC:
                 if token.value not in channels:
                     channels[token.value] = Broadcast(token.value)
-                engine.push_metric(
+                builder.push_metric(
                     f"#{token.value}",
                     channels[token.value].new_receiver(),
                     nones_are_zeros,
                 )
             elif token.type == TokenType.OPER:
-                engine.push_oper(token.value)
-        engine.finalize()
+                builder.push_oper(token.value)
+        engine = builder.build()
 
         assert repr(engine._steps) == postfix
 

--- a/tests/timeseries/test_logical_meter.py
+++ b/tests/timeseries/test_logical_meter.py
@@ -25,7 +25,9 @@ from frequenz.sdk.actor import (
 )
 from frequenz.sdk.microgrid.component import ComponentMetricId
 from frequenz.sdk.timeseries.logical_meter import LogicalMeter
-from frequenz.sdk.timeseries.logical_meter._formula_builder import FormulaBuilder
+from frequenz.sdk.timeseries.logical_meter._resampled_formula_builder import (
+    ResampledFormulaBuilder,
+)
 from tests.microgrid import mock_api
 
 
@@ -149,7 +151,7 @@ class TestLogicalMeter:
         # `_get_resampled_receiver` function implementation.
 
         # pylint: disable=protected-access
-        builder = FormulaBuilder(
+        builder = ResampledFormulaBuilder(
             logical_meter._namespace,
             channel_registry,
             request_sender,


### PR DESCRIPTION
Splits the `FormulaEngine` class into:
  - `FormulaBuilder`
  - `FormulaEngine`

The `FormulaBuilder` class is used to build formulas, and has a
`build` method that returns a `FormulaEngine` instance.

Closes https://github.com/frequenz-floss/frequenz-sdk-python/issues/82