### PR TITLE
Fix warnings in unit tests

### DIFF
--- a/tests/actor/test_data_sourcing.py
+++ b/tests/actor/test_data_sourcing.py
@@ -93,5 +93,5 @@ class TestDataSourcingActor:
             assert sample is not None
             assert 100.0 == sample.value
 
-        await server.stop(0.1)
+        assert await server.graceful_shutdown()
         _microgrid._MICROGRID = None  # pylint: disable=protected-access

--- a/tests/actor/test_decorator.py
+++ b/tests/actor/test_decorator.py
@@ -96,6 +96,8 @@ async def test_basic_actor() -> None:
 
     msg = await echo_rx.receive()
     assert msg is False
+    # pylint: disable=protected-access,no-member
+    await _echo_actor._stop()  # type: ignore[attr-defined]
 
 
 async def test_actor_does_not_restart() -> None:

--- a/tests/microgrid/test_client.py
+++ b/tests/microgrid/test_client.py
@@ -130,7 +130,7 @@ class TestMicrogridGrpcClient:
             }
 
         finally:
-            await server.stop(grace=1.0)
+            assert await server.graceful_shutdown()
 
     async def test_connections(self) -> None:
         servicer = mock_api.MockMicrogridServicer()
@@ -284,7 +284,7 @@ class TestMicrogridGrpcClient:
             }
 
         finally:
-            await server.stop(grace=1.0)
+            assert await server.graceful_shutdown()
 
     async def test_bad_connections(self) -> None:
         """Validate that the client does not apply connection filters itself."""
@@ -355,7 +355,7 @@ class TestMicrogridGrpcClient:
             )
 
         finally:
-            await server.stop(grace=1.0)
+            assert await server.graceful_shutdown()
 
     async def test_meter_data(self) -> None:
         servicer = mock_api.MockMicrogridServicer()
@@ -383,7 +383,7 @@ class TestMicrogridGrpcClient:
             await asyncio.sleep(0.2)
 
         finally:
-            await server.stop(0.1)
+            assert await server.graceful_shutdown()
 
         latest = peekable.peek()
         assert isinstance(latest, MeterData)
@@ -415,7 +415,7 @@ class TestMicrogridGrpcClient:
             await asyncio.sleep(0.2)
 
         finally:
-            await server.stop(0.1)
+            assert await server.graceful_shutdown()
 
         latest = peekable.peek()
         assert isinstance(latest, BatteryData)
@@ -447,7 +447,7 @@ class TestMicrogridGrpcClient:
             await asyncio.sleep(0.2)
 
         finally:
-            await server.stop(0.1)
+            assert await server.graceful_shutdown()
 
         latest = peekable.peek()
         assert isinstance(latest, InverterData)
@@ -479,7 +479,7 @@ class TestMicrogridGrpcClient:
             await asyncio.sleep(0.2)
 
         finally:
-            await server.stop(0.1)
+            assert await server.graceful_shutdown()
 
         latest = peekable.peek()
         assert isinstance(latest, EVChargerData)
@@ -506,7 +506,7 @@ class TestMicrogridGrpcClient:
             assert servicer.latest_charge.power_w == 12
 
         finally:
-            await server.stop(0.1)
+            assert await server.graceful_shutdown()
 
     async def test_discharge(self) -> None:
         """Check if discharge is able to discharge component."""
@@ -528,7 +528,7 @@ class TestMicrogridGrpcClient:
             assert servicer.latest_discharge.component_id == 73
             assert servicer.latest_discharge.power_w == 15
         finally:
-            await server.stop(0.1)
+            assert await server.graceful_shutdown()
 
     async def test_set_bounds(self) -> None:
         servicer = mock_api.MockMicrogridServicer()
@@ -558,7 +558,7 @@ class TestMicrogridGrpcClient:
                 await asyncio.sleep(0.1)
 
         finally:
-            await server.stop(0.1)
+            assert await server.graceful_shutdown()
 
         assert len(expected_bounds) == len(servicer.get_bounds())
 

--- a/tests/microgrid/test_graph.py
+++ b/tests/microgrid/test_graph.py
@@ -766,7 +766,7 @@ class Test_MicrogridComponentGraph:
         }
         graph.validate()
 
-        await server.stop(1)
+        assert await server.graceful_shutdown()
 
     def test_validate(self) -> None:
         # `validate` will fail if any of the following are the case:

--- a/tests/microgrid/test_mock_api.py
+++ b/tests/microgrid/test_mock_api.py
@@ -239,7 +239,7 @@ async def test_MockGrpcServer() -> None:
         Connection(start=2, end=3),
     ]
 
-    await server1.stop(1)
+    await server1.graceful_shutdown()
 
     servicer2 = mock_api.MockMicrogridServicer(
         components=[
@@ -285,4 +285,4 @@ async def test_MockGrpcServer() -> None:
         Connection(start=77, end=9999),
     ]
 
-    await server2.wait_for_termination(0.1)
+    await server2.graceful_shutdown()

--- a/tests/microgrid/test_timeout.py
+++ b/tests/microgrid/test_timeout.py
@@ -30,10 +30,6 @@ GRPC_CALL_TIMEOUT: float = 0.1
 # error and needs to be greater than `GRPC_CALL_TIMEOUT`.
 GRPC_SERVER_DELAY: float = 0.3
 
-# How long a mocked Microgrid server should be running for a single test function,
-# before it gets shut down so that the tests can finish.
-GRPC_SERVER_SHUTDOWN_DELAY: float = 1.0
-
 
 @patch(
     "frequenz.sdk.microgrid.client._client.DEFAULT_GRPC_CALL_TIMEOUT", GRPC_CALL_TIMEOUT
@@ -59,7 +55,7 @@ async def test_components_timeout(mocker: MockerFixture) -> None:
     with pytest.raises(grpc.aio.AioRpcError) as err_ctx:
         _ = await client.components()
     assert err_ctx.value.code() == grpc.StatusCode.DEADLINE_EXCEEDED
-    await server.wait_for_termination(GRPC_SERVER_SHUTDOWN_DELAY)
+    assert await server.graceful_shutdown()
 
 
 @patch(
@@ -86,7 +82,7 @@ async def test_connections_timeout(mocker: MockerFixture) -> None:
     with pytest.raises(grpc.aio.AioRpcError) as err_ctx:
         _ = await client.connections()
     assert err_ctx.value.code() == grpc.StatusCode.DEADLINE_EXCEEDED
-    await server.wait_for_termination(GRPC_SERVER_SHUTDOWN_DELAY)
+    assert await server.graceful_shutdown()
 
 
 @patch(
@@ -117,4 +113,4 @@ async def test_set_power_timeout(mocker: MockerFixture) -> None:
             _ = await client.set_power(component_id=1, power_w=power_w)
         assert err_ctx.value.code() == grpc.StatusCode.DEADLINE_EXCEEDED
 
-    await server.stop(GRPC_SERVER_SHUTDOWN_DELAY)
+    assert await server.graceful_shutdown()

--- a/tests/timeseries/mock_microgrid.py
+++ b/tests/timeseries/mock_microgrid.py
@@ -243,5 +243,5 @@ class MockMicrogrid:
 
     async def cleanup(self) -> None:
         """Clean up after a test."""
-        await self._server.stop(0.1)
+        await self._server.graceful_shutdown()
         microgrid._microgrid._MICROGRID = None  # pylint: disable=protected-access


### PR DESCRIPTION
This PR cleans some warnings in pytest (Python 3.8).
More work is required to clean all warnings.
But this is enough for one PR.