### PR TITLE
Implement a custom resampling buffer

### DIFF
--- a/benchmarks/timeseries/resampling.py
+++ b/benchmarks/timeseries/resampling.py
@@ -25,6 +25,7 @@ def _benchmark_resampling_helper(resamples: int, samples: int) -> None:
             resampling_period_s=1.0,
             max_data_age_in_periods=3.0,
             resampling_function=nop,
+            initial_buffer_len=samples * 3,
         )
     )
     now = datetime.now(timezone.utc)

--- a/benchmarks/timeseries/resampling.py
+++ b/benchmarks/timeseries/resampling.py
@@ -8,7 +8,10 @@ from timeit import timeit
 from typing import Sequence
 
 from frequenz.sdk.timeseries import Sample
-from frequenz.sdk.timeseries._resampling import ResamplerConfig, _ResamplingHelper
+from frequenz.sdk.timeseries._resampling._resampler import (
+    ResamplerConfig,
+    _ResamplingHelper,
+)
 
 
 def nop(  # pylint: disable=unused-argument

--- a/benchmarks/timeseries/resampling.py
+++ b/benchmarks/timeseries/resampling.py
@@ -1,0 +1,51 @@
+# License: MIT
+# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+
+"""Benchmark resampling."""
+
+from datetime import datetime, timedelta, timezone
+from timeit import timeit
+from typing import Sequence
+
+from frequenz.sdk.timeseries import Sample
+from frequenz.sdk.timeseries._resampling import ResamplerConfig, _ResamplingHelper
+
+
+def nop(  # pylint: disable=unused-argument
+    samples: Sequence[Sample], resampling_period_s: float
+) -> float:
+    """Return 0.0."""
+    return 0.0
+
+
+def _benchmark_resampling_helper(resamples: int, samples: int) -> None:
+    """Benchmark the resampling helper."""
+    helper = _ResamplingHelper(
+        ResamplerConfig(
+            resampling_period_s=1.0,
+            max_data_age_in_periods=3.0,
+            resampling_function=nop,
+        )
+    )
+    now = datetime.now(timezone.utc)
+
+    def _do_work() -> None:
+        nonlocal now
+        for _n_resample in range(resamples):
+            for _n_sample in range(samples):
+                now = now + timedelta(seconds=1 / samples)
+                helper.add_sample(Sample(now, 0.0))
+            helper.resample(now)
+
+    print(timeit(_do_work, number=5))
+
+
+def _benchmark() -> None:
+    for resamples in [10, 100, 1000]:
+        for samples in [10, 100, 1000]:
+            print(f"{resamples=} {samples=}")
+            _benchmark_resampling_helper(resamples, samples)
+
+
+if __name__ == "__main__":
+    _benchmark()

--- a/examples/resampling.py
+++ b/examples/resampling.py
@@ -18,7 +18,8 @@ from frequenz.sdk.actor import (
 )
 from frequenz.sdk.microgrid.component import ComponentCategory, ComponentMetricId
 from frequenz.sdk.timeseries import Sample
-from frequenz.sdk.timeseries._resampling import Resampler, ResamplerConfig, Sink, Source
+from frequenz.sdk.timeseries._resampling import Resampler, ResamplerConfig
+from frequenz.sdk.timeseries._resampling._resampler import Sink, Source
 
 HOST = "microgrid.sandbox.api.frequenz.io"
 PORT = 61060

--- a/examples/resampling.py
+++ b/examples/resampling.py
@@ -18,7 +18,7 @@ from frequenz.sdk.actor import (
 )
 from frequenz.sdk.microgrid.component import ComponentCategory, ComponentMetricId
 from frequenz.sdk.timeseries import Sample
-from frequenz.sdk.timeseries._resampling import Resampler, Sink, Source
+from frequenz.sdk.timeseries._resampling import Resampler, ResamplerConfig, Sink, Source
 
 HOST = "microgrid.sandbox.api.frequenz.io"
 PORT = 61060
@@ -65,7 +65,7 @@ async def run() -> None:  # pylint: disable=too-many-locals
         channel_registry=channel_registry,
         data_sourcing_request_sender=data_source_request_sender,
         resampling_request_receiver=resampling_request_receiver,
-        resampling_period_s=1,
+        config=ResamplerConfig(resampling_period_s=1),
     )
 
     components = await microgrid.get().api_client.components()
@@ -104,7 +104,7 @@ async def run() -> None:  # pylint: disable=too-many-locals
     # Create a channel to calculate an average for all the data
     average_chan = Broadcast[Sample]("average")
 
-    second_stage_resampler = Resampler(resampling_period_s=3.0)
+    second_stage_resampler = Resampler(ResamplerConfig(resampling_period_s=3.0))
     second_stage_resampler.add_timeseries(average_chan.new_receiver(), _print_sample)
 
     average_sender = average_chan.new_sender()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
     "sympy >= 1.10.1, < 2",
     "toml >= 0.10",
     "tqdm >= 4.38.0, < 5",
+    "typing_extensions >= 4.4.0, < 5",
     "watchfiles >= 0.15.0",
 ]
 dynamic = [ "version" ]

--- a/src/frequenz/sdk/actor/__init__.py
+++ b/src/frequenz/sdk/actor/__init__.py
@@ -7,7 +7,7 @@ from ._channel_registry import ChannelRegistry
 from ._config_managing import ConfigManagingActor
 from ._data_sourcing import ComponentMetricRequest, DataSourcingActor
 from ._decorator import actor
-from ._resampling import ComponentMetricsResamplingActor
+from ._resampling import ComponentMetricsResamplingActor, ResamplerConfig
 
 __all__ = [
     "ChannelRegistry",
@@ -15,5 +15,6 @@ __all__ = [
     "ComponentMetricsResamplingActor",
     "ConfigManagingActor",
     "DataSourcingActor",
+    "ResamplerConfig",
     "actor",
 ]

--- a/src/frequenz/sdk/timeseries/_base_types.py
+++ b/src/frequenz/sdk/timeseries/_base_types.py
@@ -3,12 +3,16 @@
 
 """Timeseries basic types."""
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Optional
 
 
-@dataclass(frozen=True)
+# Ordering by timestamp is a bit arbitrary, and it is not always what might be
+# wanted. We are using this order now because usually we need to do binary
+# searches on sequences of samples, and the Python `bisect` module doesn't
+# support providing a key until Python 3.10.
+@dataclass(frozen=True, order=True)
 class Sample:
     """A measurement taken at a particular point in time.
 
@@ -17,5 +21,8 @@ class Sample:
     coherent view on a group of component metrics for a particular timestamp.
     """
 
-    timestamp: datetime
-    value: Optional[float] = None
+    timestamp: datetime = field(compare=True)
+    """The time when this sample was generated."""
+
+    value: Optional[float] = field(compare=False, default=None)
+    """The value of this sample."""

--- a/src/frequenz/sdk/timeseries/_resampling/__init__.py
+++ b/src/frequenz/sdk/timeseries/_resampling/__init__.py
@@ -1,0 +1,21 @@
+# License: MIT
+# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+
+"""Timeseries resampling."""
+
+
+from ._resampler import (
+    Resampler,
+    ResamplerConfig,
+    ResamplingError,
+    ResamplingFunction,
+    SourceStoppedError,
+)
+
+__all__ = [
+    "Resampler",
+    "ResamplerConfig",
+    "ResamplingError",
+    "ResamplingFunction",
+    "SourceStoppedError",
+]

--- a/src/frequenz/sdk/timeseries/_resampling/_buffer.py
+++ b/src/frequenz/sdk/timeseries/_resampling/_buffer.py
@@ -1,0 +1,262 @@
+# License: MIT
+# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+
+"""Timeseries resampler buffer handling."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Sequence, TypeVar, overload
+
+T = TypeVar("T")
+
+
+@dataclass
+class _Uninitialized:
+    """A sentinel class to mark uninitialized data in the buffer."""
+
+
+_UNINITIALIZED = _Uninitialized()
+"""A uninitialized sentinel instance."""
+
+
+class _BufferView(Sequence[T]):
+    """A read-only view into a Buffer.
+
+    This is a ring buffer with the following structure:
+
+    * It is a fixed size buffer.
+    * If the buffer isn't full, elements not yet filled up are represented with
+      a `_UNINITIALIZED` instance.
+    * The `tail` pointer points to the first element in the view.
+    * The `head` pointer points past the last element in the view.
+    * The ring buffer can, of course, wrap around, so `head` can be smaller than `tail`.
+    * When `head` == `tail`, the view is empty, unless `_is_full` is `True`, in
+      which case the view covers the whole buffer.
+    """
+
+    def __init__(
+        self, *, buffer: list[_Uninitialized | T], full: bool, tail: int, head: int
+    ) -> None:
+        """Create an instance.
+
+        Args:
+            buffer: The internal buffer that needs to be viewed.
+            full: Whether this is a view on a full buffer.
+            tail: The index of the first element of the view.
+            head: The index of the last element of the view.
+        """
+        super().__init__()
+        self._buffer: list[_Uninitialized | T] = buffer
+        self._is_full: bool = full
+        self._tail: int = tail  # Points to the oldest element in the buffer
+        self._head: int = head  # Points to the newest element in the buffer
+
+    @property
+    def capacity(self) -> int:
+        """Return the capacity of the internal buffer.
+
+        Returns:
+            The capacity of the internal buffer.
+        """
+        return len(self._buffer)
+
+    def _adjust(self, position: int, *, offset: int = 0) -> int:
+        """Adjust a position to point to a valid index in the buffer.
+
+        An optional `offset` can be passed if the position needs to be also
+        updated using some offset.
+
+        Args:
+            position: The position index to adjust.
+            offset: The offset to use to calculate the new position.
+
+        Returns:
+            The adjusted position index.
+        """
+        return (position + offset) % self.capacity
+
+    def _index(self, /, index: int) -> T:
+        """Get the nth element in this view.
+
+        Args:
+            index: The index of the element to get.
+
+        Returns:
+            The element in the nth position.
+        """
+        if index < 0:
+            index += len(self)
+        if index < 0:
+            raise IndexError("Buffer index out of range")
+        if index >= len(self):
+            raise IndexError("Buffer index out of range")
+        index = self._adjust(self._tail, offset=index)
+        item = self._buffer[index]
+        assert not isinstance(item, _Uninitialized)
+        return item
+
+    def _slice(self, /, slice_: slice) -> Sequence[T]:
+        """Get a slice on this view.
+
+        Args:
+            slice_: The parameters of the slice to get.
+
+        Returns:
+            The slice on this view.
+        """
+        start, stop, step = slice_.indices(len(self))
+        # This is a bit expensive, but making all the calculation each time
+        # an item is accessed would also be expensive. This way the slice
+        # might be expensive to construct but then is super cheap to use,
+        # which should probably be the most common sense. We also avoid
+        # having to implement a lot of weird corner cases.
+        if step != 1:
+            new_slice: list[T] = []
+            for i in range(start, stop, step):
+                new_slice.append(self[i])
+            return new_slice
+
+        # If we have a step of 1, then things are very simple, and we can
+        # use another view on the same buffer. This is also probably the
+        # most common slicing case.
+
+        # If the requested size is empty, then just return an empty tuple
+        if start >= stop:
+            return ()
+
+        tail = self._adjust(self._tail, offset=start)
+        head = self._adjust(self._tail, offset=stop)
+        slice_is_full = stop - start == self.capacity
+        return _BufferView(
+            buffer=self._buffer, full=slice_is_full, head=head, tail=tail
+        )
+
+    @overload
+    def __getitem__(self, index: int) -> T:
+        ...
+
+    @overload
+    def __getitem__(self, index: slice) -> Sequence[T]:
+        ...
+
+    def __getitem__(self, index: int | slice) -> T | Sequence[T]:
+        """Get an item or slice on this view.
+
+        Args:
+            index: The index of the element or parameters of the slice to get.
+
+        Returns:
+            The element or slice on this view.
+        """
+        if isinstance(index, slice):
+            return self._slice(index)
+
+        return self._index(index)
+
+    def __len__(self) -> int:
+        """Get the length of this view.
+
+        Returns:
+            The length of this view.
+        """
+        if self._is_full:
+            return self.capacity
+        if self._head == self._tail:
+            return 0
+        offset = self.capacity if self._head < self._tail else 0
+        return offset + self._head - self._tail
+
+    def __repr__(self) -> str:
+        """Get the string representation of this view.
+
+        Returns:
+            The string representation of this view.
+        """
+        items = []
+        if self._tail != self._head or self._is_full:
+            tail = self._tail
+            for _ in range(len(self)):
+                items.append(self._buffer[tail])
+                tail = self._adjust(tail, offset=1)
+        return f"{self.__class__.__name__}({items})"
+
+    def _debug_repr(self) -> str:
+        """Get the debug string representation of this view.
+
+        Returns:
+            The debug string representation of this view.
+        """
+        return (
+            f"{self.__class__.__name__}(buffer={self._buffer!r}, "
+            "full={self._is_full!r}, tail={self._tail!r}, head={self._head!r})"
+        )
+
+    def __eq__(self, __o: object) -> bool:
+        """Compare this view to another object.
+
+        Returns:
+            `True` if the other object is also a `Sequence` and all the
+                elements compare equal, `False` otherwise.
+        """
+        if isinstance(__o, Sequence):
+            len_self = len(self)
+            if len_self != len(__o):
+                return False
+            for i in range(len_self):
+                if self[i] != __o[i]:
+                    return False
+            return True
+        return super().__eq__(__o)
+
+
+class Buffer(_BufferView[T]):
+    """A push-only, fixed-size ring buffer.
+
+    Elements can be `push`ed to the buffer, when the buffer gets full, newer
+    elements will replace older elements. The buffer can be `clear`ed.
+    """
+
+    def __init__(self, /, capacity: int, initial_values: Sequence[T] = ()) -> None:
+        """Create an instance.
+
+        Args:
+            capacity: The capacity of the buffer.
+            initial_values: The initial values to fill the buffer with. If it
+                has more items than the capacity, then only the last items will
+                be added.
+        """
+        if capacity <= 0:
+            raise ValueError("The buffer capacity must be larger than 0")
+        if len(initial_values) > capacity:
+            initial_values = initial_values[-capacity:]
+        buffer: list[_Uninitialized | T] = list(initial_values)
+        is_full = False
+        if len(initial_values) < capacity:
+            buffer += [_UNINITIALIZED] * (capacity - len(initial_values))
+            head = len(initial_values)
+        else:
+            is_full = True
+            head = 0
+        super().__init__(buffer=buffer, full=is_full, tail=0, head=head)
+
+    def clear(self) -> None:
+        """Clear the buffer."""
+        self._head = 0
+        self._tail = 0
+        self._is_full = False
+
+    def push(self, element: T) -> None:
+        """Push a new element to the buffer.
+
+        If the buffer is full, the oldest element will be dropped.
+
+        Args:
+            element: Element to push.
+        """
+        self._buffer[self._head] = element
+        self._head = self._adjust(self._head, offset=1)
+        if self._is_full:
+            self._tail = self._adjust(self._tail, offset=1)
+        if self._head == self._tail and not self._is_full:
+            self._is_full = True

--- a/tests/actor/test_resampling.py
+++ b/tests/actor/test_resampling.py
@@ -16,6 +16,7 @@ from frequenz.sdk.actor import (
     ChannelRegistry,
     ComponentMetricRequest,
     ComponentMetricsResamplingActor,
+    ResamplerConfig,
 )
 from frequenz.sdk.microgrid.component import ComponentMetricId
 from frequenz.sdk.timeseries import Sample
@@ -123,8 +124,10 @@ async def test_single_request(
         channel_registry=channel_registry,
         data_sourcing_request_sender=data_source_req_chan.new_sender(),
         resampling_request_receiver=resampling_req_chan.new_receiver(),
-        resampling_period_s=0.2,
-        max_data_age_in_periods=2,
+        config=ResamplerConfig(
+            resampling_period_s=0.2,
+            max_data_age_in_periods=2,
+        ),
     )
 
     subs_req = ComponentMetricRequest(
@@ -167,8 +170,10 @@ async def test_duplicate_request(
         channel_registry=channel_registry,
         data_sourcing_request_sender=data_source_req_chan.new_sender(),
         resampling_request_receiver=resampling_req_chan.new_receiver(),
-        resampling_period_s=0.2,
-        max_data_age_in_periods=2,
+        config=ResamplerConfig(
+            resampling_period_s=0.2,
+            max_data_age_in_periods=2,
+        ),
     )
 
     subs_req = ComponentMetricRequest(

--- a/tests/timeseries/mock_microgrid.py
+++ b/tests/timeseries/mock_microgrid.py
@@ -27,6 +27,7 @@ from frequenz.sdk.actor import (
     ComponentMetricRequest,
     ComponentMetricsResamplingActor,
     DataSourcingActor,
+    ResamplerConfig,
 )
 from tests.microgrid import mock_api
 
@@ -236,7 +237,7 @@ class MockMicrogrid:
             channel_registry=channel_registry,
             data_sourcing_request_sender=data_source_request_sender,
             resampling_request_receiver=resampling_actor_request_receiver,
-            resampling_period_s=0.1,
+            config=ResamplerConfig(resampling_period_s=0.1),
         )
 
         return (resampling_actor_request_sender, channel_registry)

--- a/tests/timeseries/resampling/__init__.py
+++ b/tests/timeseries/resampling/__init__.py
@@ -1,0 +1,4 @@
+# License: MIT
+# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+
+"""Frequenz Python SDK Tests."""

--- a/tests/timeseries/resampling/test_buffer.py
+++ b/tests/timeseries/resampling/test_buffer.py
@@ -1,0 +1,177 @@
+# tests/timeseries/test_resampling.py:93: License: MIT
+# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+
+"""Tests for the resampling buffer."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import pytest
+
+from frequenz.sdk.timeseries._resampling._buffer import Buffer
+
+
+def test_buffer_init_zero_capacity() -> None:
+    """Test a buffer with zero capacity can't be created."""
+    with pytest.raises(ValueError):
+        _ = Buffer[int](0)
+
+
+def test_buffer_init_empty() -> None:
+    """Test an empty buffer is empty and can be pushed to."""
+    buffer = Buffer[int](2)
+
+    assert not buffer
+    assert buffer == []  # pylint: disable=use-implicit-booleaness-not-comparison
+    assert len(buffer) == 0
+    for i in range(-5, 5):
+        with pytest.raises(IndexError):
+            _ = buffer[i]
+
+    buffer.push(11)
+    assert buffer == [11]
+
+    buffer.push(15)
+    assert buffer == [11, 15]
+
+    buffer.push(25)
+    assert buffer == [15, 25]
+
+
+def test_buffer_init_full() -> None:
+    """Test a full buffer can be created, pushed to, and drops old values."""
+    init = (3, 2, 6, 10, 9)
+    buffer = Buffer[int](5, init)
+
+    assert buffer == init
+    assert len(buffer) == len(init)
+    for i in range(5):
+        assert buffer[i] == init[i]
+    for i in range(-1, -6, -1):
+        assert buffer[i] == init[i]
+    with pytest.raises(IndexError):
+        _ = buffer[-6]
+    with pytest.raises(IndexError):
+        _ = buffer[5]
+
+    buffer.push(11)
+    assert buffer == [2, 6, 10, 9, 11]
+    assert buffer[4] == 11
+    with pytest.raises(IndexError):
+        _ = buffer[-6]
+    with pytest.raises(IndexError):
+        _ = buffer[5]
+
+
+def test_buffer_init_partial() -> None:
+    """Test a partially initialized buffer.
+
+    Test it can be created, pushed to, grows and eventuall drops old values.
+    """
+    init = (2, 9)
+    buffer = Buffer[int](4, init)
+
+    assert buffer == init
+    assert len(buffer) == len(init)
+    with pytest.raises(IndexError):
+        _ = buffer[-3]
+    with pytest.raises(IndexError):
+        _ = buffer[2]
+    for i in range(2):
+        assert buffer[i] == init[i]
+    for i in range(-1, -3, -1):
+        assert buffer[i] == init[i]
+
+    buffer.push(11)
+    assert buffer == [2, 9, 11]
+
+    buffer.push(15)
+    assert buffer == [2, 9, 11, 15]
+
+    buffer.push(25)
+    assert buffer == [9, 11, 15, 25]
+
+
+def test_buffer_push() -> None:
+    """Test a buffer can be pushed to."""
+    buffer = Buffer[int](2)
+
+    with pytest.raises(IndexError):
+        _ = buffer[0]
+    with pytest.raises(IndexError):
+        _ = buffer[1]
+    with pytest.raises(IndexError):
+        _ = buffer[2]
+
+    buffer.push(10)
+    assert len(buffer) == 1
+    assert buffer == [10]
+    assert buffer[0] == 10
+    with pytest.raises(IndexError):
+        _ = buffer[2]
+
+    buffer.push(20)
+    assert len(buffer) == 2
+    assert buffer == [10, 20]
+    assert buffer[0] == 10
+    assert buffer[1] == 20
+    with pytest.raises(IndexError):
+        _ = buffer[2]
+
+    buffer.push(5)
+    assert len(buffer) == 2
+    assert buffer == [20, 5]
+    assert buffer[0] == 20
+    assert buffer[1] == 5
+    with pytest.raises(IndexError):
+        _ = buffer[2]
+
+
+def test_buffer_clear() -> None:
+    """Test a buffer can be cleared correctly."""
+    buffer = Buffer[int](2, (1, 2))
+
+    buffer.clear()
+    assert not buffer
+    assert buffer == []  # pylint: disable=use-implicit-booleaness-not-comparison
+    assert len(buffer) == 0
+    with pytest.raises(IndexError):
+        _ = buffer[0]
+    with pytest.raises(IndexError):
+        _ = buffer[1]
+    with pytest.raises(IndexError):
+        _ = buffer[2]
+
+
+@pytest.mark.parametrize("step", [None, 1, 2, 5, -5, -2, -1])
+@pytest.mark.parametrize("stop", [0, None, 1, 3, 5, -5, -3, -1])
+@pytest.mark.parametrize("start", [0, None, 1, 3, 5, -5, -3, -1])
+def test_slice(start: Optional[int], stop: Optional[int], step: Optional[int]) -> None:
+    """Test slicing operations."""
+    init = (3, 2, 6, 10, 9)
+    buffer = Buffer[int](5, init)
+
+    init_slice = init[start:stop:step]
+    slice_ = buffer[start:stop:step]
+
+    assert len(slice_) == len(init_slice)
+    assert list(slice_) == list(init_slice)
+    for i in range(3):
+        with pytest.raises(IndexError):
+            _ = init_slice[-len(init_slice) - i - 1]
+        with pytest.raises(IndexError):
+            # For some reason pylint thinks slice_ is unsubscriptable, but the
+            # type is properly inferred as Sequence[int], so it looks like
+            # a pylint bug
+            # pylint: disable=unsubscriptable-object
+            _ = slice_[-len(init_slice) - i - 1]
+        with pytest.raises(IndexError):
+            # pylint: disable=unsubscriptable-object
+            _ = slice_[len(init_slice) + i]
+    for i in range(len(init_slice)):  # pylint: disable=consider-using-enumerate
+        # pylint: disable=unsubscriptable-object
+        assert slice_[i] == init_slice[i]
+    for i in range(-1, -len(init_slice) - 1, -1):
+        # pylint: disable=unsubscriptable-object
+        assert slice_[i] == init_slice[i]

--- a/tests/timeseries/test_resampling.py
+++ b/tests/timeseries/test_resampling.py
@@ -17,6 +17,7 @@ from frequenz.channels import Broadcast
 from frequenz.sdk.timeseries import Sample
 from frequenz.sdk.timeseries._resampling import (
     Resampler,
+    ResamplerConfig,
     ResamplingError,
     ResamplingFunction,
     Sink,
@@ -90,9 +91,11 @@ async def test_resampling_with_one_window(
         spec=ResamplingFunction, return_value=expected_resampled_value
     )
     resampler = Resampler(
-        resampling_period_s=resampling_period_s,
-        max_data_age_in_periods=1.0,
-        resampling_function=resampling_fun_mock,
+        ResamplerConfig(
+            resampling_period_s=resampling_period_s,
+            max_data_age_in_periods=1.0,
+            resampling_function=resampling_fun_mock,
+        )
     )
 
     source_recvr = source_chan.new_receiver()
@@ -180,9 +183,11 @@ async def test_resampling_with_one_and_a_half_windows(  # pylint: disable=too-ma
         spec=ResamplingFunction, return_value=expected_resampled_value
     )
     resampler = Resampler(
-        resampling_period_s=resampling_period_s,
-        max_data_age_in_periods=1.5,
-        resampling_function=resampling_fun_mock,
+        ResamplerConfig(
+            resampling_period_s=resampling_period_s,
+            max_data_age_in_periods=1.5,
+            resampling_function=resampling_fun_mock,
+        )
     )
 
     source_recvr = source_chan.new_receiver()
@@ -311,9 +316,11 @@ async def test_resampling_with_two_windows(  # pylint: disable=too-many-statemen
         spec=ResamplingFunction, return_value=expected_resampled_value
     )
     resampler = Resampler(
-        resampling_period_s=resampling_period_s,
-        max_data_age_in_periods=2.0,
-        resampling_function=resampling_fun_mock,
+        ResamplerConfig(
+            resampling_period_s=resampling_period_s,
+            max_data_age_in_periods=2.0,
+            resampling_function=resampling_fun_mock,
+        )
     )
 
     source_recvr = source_chan.new_receiver()
@@ -442,9 +449,11 @@ async def test_receiving_stopped_resampling_error(
         spec=ResamplingFunction, return_value=expected_resampled_value
     )
     resampler = Resampler(
-        resampling_period_s=resampling_period_s,
-        max_data_age_in_periods=2.0,
-        resampling_function=resampling_fun_mock,
+        ResamplerConfig(
+            resampling_period_s=resampling_period_s,
+            max_data_age_in_periods=2.0,
+            resampling_function=resampling_fun_mock,
+        )
     )
 
     source_recvr = source_chan.new_receiver()
@@ -499,9 +508,11 @@ async def test_receiving_resampling_error(fake_time: time_machine.Coordinates) -
         spec=ResamplingFunction, return_value=expected_resampled_value
     )
     resampler = Resampler(
-        resampling_period_s=resampling_period_s,
-        max_data_age_in_periods=2.0,
-        resampling_function=resampling_fun_mock,
+        ResamplerConfig(
+            resampling_period_s=resampling_period_s,
+            max_data_age_in_periods=2.0,
+            resampling_function=resampling_fun_mock,
+        )
     )
 
     class TestException(Exception):

--- a/tests/timeseries/test_resampling.py
+++ b/tests/timeseries/test_resampling.py
@@ -20,10 +20,9 @@ from frequenz.sdk.timeseries._resampling import (
     ResamplerConfig,
     ResamplingError,
     ResamplingFunction,
-    Sink,
-    Source,
     SourceStoppedError,
 )
+from frequenz.sdk.timeseries._resampling._resampler import Sink, Source
 
 from ..utils import a_sequence
 


### PR DESCRIPTION
Add a custom resampling buffer

The resampling buffer uses a list as a backing container to implement a push-only ring buffer that can be also easily sliced.

Sadly the custom resampling buffer sucks. I think we need to implement it in C/Rust if we want to make it fast. Here are the results of the benchmark:

```
         OLD                           NEW                    NEW WITH BISECT          CUSTOM BUFFER WITH BISECT

resamples=10 samples=10      resamples=10 samples=10      resamples=10 samples=10      resamples=10 samples=10     
0.0008896420185919851        0.00062773801619187          0.0008012260077521205        0.0019748720005736686       
resamples=10 samples=100     resamples=10 samples=100     resamples=10 samples=100     resamples=10 samples=100    
0.007817161997081712         0.005761806009104475         0.006307974021183327         0.014143209002213553        
resamples=10 samples=1000    resamples=10 samples=1000    resamples=10 samples=1000    resamples=10 samples=1000   
0.07768873398890719          0.05851042701397091          0.0604277040110901           0.12536667400127044         
resamples=100 samples=10     resamples=100 samples=10     resamples=100 samples=10     resamples=100 samples=10    
0.008742492995224893         0.0062527229893021286        0.00808265499654226          0.021197415997448843        
resamples=100 samples=100    resamples=100 samples=100    resamples=100 samples=100    resamples=100 samples=100   
0.07808284999919124          0.057997508003609255         0.0624066719901748           0.13266414900135715         
resamples=100 samples=1000   resamples=100 samples=1000   resamples=100 samples=1000   resamples=100 samples=1000  
0.782658567011822            0.5870920980232768           0.6098103950207587           1.4532136470006662          
resamples=1000 samples=10    resamples=1000 samples=10    resamples=1000 samples=10    resamples=1000 samples=10   
0.08764891701866873          0.062448524025967345         0.07815460601705126          0.22267909600486746         
resamples=1000 samples=100   resamples=1000 samples=100   resamples=1000 samples=100   resamples=1000 samples=100  
0.78426024899818             0.5858371119829826           0.6357307220168877           1.5354863690008642          
resamples=1000 samples=1000  resamples=1000 samples=1000  resamples=1000 samples=1000  resamples=1000 samples=1000 
7.513815971993608            5.984694316983223            6.42200836900156             12.64786391400412           
```

So this PR is just opened for documentation purposes, but it won't be merged.
