### PR TITLE
Improve resampler buffer and config

### DIFF
--- a/benchmarks/timeseries/resampling.py
+++ b/benchmarks/timeseries/resampling.py
@@ -25,6 +25,7 @@ def _benchmark_resampling_helper(resamples: int, samples: int) -> None:
             resampling_period_s=1.0,
             max_data_age_in_periods=3.0,
             resampling_function=nop,
+            initial_buffer_len=samples * 3,
         )
     )
     now = datetime.now(timezone.utc)

--- a/benchmarks/timeseries/resampling.py
+++ b/benchmarks/timeseries/resampling.py
@@ -1,0 +1,51 @@
+# License: MIT
+# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+
+"""Benchmark resampling."""
+
+from datetime import datetime, timedelta, timezone
+from timeit import timeit
+from typing import Sequence
+
+from frequenz.sdk.timeseries import Sample
+from frequenz.sdk.timeseries._resampling import ResamplerConfig, _ResamplingHelper
+
+
+def nop(  # pylint: disable=unused-argument
+    samples: Sequence[Sample], resampling_period_s: float
+) -> float:
+    """Return 0.0."""
+    return 0.0
+
+
+def _benchmark_resampling_helper(resamples: int, samples: int) -> None:
+    """Benchmark the resampling helper."""
+    helper = _ResamplingHelper(
+        ResamplerConfig(
+            resampling_period_s=1.0,
+            max_data_age_in_periods=3.0,
+            resampling_function=nop,
+        )
+    )
+    now = datetime.now(timezone.utc)
+
+    def _do_work() -> None:
+        nonlocal now
+        for _n_resample in range(resamples):
+            for _n_sample in range(samples):
+                now = now + timedelta(seconds=1 / samples)
+                helper.add_sample(Sample(now, 0.0))
+            helper.resample(now)
+
+    print(timeit(_do_work, number=5))
+
+
+def _benchmark() -> None:
+    for resamples in [10, 100, 1000]:
+        for samples in [10, 100, 1000]:
+            print(f"{resamples=} {samples=}")
+            _benchmark_resampling_helper(resamples, samples)
+
+
+if __name__ == "__main__":
+    _benchmark()

--- a/examples/resampling.py
+++ b/examples/resampling.py
@@ -18,7 +18,7 @@ from frequenz.sdk.actor import (
 )
 from frequenz.sdk.microgrid.component import ComponentCategory, ComponentMetricId
 from frequenz.sdk.timeseries import Sample
-from frequenz.sdk.timeseries._resampling import Resampler, Sink, Source
+from frequenz.sdk.timeseries._resampling import Resampler, ResamplerConfig, Sink, Source
 
 HOST = "microgrid.sandbox.api.frequenz.io"
 PORT = 61060
@@ -65,7 +65,7 @@ async def run() -> None:  # pylint: disable=too-many-locals
         channel_registry=channel_registry,
         data_sourcing_request_sender=data_source_request_sender,
         resampling_request_receiver=resampling_request_receiver,
-        resampling_period_s=1,
+        config=ResamplerConfig(resampling_period_s=1),
     )
 
     components = await microgrid.get().api_client.components()
@@ -104,7 +104,7 @@ async def run() -> None:  # pylint: disable=too-many-locals
     # Create a channel to calculate an average for all the data
     average_chan = Broadcast[Sample]("average")
 
-    second_stage_resampler = Resampler(resampling_period_s=3.0)
+    second_stage_resampler = Resampler(ResamplerConfig(resampling_period_s=3.0))
     second_stage_resampler.add_timeseries(average_chan.new_receiver(), _print_sample)
 
     average_sender = average_chan.new_sender()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
     "sympy >= 1.10.1, < 2",
     "toml >= 0.10",
     "tqdm >= 4.38.0, < 5",
+    "typing_extensions >= 4.4.0, < 5",
     "watchfiles >= 0.15.0",
 ]
 dynamic = [ "version" ]

--- a/src/frequenz/sdk/actor/__init__.py
+++ b/src/frequenz/sdk/actor/__init__.py
@@ -7,7 +7,7 @@ from ._channel_registry import ChannelRegistry
 from ._config_managing import ConfigManagingActor
 from ._data_sourcing import ComponentMetricRequest, DataSourcingActor
 from ._decorator import actor
-from ._resampling import ComponentMetricsResamplingActor
+from ._resampling import ComponentMetricsResamplingActor, ResamplerConfig
 
 __all__ = [
     "ChannelRegistry",
@@ -15,5 +15,6 @@ __all__ = [
     "ComponentMetricsResamplingActor",
     "ConfigManagingActor",
     "DataSourcingActor",
+    "ResamplerConfig",
     "actor",
 ]

--- a/src/frequenz/sdk/timeseries/_base_types.py
+++ b/src/frequenz/sdk/timeseries/_base_types.py
@@ -3,12 +3,16 @@
 
 """Timeseries basic types."""
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Optional
 
 
-@dataclass(frozen=True)
+# Ordering by timestamp is a bit arbitrary, and it is not always what might be
+# wanted. We are using this order now because usually we need to do binary
+# searches on sequences of samples, and the Python `bisect` module doesn't
+# support providing a key until Python 3.10.
+@dataclass(frozen=True, order=True)
 class Sample:
     """A measurement taken at a particular point in time.
 
@@ -17,5 +21,8 @@ class Sample:
     coherent view on a group of component metrics for a particular timestamp.
     """
 
-    timestamp: datetime
-    value: Optional[float] = None
+    timestamp: datetime = field(compare=True)
+    """The time when this sample was generated."""
+
+    value: Optional[float] = field(compare=False, default=None)
+    """The value of this sample."""

--- a/src/frequenz/sdk/timeseries/_resampling.py
+++ b/src/frequenz/sdk/timeseries/_resampling.py
@@ -355,10 +355,12 @@ class _ResamplingHelper:
         # specifying a key extraction function in Python 3.10, so we need to
         # compare samples at the moment.
         cut_index = bisect(self._buffer, Sample(minimum_relevant_timestamp, None))
-        # pylint: disable=fixme
-        # FIXME: This is far from efficient, but we don't want to start new
-        # ring buffer implementation here that uses a list to overcome the
-        # deque limitation of not being able to get slices
+        # Using itertools for slicing doesn't look very efficient, but
+        # experiements with a custom (ring) buffer that can slice showed that
+        # it is not that bad. See:
+        # https://github.com/frequenz-floss/frequenz-sdk-python/pull/130
+        # So if we need more performance beyond this point, we probably need to
+        # resort to some C (or similar) implementation.
         relevant_samples = list(itertools.islice(self._buffer, cut_index, None))
         value = (
             conf.resampling_function(relevant_samples, conf.resampling_period_s)

--- a/tests/actor/test_resampling.py
+++ b/tests/actor/test_resampling.py
@@ -16,6 +16,7 @@ from frequenz.sdk.actor import (
     ChannelRegistry,
     ComponentMetricRequest,
     ComponentMetricsResamplingActor,
+    ResamplerConfig,
 )
 from frequenz.sdk.microgrid.component import ComponentMetricId
 from frequenz.sdk.timeseries import Sample
@@ -123,8 +124,10 @@ async def test_single_request(
         channel_registry=channel_registry,
         data_sourcing_request_sender=data_source_req_chan.new_sender(),
         resampling_request_receiver=resampling_req_chan.new_receiver(),
-        resampling_period_s=0.2,
-        max_data_age_in_periods=2,
+        config=ResamplerConfig(
+            resampling_period_s=0.2,
+            max_data_age_in_periods=2,
+        ),
     )
 
     subs_req = ComponentMetricRequest(
@@ -167,8 +170,10 @@ async def test_duplicate_request(
         channel_registry=channel_registry,
         data_sourcing_request_sender=data_source_req_chan.new_sender(),
         resampling_request_receiver=resampling_req_chan.new_receiver(),
-        resampling_period_s=0.2,
-        max_data_age_in_periods=2,
+        config=ResamplerConfig(
+            resampling_period_s=0.2,
+            max_data_age_in_periods=2,
+        ),
     )
 
     subs_req = ComponentMetricRequest(

--- a/tests/timeseries/mock_microgrid.py
+++ b/tests/timeseries/mock_microgrid.py
@@ -27,6 +27,7 @@ from frequenz.sdk.actor import (
     ComponentMetricRequest,
     ComponentMetricsResamplingActor,
     DataSourcingActor,
+    ResamplerConfig,
 )
 from tests.microgrid import mock_api
 
@@ -236,7 +237,7 @@ class MockMicrogrid:
             channel_registry=channel_registry,
             data_sourcing_request_sender=data_source_request_sender,
             resampling_request_receiver=resampling_actor_request_receiver,
-            resampling_period_s=0.1,
+            config=ResamplerConfig(resampling_period_s=0.1),
         )
 
         return (resampling_actor_request_sender, channel_registry)

--- a/tests/timeseries/test_resampling.py
+++ b/tests/timeseries/test_resampling.py
@@ -17,6 +17,7 @@ from frequenz.channels import Broadcast
 from frequenz.sdk.timeseries import Sample
 from frequenz.sdk.timeseries._resampling import (
     Resampler,
+    ResamplerConfig,
     ResamplingError,
     ResamplingFunction,
     Sink,
@@ -90,9 +91,11 @@ async def test_resampling_with_one_window(
         spec=ResamplingFunction, return_value=expected_resampled_value
     )
     resampler = Resampler(
-        resampling_period_s=resampling_period_s,
-        max_data_age_in_periods=1.0,
-        resampling_function=resampling_fun_mock,
+        ResamplerConfig(
+            resampling_period_s=resampling_period_s,
+            max_data_age_in_periods=1.0,
+            resampling_function=resampling_fun_mock,
+        )
     )
 
     source_recvr = source_chan.new_receiver()
@@ -180,9 +183,11 @@ async def test_resampling_with_one_and_a_half_windows(  # pylint: disable=too-ma
         spec=ResamplingFunction, return_value=expected_resampled_value
     )
     resampler = Resampler(
-        resampling_period_s=resampling_period_s,
-        max_data_age_in_periods=1.5,
-        resampling_function=resampling_fun_mock,
+        ResamplerConfig(
+            resampling_period_s=resampling_period_s,
+            max_data_age_in_periods=1.5,
+            resampling_function=resampling_fun_mock,
+        )
     )
 
     source_recvr = source_chan.new_receiver()
@@ -311,9 +316,11 @@ async def test_resampling_with_two_windows(  # pylint: disable=too-many-statemen
         spec=ResamplingFunction, return_value=expected_resampled_value
     )
     resampler = Resampler(
-        resampling_period_s=resampling_period_s,
-        max_data_age_in_periods=2.0,
-        resampling_function=resampling_fun_mock,
+        ResamplerConfig(
+            resampling_period_s=resampling_period_s,
+            max_data_age_in_periods=2.0,
+            resampling_function=resampling_fun_mock,
+        )
     )
 
     source_recvr = source_chan.new_receiver()
@@ -442,9 +449,11 @@ async def test_receiving_stopped_resampling_error(
         spec=ResamplingFunction, return_value=expected_resampled_value
     )
     resampler = Resampler(
-        resampling_period_s=resampling_period_s,
-        max_data_age_in_periods=2.0,
-        resampling_function=resampling_fun_mock,
+        ResamplerConfig(
+            resampling_period_s=resampling_period_s,
+            max_data_age_in_periods=2.0,
+            resampling_function=resampling_fun_mock,
+        )
     )
 
     source_recvr = source_chan.new_receiver()
@@ -499,9 +508,11 @@ async def test_receiving_resampling_error(fake_time: time_machine.Coordinates) -
         spec=ResamplingFunction, return_value=expected_resampled_value
     )
     resampler = Resampler(
-        resampling_period_s=resampling_period_s,
-        max_data_age_in_periods=2.0,
-        resampling_function=resampling_fun_mock,
+        ResamplerConfig(
+            resampling_period_s=resampling_period_s,
+            max_data_age_in_periods=2.0,
+            resampling_function=resampling_fun_mock,
+        )
     )
 
     class TestException(Exception):


### PR DESCRIPTION
This add `typing_extensions` to the dependencies, even if it is not needed by this PR in particular.

We also move the resampler configuration to its own class, as it will start growing in options and otherwise there is too much duplication of a huge list of arguments that need to be repeated in multiple classes.

Finally we improve the performance of the resampling buffer (adding a benchmark to check it) and add a comment about the failed experiment to build our own custom resampling buffer.
