### PR TITLE
Add `FormulaChannel`s for composing formula outputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ pip-delete-this-directory.txt
 
 # Unit test / coverage reports
 htmlcov/
+.htmlcov*/
 .tox/
 .nox/
 .coverage

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,7 +10,8 @@
 
 ## New Features
 
-<!-- Here goes the main new features and examples or instructions on how to use them -->
+- Ability to compose formula outputs into higher-order formulas:
+  https://github.com/frequenz-floss/frequenz-sdk-python/pull/133
 
 ## Bug Fixes
 

--- a/src/frequenz/sdk/timeseries/logical_meter/_formula_engine.py
+++ b/src/frequenz/sdk/timeseries/logical_meter/_formula_engine.py
@@ -16,6 +16,7 @@ from uuid import UUID, uuid4
 from frequenz.channels import Broadcast, Receiver
 from frequenz.channels._broadcast import Receiver as BroadcastReceiver
 
+from ...util.asyncio import cancel_and_await
 from .. import Sample
 from ._formula_steps import (
     Adder,
@@ -169,6 +170,12 @@ class FormulaEngine:
                 )
             else:
                 await sender.send(msg)
+
+    async def _stop(self) -> None:
+        """Stop a running formula engine."""
+        if self._task is None:
+            return
+        await cancel_and_await(self._task)
 
     def new_receiver(
         self, name: Optional[str] = None, max_size: int = 50

--- a/src/frequenz/sdk/timeseries/logical_meter/_formula_generators/_battery_power_formula.py
+++ b/src/frequenz/sdk/timeseries/logical_meter/_formula_generators/_battery_power_formula.py
@@ -32,7 +32,7 @@ class BatteryPowerFormula(FormulaGenerator):
             FormulaGenerationError: If a battery has a non-inverter predecessor
                 in the component graph.
         """
-        builder = self._get_builder(ComponentMetricId.ACTIVE_POWER)
+        builder = self._get_builder("battery-power", ComponentMetricId.ACTIVE_POWER)
         component_graph = microgrid.get().component_graph
         battery_inverters = list(
             comp

--- a/src/frequenz/sdk/timeseries/logical_meter/_formula_generators/_battery_soc_formula.py
+++ b/src/frequenz/sdk/timeseries/logical_meter/_formula_generators/_battery_soc_formula.py
@@ -62,7 +62,7 @@ class BatterySoCFormula(FormulaGenerator):
             FormulaGenerationError: If a battery has a non-inverter predecessor
                 in the component graph.
         """
-        builder = self._get_builder(ComponentMetricId.ACTIVE_POWER)
+        builder = self._get_builder("soc", ComponentMetricId.ACTIVE_POWER)
         component_graph = microgrid.get().component_graph
         inv_bat_pairs = {
             comp: component_graph.successors(comp.component_id)

--- a/src/frequenz/sdk/timeseries/logical_meter/_formula_generators/_formula_generator.py
+++ b/src/frequenz/sdk/timeseries/logical_meter/_formula_generators/_formula_generator.py
@@ -44,10 +44,11 @@ class FormulaGenerator(ABC):
         self._namespace = namespace
 
     def _get_builder(
-        self, component_metric_id: ComponentMetricId
+        self, name: str, component_metric_id: ComponentMetricId
     ) -> ResampledFormulaBuilder:
         builder = ResampledFormulaBuilder(
             self._namespace,
+            name,
             self._channel_registry,
             self._resampler_subscription_sender,
             component_metric_id,

--- a/src/frequenz/sdk/timeseries/logical_meter/_formula_generators/_grid_power_formula.py
+++ b/src/frequenz/sdk/timeseries/logical_meter/_formula_generators/_grid_power_formula.py
@@ -23,7 +23,7 @@ class GridPowerFormula(FormulaGenerator):
         Raises:
             ComponentNotFound: when the component graph doesn't have a `GRID` component.
         """
-        builder = self._get_builder(ComponentMetricId.ACTIVE_POWER)
+        builder = self._get_builder("grid-power", ComponentMetricId.ACTIVE_POWER)
         component_graph = microgrid.get().component_graph
         grid_component = next(
             (

--- a/src/frequenz/sdk/timeseries/logical_meter/_formula_generators/_pv_power_formula.py
+++ b/src/frequenz/sdk/timeseries/logical_meter/_formula_generators/_pv_power_formula.py
@@ -21,7 +21,7 @@ class PVPowerFormula(FormulaGenerator):
         Raises:
             ComponentNotFound: if there are no PV inverters in the component graph.
         """
-        builder = self._get_builder(ComponentMetricId.ACTIVE_POWER)
+        builder = self._get_builder("pv-power", ComponentMetricId.ACTIVE_POWER)
 
         component_graph = microgrid.get().component_graph
         pv_inverters = list(

--- a/src/frequenz/sdk/timeseries/logical_meter/_logical_meter.py
+++ b/src/frequenz/sdk/timeseries/logical_meter/_logical_meter.py
@@ -10,7 +10,7 @@ import logging
 import uuid
 from typing import Dict, List, Type
 
-from frequenz.channels import Broadcast, Receiver, Sender
+from frequenz.channels import Receiver, Sender
 
 from ...actor import ChannelRegistry, ComponentMetricRequest
 from ...microgrid import ComponentGraph
@@ -63,7 +63,7 @@ class LogicalMeter:
         # meter to use when communicating with the resampling actor.
         self._namespace = f"logical-meter-{uuid.uuid4()}"
         self._component_graph = component_graph
-        self._output_channels: Dict[str, Broadcast[Sample]] = {}
+        self._engines: Dict[str, FormulaEngine] = {}
         self._tasks: List[asyncio.Task[None]] = []
 
     async def _engine_from_formula_string(
@@ -71,31 +71,12 @@ class LogicalMeter:
     ) -> FormulaEngine:
         builder = ResampledFormulaBuilder(
             self._namespace,
+            formula,
             self._channel_registry,
             self._resampler_subscription_sender,
             metric_id,
         )
         return await builder.from_string(formula, nones_are_zeros)
-
-    async def _run_formula(
-        self, formula: FormulaEngine, sender: Sender[Sample]
-    ) -> None:
-        """Run the formula repeatedly and send the results to a channel.
-
-        Args:
-            formula: The formula to run.
-            sender: A sender for sending the formula results to.
-        """
-        while True:
-            try:
-                msg = await formula.apply()
-            except asyncio.CancelledError:
-                logger.exception("LogicalMeter task cancelled")
-                break
-            except Exception as err:  # pylint: disable=broad-except
-                logger.warning("Formula application failed: %s", err)
-            else:
-                await sender.send(msg)
 
     async def start_formula(
         self,
@@ -116,40 +97,29 @@ class LogicalMeter:
             A Receiver that streams values with the formulas applied.
         """
         channel_key = formula + component_metric_id.value
-        if channel_key in self._output_channels:
-            return self._output_channels[channel_key].new_receiver()
+        if channel_key in self._engines:
+            return self._engines[channel_key].new_receiver()
 
         formula_engine = await self._engine_from_formula_string(
             formula, component_metric_id, nones_are_zeros
         )
-        out_chan = Broadcast[Sample](channel_key)
-        self._output_channels[channel_key] = out_chan
-        self._tasks.append(
-            asyncio.create_task(
-                self._run_formula(formula_engine, out_chan.new_sender())
-            )
-        )
-        return out_chan.new_receiver()
+        self._engines[channel_key] = formula_engine
+
+        return formula_engine.new_receiver()
 
     async def _get_formula_stream(
         self,
         channel_key: str,
         generator: Type[FormulaGenerator],
     ) -> Receiver[Sample]:
-        if channel_key in self._output_channels:
-            return self._output_channels[channel_key].new_receiver()
+        if channel_key in self._engines:
+            return self._engines[channel_key].new_receiver()
 
-        formula_engine = await generator(
+        engine = await generator(
             self._namespace, self._channel_registry, self._resampler_subscription_sender
         ).generate()
-        out_chan = Broadcast[Sample](channel_key)
-        self._output_channels[channel_key] = out_chan
-        self._tasks.append(
-            asyncio.create_task(
-                self._run_formula(formula_engine, out_chan.new_sender())
-            )
-        )
-        return out_chan.new_receiver()
+        self._engines[channel_key] = engine
+        return engine.new_receiver()
 
     async def grid_power(self) -> Receiver[Sample]:
         """Fetch the grid power for the microgrid.

--- a/src/frequenz/sdk/timeseries/logical_meter/_resampled_formula_builder.py
+++ b/src/frequenz/sdk/timeseries/logical_meter/_resampled_formula_builder.py
@@ -16,9 +16,10 @@ from ._tokenizer import Tokenizer, TokenType
 class ResampledFormulaBuilder(FormulaBuilder):
     """Provides a way to build a FormulaEngine from resampled data streams."""
 
-    def __init__(
+    def __init__(  # pylint: disable=too-many-arguments
         self,
         namespace: str,
+        formula_name: str,
         channel_registry: ChannelRegistry,
         resampler_subscription_sender: Sender[ComponentMetricRequest],
         metric_id: ComponentMetricId,
@@ -28,6 +29,7 @@ class ResampledFormulaBuilder(FormulaBuilder):
         Args:
             namespace: The unique namespace to allow reuse of streams in the data
                 pipeline.
+            formula_name: A name for the formula.
             channel_registry: The channel registry instance shared with the resampling
                 and the data sourcing actors.
             resampler_subscription_sender: A sender to send metric requests to the
@@ -38,7 +40,7 @@ class ResampledFormulaBuilder(FormulaBuilder):
         self._resampler_subscription_sender = resampler_subscription_sender
         self._namespace = namespace
         self._metric_id = metric_id
-        super().__init__()
+        super().__init__(formula_name)
 
     async def _get_resampled_receiver(
         self, component_id: int, metric_id: ComponentMetricId

--- a/tests/microgrid/mock_api.py
+++ b/tests/microgrid/mock_api.py
@@ -262,7 +262,7 @@ class MockGrpcServer:
         self, servicer: MicrogridServicer, host: str = "[::]", port: int = 61060
     ) -> None:
         """Create a MockGrpcServicer instance."""
-        self._server = grpc.aio.server(futures.ThreadPoolExecutor(max_workers=10))
+        self._server = grpc.aio.server(futures.ThreadPoolExecutor(max_workers=20))
         add_MicrogridServicer_to_server(servicer, self._server)
         self._server.add_insecure_port(f"{host}:{port}")
 

--- a/tests/timeseries/mock_microgrid.py
+++ b/tests/timeseries/mock_microgrid.py
@@ -151,10 +151,9 @@ class MockMicrogrid:
                 # for inverters with component_id > 100, send only half the messages.
                 if request.id % 10 == cls.inverter_id_suffix:
                     if request.id < 100 or value <= 5:
-                        yield next_msg(value=value + request.id)
+                        yield next_msg(value=value + int(request.id / 10))
                 else:
-                    yield next_msg(value=value + request.id)
-
+                    yield next_msg(value=value + int(request.id / 10))
                 time.sleep(0.1)
 
         mocker.patch.object(servicer, "GetComponentData", get_component_data)

--- a/tests/timeseries/test_formula_engine.py
+++ b/tests/timeseries/test_formula_engine.py
@@ -48,7 +48,7 @@ class TestFormulaEngine:
     ) -> None:
         """Run a formula test."""
         channels: Dict[str, Broadcast[Sample]] = {}
-        builder = FormulaBuilder()
+        builder = FormulaBuilder("test_formula")
         for token in Tokenizer(formula):
             if token.type == TokenType.COMPONENT_METRIC:
                 if token.value not in channels:
@@ -76,7 +76,8 @@ class TestFormulaEngine:
                     ]
                 )
             )
-            assert (await engine.apply()).value == io_output
+            next_val = await engine._apply()  # pylint: disable=protected-access
+            assert (next_val).value == io_output
             tests_passed += 1
         assert tests_passed == len(io_pairs)
 

--- a/tests/timeseries/test_formula_engine.py
+++ b/tests/timeseries/test_formula_engine.py
@@ -5,12 +5,17 @@
 
 import asyncio
 from datetime import datetime
-from typing import Dict, List, Optional, Tuple
+from typing import Callable, Dict, List, Optional, Tuple, Union
 
-from frequenz.channels import Broadcast
+from frequenz.channels import Broadcast, Receiver
 
 from frequenz.sdk.timeseries import Sample
-from frequenz.sdk.timeseries.logical_meter._formula_engine import FormulaBuilder
+from frequenz.sdk.timeseries.logical_meter._formula_engine import (
+    FormulaBuilder,
+    FormulaEngine,
+    FormulaReceiver,
+    HigherOrderFormulaBuilder,
+)
 from frequenz.sdk.timeseries.logical_meter._tokenizer import Token, Tokenizer, TokenType
 
 
@@ -79,6 +84,7 @@ class TestFormulaEngine:
             next_val = await engine._apply()  # pylint: disable=protected-access
             assert (next_val).value == io_output
             tests_passed += 1
+        await engine._stop()  # pylint: disable=protected-access
         assert tests_passed == len(io_pairs)
 
     async def test_simple(self) -> None:
@@ -269,6 +275,263 @@ class TestFormulaEngine:
         await self.run_test(
             "#2 + #4 - (#5 * #6)",
             "[#2, #4, #5, #6, *, -, +]",
+            [
+                ([10.0, 12.0, 15.0, 2.0], -8.0),
+                ([10.0, 12.0, 15.0, None], None),
+                ([10.0, None, 15.0, 2.0], None),
+                ([15.0, 17.0, 20.0, 5.0], -68.0),
+                ([15.0, 17.0, None, 5.0], None),
+            ],
+            False,
+        )
+
+
+class TestFormulaChannel:
+    """Tests for formula channels."""
+
+    def make_engine(self, stream_id: int, data: Receiver[Sample]) -> FormulaEngine:
+        """Make a basic FormulaEngine."""
+        name = f"#{stream_id}"
+        builder = FormulaBuilder(name)
+        builder.push_metric(
+            name,
+            data,
+            nones_are_zeros=False,
+        )
+        return builder.build()
+
+    async def run_test(  # pylint: disable=too-many-locals
+        self,
+        num_items: int,
+        make_builder: Union[
+            Callable[
+                [FormulaReceiver, FormulaReceiver, FormulaReceiver],
+                HigherOrderFormulaBuilder,
+            ],
+            Callable[
+                [FormulaReceiver, FormulaReceiver, FormulaReceiver, FormulaReceiver],
+                HigherOrderFormulaBuilder,
+            ],
+        ],
+        io_pairs: List[Tuple[List[Optional[float]], Optional[float]]],
+        nones_are_zeros: bool = False,
+    ) -> None:
+        """Run a test with the specs provided."""
+        channels = [Broadcast[Sample](str(ctr)) for ctr in range(num_items)]
+        l1_engines = [
+            self.make_engine(ctr, channels[ctr].new_receiver())
+            for ctr in range(num_items)
+        ]
+        builder = make_builder(*[e.new_receiver() for e in l1_engines])
+        engine = builder.build("l2 formula", nones_are_zeros)
+        result_chan = engine.new_receiver()
+
+        now = datetime.now()
+        tests_passed = 0
+        for io_pair in io_pairs:
+            io_input, io_output = io_pair
+            assert all(
+                await asyncio.gather(
+                    *[
+                        chan.new_sender().send(Sample(now, value))
+                        for chan, value in zip(channels, io_input)
+                    ]
+                )
+            )
+            next_val = await result_chan.receive()
+            assert next_val.value == io_output
+            tests_passed += 1
+        await engine._stop()  # pylint: disable=protected-access
+        assert tests_passed == len(io_pairs)
+
+    async def test_simple(self) -> None:
+        """Test simple formulas."""
+        await self.run_test(
+            3,
+            lambda c2, c4, c5: c2 - c4 + c5,
+            [
+                ([10.0, 12.0, 15.0], 13.0),
+                ([15.0, 17.0, 20.0], 18.0),
+            ],
+        )
+        await self.run_test(
+            3,
+            lambda c2, c4, c5: c2 + c4 - c5,
+            [
+                ([10.0, 12.0, 15.0], 7.0),
+                ([15.0, 17.0, 20.0], 12.0),
+            ],
+        )
+        await self.run_test(
+            3,
+            lambda c2, c4, c5: c2 * c4 + c5,
+            [
+                ([10.0, 12.0, 15.0], 135.0),
+                ([15.0, 17.0, 20.0], 275.0),
+            ],
+        )
+        await self.run_test(
+            3,
+            lambda c2, c4, c5: c2 * c4 / c5,
+            [
+                ([10.0, 12.0, 15.0], 8.0),
+                ([15.0, 17.0, 20.0], 12.75),
+            ],
+        )
+        await self.run_test(
+            3,
+            lambda c2, c4, c5: c2 / c4 - c5,
+            [
+                ([6.0, 12.0, 15.0], -14.5),
+                ([15.0, 20.0, 20.0], -19.25),
+            ],
+        )
+        await self.run_test(
+            3,
+            lambda c2, c4, c5: c2 - c4 - c5,
+            [
+                ([6.0, 12.0, 15.0], -21.0),
+                ([15.0, 20.0, 20.0], -25.0),
+            ],
+        )
+        await self.run_test(
+            3,
+            lambda c2, c4, c5: c2 + c4 + c5,
+            [
+                ([6.0, 12.0, 15.0], 33.0),
+                ([15.0, 20.0, 20.0], 55.0),
+            ],
+        )
+        await self.run_test(
+            3,
+            lambda c2, c4, c5: c2 / c4 / c5,
+            [
+                ([30.0, 3.0, 5.0], 2.0),
+                ([15.0, 3.0, 2.0], 2.5),
+            ],
+        )
+
+    async def test_compound(self) -> None:
+        """Test compound formulas."""
+        await self.run_test(
+            4,
+            lambda c2, c4, c5, c6: c2 + c4 - c5 * c6,
+            [
+                ([10.0, 12.0, 15.0, 2.0], -8.0),
+                ([15.0, 17.0, 20.0, 1.5], 2.0),
+            ],
+        )
+        await self.run_test(
+            4,
+            lambda c2, c4, c5, c6: c2 + (c4 - c5) * c6,
+            [
+                ([10.0, 12.0, 15.0, 2.0], 4.0),
+                ([15.0, 17.0, 20.0, 1.5], 10.5),
+            ],
+        )
+        await self.run_test(
+            4,
+            lambda c2, c4, c5, c6: c2 + (c4 - c5 * c6),
+            [
+                ([10.0, 12.0, 15.0, 2.0], -8.0),
+                ([15.0, 17.0, 20.0, 1.5], 2.0),
+            ],
+        )
+        await self.run_test(
+            4,
+            lambda c2, c4, c5, c6: c2 + (c4 - c5 - c6),
+            [
+                ([10.0, 12.0, 15.0, 2.0], 5.0),
+                ([15.0, 17.0, 20.0, 1.5], 10.5),
+            ],
+        )
+        await self.run_test(
+            4,
+            lambda c2, c4, c5, c6: c2 + c4 - c5 - c6,
+            [
+                ([10.0, 12.0, 15.0, 2.0], 5.0),
+                ([15.0, 17.0, 20.0, 1.5], 10.5),
+            ],
+        )
+        await self.run_test(
+            4,
+            lambda c2, c4, c5, c6: c2 + c4 - (c5 - c6),
+            [
+                ([10.0, 12.0, 15.0, 2.0], 9.0),
+                ([15.0, 17.0, 20.0, 1.5], 13.5),
+            ],
+        )
+        await self.run_test(
+            4,
+            lambda c2, c4, c5, c6: (c2 + c4 - c5) * c6,
+            [
+                ([10.0, 12.0, 15.0, 2.0], 14.0),
+                ([15.0, 17.0, 20.0, 1.5], 18.0),
+            ],
+        )
+        await self.run_test(
+            4,
+            lambda c2, c4, c5, c6: (c2 + c4 - c5) / c6,
+            [
+                ([10.0, 12.0, 15.0, 2.0], 3.5),
+                ([15.0, 17.0, 20.0, 1.5], 8.0),
+            ],
+        )
+        await self.run_test(
+            4,
+            lambda c2, c4, c5, c6: c2 + c4 - (c5 / c6),
+            [
+                ([10.0, 12.0, 15.0, 2.0], 14.5),
+                ([15.0, 17.0, 20.0, 5.0], 28.0),
+            ],
+        )
+
+    async def test_nones_are_zeros(self) -> None:
+        """Test that `None`s are treated as zeros when configured."""
+        await self.run_test(
+            3,
+            lambda c2, c4, c5: c2 - c4 + c5,
+            [
+                ([10.0, 12.0, 15.0], 13.0),
+                ([None, 12.0, 15.0], 3.0),
+                ([10.0, None, 15.0], 25.0),
+                ([15.0, 17.0, 20.0], 18.0),
+                ([15.0, None, None], 15.0),
+            ],
+            True,
+        )
+
+        await self.run_test(
+            4,
+            lambda c2, c4, c5, c6: c2 + c4 - (c5 * c6),
+            [
+                ([10.0, 12.0, 15.0, 2.0], -8.0),
+                ([10.0, 12.0, 15.0, None], 22.0),
+                ([10.0, None, 15.0, 2.0], -20.0),
+                ([15.0, 17.0, 20.0, 5.0], -68.0),
+                ([15.0, 17.0, None, 5.0], 32.0),
+            ],
+            True,
+        )
+
+    async def test_nones_are_not_zeros(self) -> None:
+        """Test that calculated values are `None` on input `None`s."""
+        await self.run_test(
+            3,
+            lambda c2, c4, c5: c2 - c4 + c5,
+            [
+                ([10.0, 12.0, 15.0], 13.0),
+                ([None, 12.0, 15.0], None),
+                ([10.0, None, 15.0], None),
+                ([15.0, 17.0, 20.0], 18.0),
+                ([15.0, None, None], None),
+            ],
+            False,
+        )
+
+        await self.run_test(
+            4,
+            lambda c2, c4, c5, c6: c2 + c4 - (c5 * c6),
             [
                 ([10.0, 12.0, 15.0, 2.0], -8.0),
                 ([10.0, 12.0, 15.0, None], None),

--- a/tests/timeseries/test_logical_meter.py
+++ b/tests/timeseries/test_logical_meter.py
@@ -38,6 +38,7 @@ class TestLogicalMeter:
         # pylint: disable=protected-access
         builder = ResampledFormulaBuilder(
             logical_meter._namespace,
+            "",
             channel_registry,
             request_sender,
             metric_id,


### PR DESCRIPTION
This PR introduces a channel type called `FormulaChannel`, which derives from `Broadcast` channels, and a receiver type for it called `FormulaReceiver`, which derives from the Broadcast `Receiver`.

LogicalMeter now returns `FormulaReceiver`s instead of broadcast `Receiver`s,  and these `FormulaReceiver`s can be composed to create new formula engines that operate on the outputs of other formula engines.

This would make it easier to build complex formulas that operate on resampled component data streams.  For example:
``` python
net_power_recv = (
    (
        logical_meter.grid_power()
        - logical_meter.battery_power()
        - logical_meter.pv_power()
    )
    .build("net_power")
    .new_receiver()
)
```