### PR TITLE
Make resampler infer the input sampling period and buffer length

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,12 +6,35 @@
 
 ## Upgrading
 
-<!-- Here goes notes on how to upgrade from previous versions, including deprecations and what they should be replaced with --> 
+* The resampler now takes a `name` argument for `add_timeseries()`. This is only used for logging purposes.
+
+* The resampler and resampling actor now takes a `ResamplerConfig` object in the constructor instead of the individual values.
+
+* The resampler and resampling actor can emit errors or warnings if the buffer needed to resample is too big. If it is bigger than `ResamplingConfig.max_buffer_len`, the buffer will be truncated to that length, so the resampling can lose accuracy.
+
+* The `ResamplingFunction` now takes different arguments:
+
+  * `resampling_period_s` was removed.
+  * `resampler_config` is the configuration of the resampler calling the resampling function.
+  * `source_properties` is the properties of the source being resampled.
 
 ## New Features
 
-<!-- Here goes the main new features and examples or instructions on how to use them -->
+* The resampler and resampling actor can now take a few new options via the new `ResamplerConfig` object:
+
+  * `warn_buffer_len`: The minimum length of the resampling buffer that will emit a warning.
+  * `max_buffer_len`: The maximum length of the resampling buffer.
+
+* The resampler now infers the input sampling rate of sources and use a buffer size according to it.
+
+  This information can be consulted via `resampler.get_source_properties(source)`. The buffer size is now calculated so it can store all the needed samples requested via the combination of `resampling_period_s`, `max_data_age_in_periods` and the calculated `input_sampling_period_s`.
+
+  If we are upsampling, one sample could be enough for back-filling, but we store `max_data_age_in_periods` using `input_sampling_period_s` as period, so the resampling functions can do more complex inter/extrapolation if they need to.
+
+  If we are downsampling, we want a buffer that can hold `max_data_age_in_periods * resampling_period_s` seconds of data, and we have one sample every `input_sampling_period_s`, so we use a buffer length of: `max_data_age_in_periods * resampling_period_s / input_sampling_period_s`
 
 ## Bug Fixes
 
-<!-- Here goes notable bug fixes that are worth a special mention or explanation -->
+* Fixed logger creationg for some modules.
+
+  Some modules didn't create the logger properly so there was no way to configure them using the standard logger configuration system. Because of this, it might have happened that some log messages were never showed, or some message that the user didn't want to get were emitted anyway.

--- a/benchmarks/timeseries/resampling.py
+++ b/benchmarks/timeseries/resampling.py
@@ -8,11 +8,17 @@ from timeit import timeit
 from typing import Sequence
 
 from frequenz.sdk.timeseries import Sample
-from frequenz.sdk.timeseries._resampling import ResamplerConfig, _ResamplingHelper
+from frequenz.sdk.timeseries._resampling import (
+    ResamplerConfig,
+    SourceProperties,
+    _ResamplingHelper,
+)
 
 
 def nop(  # pylint: disable=unused-argument
-    samples: Sequence[Sample], resampler_config: ResamplerConfig
+    samples: Sequence[Sample],
+    resampler_config: ResamplerConfig,
+    source_properties: SourceProperties,
 ) -> float:
     """Return 0.0."""
     return 0.0
@@ -21,14 +27,15 @@ def nop(  # pylint: disable=unused-argument
 def _benchmark_resampling_helper(resamples: int, samples: int) -> None:
     """Benchmark the resampling helper."""
     helper = _ResamplingHelper(
+        "benchmark",
         ResamplerConfig(
             resampling_period_s=1.0,
             max_data_age_in_periods=3.0,
             resampling_function=nop,
             initial_buffer_len=samples * 3,
-            max_buffer_len=samples * 3,
-            warn_buffer_len=samples * 3,
-        )
+            warn_buffer_len=samples * 3 + 2,
+            max_buffer_len=samples * 3 + 3,
+        ),
     )
     now = datetime.now(timezone.utc)
 

--- a/benchmarks/timeseries/resampling.py
+++ b/benchmarks/timeseries/resampling.py
@@ -12,7 +12,7 @@ from frequenz.sdk.timeseries._resampling import ResamplerConfig, _ResamplingHelp
 
 
 def nop(  # pylint: disable=unused-argument
-    samples: Sequence[Sample], resampling_period_s: float
+    samples: Sequence[Sample], resampler_config: ResamplerConfig
 ) -> float:
     """Return 0.0."""
     return 0.0

--- a/benchmarks/timeseries/resampling.py
+++ b/benchmarks/timeseries/resampling.py
@@ -26,6 +26,8 @@ def _benchmark_resampling_helper(resamples: int, samples: int) -> None:
             max_data_age_in_periods=3.0,
             resampling_function=nop,
             initial_buffer_len=samples * 3,
+            max_buffer_len=samples * 3,
+            warn_buffer_len=samples * 3,
         )
     )
     now = datetime.now(timezone.utc)

--- a/examples/resampling.py
+++ b/examples/resampling.py
@@ -105,7 +105,9 @@ async def run() -> None:  # pylint: disable=too-many-locals
     average_chan = Broadcast[Sample]("average")
 
     second_stage_resampler = Resampler(ResamplerConfig(resampling_period_s=3.0))
-    second_stage_resampler.add_timeseries(average_chan.new_receiver(), _print_sample)
+    second_stage_resampler.add_timeseries(
+        "avg", average_chan.new_receiver(), _print_sample
+    )
 
     average_sender = average_chan.new_sender()
     # Needed until channels Senders raises exceptions on errors

--- a/src/frequenz/sdk/_data_handling/time_series.py
+++ b/src/frequenz/sdk/_data_handling/time_series.py
@@ -15,7 +15,7 @@ from .formula import Formula
 Key = TypeVar("Key")
 Value = TypeVar("Value")
 
-logger = logging.Logger(__name__)
+logger = logging.getLogger(__name__)
 
 SYMBOL_SEGMENT_SEPARATOR = "_"
 

--- a/src/frequenz/sdk/_data_ingestion/component_info.py
+++ b/src/frequenz/sdk/_data_ingestion/component_info.py
@@ -10,7 +10,7 @@ from typing import Dict, List, Optional, Tuple
 from ..microgrid import ComponentGraph
 from ..microgrid.component import ComponentCategory
 
-logger = logging.Logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 @dataclass

--- a/src/frequenz/sdk/_data_ingestion/formula_calculator.py
+++ b/src/frequenz/sdk/_data_ingestion/formula_calculator.py
@@ -36,7 +36,7 @@ from .constants import (
     METRIC_PV_PROD,
 )
 
-logger = logging.Logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)

--- a/src/frequenz/sdk/_data_ingestion/load_historic_data.py
+++ b/src/frequenz/sdk/_data_ingestion/load_historic_data.py
@@ -22,7 +22,7 @@ import pandas as pd
 import pyarrow.parquet as pq
 from tqdm import tqdm
 
-logger = logging.Logger(__name__)
+logger = logging.getLogger(__name__)
 
 # directory path to all component data of a particular site
 HISTDATA_DIR = "/data"

--- a/src/frequenz/sdk/_data_ingestion/microgrid_data.py
+++ b/src/frequenz/sdk/_data_ingestion/microgrid_data.py
@@ -27,7 +27,7 @@ from .component_info import infer_microgrid_config
 from .formula_calculator import FormulaCalculator
 from .gen_component_receivers import gen_component_receivers
 
-logger = logging.Logger(__name__)
+logger = logging.getLogger(__name__)
 
 CONFIG_FILE_FORMULA_PREFIX = "formula_"
 

--- a/src/frequenz/sdk/actor/_decorator.py
+++ b/src/frequenz/sdk/actor/_decorator.py
@@ -14,7 +14,7 @@ import inspect
 import logging
 from typing import Any, Generic, Optional, Type, TypeVar
 
-logger = logging.Logger(__name__)
+logger = logging.getLogger(__name__)
 
 OT = TypeVar("OT")
 

--- a/src/frequenz/sdk/actor/_resampling.py
+++ b/src/frequenz/sdk/actor/_resampling.py
@@ -19,7 +19,7 @@ from ._channel_registry import ChannelRegistry
 from ._data_sourcing import ComponentMetricRequest
 from ._decorator import actor
 
-logger = logging.Logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 @actor

--- a/src/frequenz/sdk/actor/_resampling.py
+++ b/src/frequenz/sdk/actor/_resampling.py
@@ -85,7 +85,7 @@ class ComponentMetricsResamplingActor:
             if not await sender.send(sample):
                 raise Exception(f"Error while sending with sender {sender}", sender)
 
-        self._resampler.add_timeseries(receiver, sink_adapter)
+        self._resampler.add_timeseries(request_channel_name, receiver, sink_adapter)
 
     async def _process_resampling_requests(self) -> None:
         """Process resampling data requests."""

--- a/src/frequenz/sdk/microgrid/client/_client.py
+++ b/src/frequenz/sdk/microgrid/client/_client.py
@@ -44,7 +44,7 @@ _GenericComponentData = TypeVar(
     EVChargerData,
 )
 
-logger = logging.Logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 class MicrogridApiClient(ABC):

--- a/src/frequenz/sdk/timeseries/_resampling.py
+++ b/src/frequenz/sdk/timeseries/_resampling.py
@@ -71,7 +71,7 @@ Args:
 """
 
 
-ResamplingFunction = Callable[[Sequence[Sample], float], float]
+ResamplingFunction = Callable[[Sequence[Sample], "ResamplerConfig"], float]
 """Resampling function type.
 
 A resampling function produces a new sample based on a list of pre-existing
@@ -86,9 +86,9 @@ new sample that is going to be produced will always be bigger than the biggest
 timestamp in the input data).
 
 Args:
-    input_samples (Sequence[Sample]): the sequence of pre-existing samples.
-    resampling_period_s (float): the period in seconds (i.e. how ofter a new sample is
-        produced.
+    input_samples (Sequence[Sample]): The sequence of pre-existing samples.
+    resampler_config (ResamplerConfig): The configuration of the resampling
+        calling this function.
 
 Returns:
     new_sample (float): The value of new sample produced after the resampling.
@@ -96,13 +96,13 @@ Returns:
 
 
 # pylint: disable=unused-argument
-def average(samples: Sequence[Sample], resampling_period_s: float) -> float:
+def average(samples: Sequence[Sample], resampler_config: ResamplerConfig) -> float:
     """Calculate average of all the provided values.
 
     Args:
         samples: The samples to apply the average to. It must be non-empty.
-        resampling_period_s: The time it passes between resampled data is
-            produced (in seconds).
+        resampler_config: The configuration of the resampler calling this
+            function.
 
     Returns:
         The average of all `samples` values.

--- a/src/frequenz/sdk/timeseries/_resampling.py
+++ b/src/frequenz/sdk/timeseries/_resampling.py
@@ -20,7 +20,7 @@ from frequenz.channels.util import Timer
 from ..util.asyncio import cancel_and_await
 from . import Sample
 
-_logger = logging.Logger(__name__)
+_logger = logging.getLogger(__name__)
 
 
 DEFAULT_BUFFER_LEN_INIT = 16

--- a/src/frequenz/sdk/timeseries/logical_meter/_logical_meter.py
+++ b/src/frequenz/sdk/timeseries/logical_meter/_logical_meter.py
@@ -25,7 +25,7 @@ from ._formula_generators import (
 )
 from ._resampled_formula_builder import ResampledFormulaBuilder
 
-logger = logging.Logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 class LogicalMeter:


### PR DESCRIPTION
The input sampling period is calculated by counting the total received samples, and dividing the total resampling time until the internal buffer is full by the total received samples.

To store all the source properties (sampling period, sampling start, total received samples) a new class is used (SourceProperties) and this information is passed to the resampling function, so it can have more information about the source to perform a proper resampling.

This calculation is performed once and then remains constant, but at some point we could add a timer to re-calculate it.

This also improves slightly the documentation and validation of the ResamplingConfig class.

The add_timeseries() methods now also takes a name as a way to identify different sources in log messages (the actor uses the channel name as timeseries name).

We also update the resampling buffer length based on the input sampling period, resampling period, and max data age in periods, so it can hold all the past data without wasting any space.

Fixes #55.
