### PR TITLE
Add a formula generator for SoC in the LogicalMeter

### DIFF
--- a/src/frequenz/sdk/timeseries/logical_meter/_exceptions.py
+++ b/src/frequenz/sdk/timeseries/logical_meter/_exceptions.py
@@ -1,0 +1,8 @@
+# License: MIT
+# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+
+"""Formula Engine Exceptions."""
+
+
+class FormulaEngineError(Exception):
+    """An error occured while fetching metrics or applying the formula on them."""

--- a/src/frequenz/sdk/timeseries/logical_meter/_formula_generators/__init__.py
+++ b/src/frequenz/sdk/timeseries/logical_meter/_formula_generators/__init__.py
@@ -4,6 +4,7 @@
 """Generators for formulas from component graphs."""
 
 from ._battery_power_formula import BatteryPowerFormula
+from ._battery_soc_formula import BatterySoCFormula
 from ._formula_generator import (
     ComponentNotFound,
     FormulaGenerationError,
@@ -22,6 +23,7 @@ __all__ = [
     #
     "GridPowerFormula",
     "BatteryPowerFormula",
+    "BatterySoCFormula",
     "PVPowerFormula",
     #
     # Exceptions

--- a/src/frequenz/sdk/timeseries/logical_meter/_formula_generators/_battery_soc_formula.py
+++ b/src/frequenz/sdk/timeseries/logical_meter/_formula_generators/_battery_soc_formula.py
@@ -1,0 +1,102 @@
+# License: MIT
+# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+
+"""Formula generator from component graph for Grid Power."""
+
+import asyncio
+
+from frequenz.channels import Receiver
+
+from .....sdk import microgrid
+from ....microgrid.component import ComponentCategory, ComponentMetricId, InverterType
+from ... import Sample
+from .._formula_engine import FormulaEngine
+from ._formula_generator import (
+    ComponentNotFound,
+    FormulaGenerationError,
+    FormulaGenerator,
+)
+
+
+class _ActiveBatteryReceiver(Receiver[Sample]):
+    """Returns a Sample from a battery, only if the attached inverter is active."""
+
+    def __init__(self, inv_recv: Receiver[Sample], bat_recv: Receiver[Sample]):
+        self._inv_recv = inv_recv
+        self._bat_recv = bat_recv
+
+    async def ready(self) -> None:
+        """Wait until the next Sample is ready."""
+        await asyncio.gather(self._inv_recv.ready(), self._bat_recv.ready())
+
+    def consume(self) -> Sample:
+        """Return the next Sample.
+
+        Returns:
+            the next Sample.
+        """
+        inv = self._inv_recv.consume()
+        bat = self._bat_recv.consume()
+        if inv.value is None:
+            return inv
+        return bat
+
+
+class BatterySoCFormula(FormulaGenerator):
+    """Creates a formula engine from the component graph for calculating battery soc."""
+
+    async def generate(
+        self,
+    ) -> FormulaEngine:
+        """Make a formula for the average battery soc of a microgrid.
+
+        If there's no data coming from an inverter or a battery, the corresponding
+        battery will be excluded from the calculation.
+
+        Returns:
+            A formula engine that will calculate average battery soc values.
+
+        Raises:
+            ComponentNotFound: if there are no batteries in the component graph, or if
+                they don't have an inverter as a predecessor.
+            FormulaGenerationError: If a battery has a non-inverter predecessor
+                in the component graph.
+        """
+        builder = self._get_builder(ComponentMetricId.ACTIVE_POWER)
+        component_graph = microgrid.get().component_graph
+        inv_bat_pairs = {
+            comp: component_graph.successors(comp.component_id)
+            for comp in component_graph.components()
+            if comp.category == ComponentCategory.INVERTER
+            and comp.type == InverterType.BATTERY
+        }
+
+        if not inv_bat_pairs:
+            raise ComponentNotFound(
+                "Unable to find any battery inverters in the component graph."
+            )
+
+        soc_streams = []
+        for inv, bats in inv_bat_pairs.items():
+            bat = list(bats)[0]
+            if len(bats) != 1:
+                raise FormulaGenerationError(
+                    f"Expected exactly one battery for inverter {inv}, got {bats}"
+                )
+
+            # pylint: disable=protected-access
+            soc_recv = _ActiveBatteryReceiver(
+                await builder._get_resampled_receiver(
+                    inv.component_id, ComponentMetricId.ACTIVE_POWER
+                ),
+                await builder._get_resampled_receiver(
+                    bat.component_id, ComponentMetricId.SOC
+                ),
+            )
+            # pylint: enable=protected-access
+
+            soc_streams.append((f"{bat.component_id}", soc_recv, False))
+
+        builder.push_average(soc_streams)
+
+        return builder.build()

--- a/src/frequenz/sdk/timeseries/logical_meter/_logical_meter.py
+++ b/src/frequenz/sdk/timeseries/logical_meter/_logical_meter.py
@@ -19,6 +19,7 @@ from .. import Sample
 from ._formula_engine import FormulaEngine
 from ._formula_generators import (
     BatteryPowerFormula,
+    BatterySoCFormula,
     FormulaGenerator,
     GridPowerFormula,
     PVPowerFormula,
@@ -187,3 +188,14 @@ class LogicalMeter:
             A *new* receiver that will stream PV power production values.
         """
         return await self._get_formula_stream("pv_power", PVPowerFormula)
+
+    async def _soc(self) -> Receiver[Sample]:
+        """Fetch the SoC of the active batteries in the microgrid.
+
+        NOTE: This method is part of the logical meter only temporarily, and will get
+        moved to the `BatteryPool` within the next few releases.
+
+        Returns:
+            A *new* receiver that will stream average SoC of active batteries.
+        """
+        return await self._get_formula_stream("soc", BatterySoCFormula)

--- a/tests/timeseries/mock_microgrid.py
+++ b/tests/timeseries/mock_microgrid.py
@@ -9,7 +9,9 @@ import time
 from typing import Iterator, Tuple
 
 from frequenz.api.microgrid import microgrid_pb2
-from frequenz.api.microgrid.common_pb2 import AC, Metric
+from frequenz.api.microgrid.battery_pb2 import Battery
+from frequenz.api.microgrid.battery_pb2 import Data as BatteryData
+from frequenz.api.microgrid.common_pb2 import AC, Metric, MetricAggregation
 from frequenz.api.microgrid.inverter_pb2 import Data as InverterData
 from frequenz.api.microgrid.inverter_pb2 import Inverter
 from frequenz.api.microgrid.inverter_pb2 import Type as InverterType
@@ -120,6 +122,15 @@ class MockMicrogrid:
                     ),
                 )
 
+            def battery_msg(value: float) -> ComponentData:
+                timestamp = Timestamp()
+                timestamp.GetCurrentTime()
+                return ComponentData(
+                    id=request.id,
+                    ts=timestamp,
+                    battery=Battery(data=BatteryData(soc=MetricAggregation(avg=value))),
+                )
+
             if request.id % 10 == cls.inverter_id_suffix:
                 next_msg = inverter_msg
             elif (
@@ -127,6 +138,8 @@ class MockMicrogrid:
                 or request.id == cls.main_meter_id
             ):
                 next_msg = meter_msg
+            elif request.id % 10 == cls.battery_id_suffix:
+                next_msg = battery_msg
             else:
                 raise RuntimeError(
                     f"Component id {request.id} unsupported by MockMicrogrid"

--- a/tests/timeseries/mock_microgrid.py
+++ b/tests/timeseries/mock_microgrid.py
@@ -145,7 +145,13 @@ class MockMicrogrid:
                     f"Component id {request.id} unsupported by MockMicrogrid"
                 )
             for value in range(1, 10):
-                yield next_msg(value=value + request.id)
+                # for inverters with component_id > 100, send only half the messages.
+                if request.id % 10 == cls.inverter_id_suffix:
+                    if request.id < 100 or value <= 5:
+                        yield next_msg(value=value + request.id)
+                else:
+                    yield next_msg(value=value + request.id)
+
                 time.sleep(0.1)
 
         mocker.patch.object(servicer, "GetComponentData", get_component_data)

--- a/tests/timeseries/test_logical_meter.py
+++ b/tests/timeseries/test_logical_meter.py
@@ -23,12 +23,13 @@ from .mock_microgrid import MockMicrogrid
 class TestLogicalMeter:
     """Tests for the logical meter."""
 
-    async def _get_resampled_stream(
+    async def _get_resampled_stream(  # pylint: disable=too-many-arguments
         self,
         logical_meter: LogicalMeter,
         channel_registry: ChannelRegistry,
         request_sender: Sender[ComponentMetricRequest],
         comp_id: int,
+        metric_id: ComponentMetricId,
     ) -> Receiver[Sample]:
         """Return the resampled data stream for the given component."""
         # Create a `FormulaBuilder` instance, just in order to reuse its
@@ -39,9 +40,12 @@ class TestLogicalMeter:
             logical_meter._namespace,
             channel_registry,
             request_sender,
-            ComponentMetricId.ACTIVE_POWER,
+            metric_id,
         )
-        return await builder._get_resampled_receiver(comp_id)
+        return await builder._get_resampled_receiver(
+            comp_id,
+            metric_id,
+        )
         # pylint: enable=protected-access
 
     async def test_grid_power_1(self, mocker: MockerFixture) -> None:
@@ -63,6 +67,7 @@ class TestLogicalMeter:
             channel_registry,
             request_sender,
             mockgrid.main_meter_id,
+            ComponentMetricId.ACTIVE_POWER,
         )
 
         results = []
@@ -102,6 +107,7 @@ class TestLogicalMeter:
                 channel_registry,
                 request_sender,
                 meter_id,
+                ComponentMetricId.ACTIVE_POWER,
             )
             for meter_id in mockgrid.meter_ids
         ]
@@ -149,6 +155,7 @@ class TestLogicalMeter:
                 channel_registry,
                 request_sender,
                 meter_id,
+                ComponentMetricId.ACTIVE_POWER,
             )
             for meter_id in mockgrid.battery_inverter_ids
         ]
@@ -159,6 +166,7 @@ class TestLogicalMeter:
                 channel_registry,
                 request_sender,
                 meter_id,
+                ComponentMetricId.ACTIVE_POWER,
             )
             for meter_id in mockgrid.pv_inverter_ids
         ]


### PR DESCRIPTION
This formula calculates and streams the average SoC of the active batteries.

This is temporarily part of the `LogicalMeter` and will be moved to the `BatteryPool` within the next few releases.