### PR TITLE
Add a delay for the mock server to start, before creating a client

### DIFF
--- a/tests/timeseries/mock_microgrid.py
+++ b/tests/timeseries/mock_microgrid.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import time
 import typing
 from typing import Iterator, Tuple
@@ -78,6 +79,7 @@ class MockMicrogrid:
                 channel registry.
         """
         await self._server.start()
+        await asyncio.sleep(0.1)
         return await self._init_client_and_actors()
 
     @classmethod


### PR DESCRIPTION
This should fix the random test failures in python 3.8, especially when testing multi-level formulas.