### PR TITLE
Send 0 values from power formulas for non-existant component types

### DIFF
--- a/src/frequenz/sdk/timeseries/logical_meter/_formula_generators/_formula_generator.py
+++ b/src/frequenz/sdk/timeseries/logical_meter/_formula_generators/_formula_generator.py
@@ -3,6 +3,7 @@
 
 """Base class for formula generators that use the component graphs."""
 
+import sys
 from abc import ABC, abstractmethod
 
 from frequenz.channels import Sender
@@ -19,6 +20,9 @@ class FormulaGenerationError(Exception):
 
 class ComponentNotFound(FormulaGenerationError):
     """Indicates that a component required for generating a formula is not found."""
+
+
+NON_EXISTING_COMPONENT_ID = sys.maxsize
 
 
 class FormulaGenerator(ABC):

--- a/src/frequenz/sdk/timeseries/logical_meter/_formula_generators/_pv_power_formula.py
+++ b/src/frequenz/sdk/timeseries/logical_meter/_formula_generators/_pv_power_formula.py
@@ -3,10 +3,14 @@
 
 """Formula generator for PV Power, from the component graph."""
 
+import logging
+
 from .....sdk import microgrid
 from ....microgrid.component import ComponentCategory, ComponentMetricId, InverterType
 from .._formula_engine import FormulaEngine
-from ._formula_generator import ComponentNotFound, FormulaGenerator
+from ._formula_generator import NON_EXISTING_COMPONENT_ID, FormulaGenerator
+
+logger = logging.getLogger(__name__)
 
 
 class PVPowerFormula(FormulaGenerator):
@@ -32,9 +36,18 @@ class PVPowerFormula(FormulaGenerator):
         )
 
         if not pv_inverters:
-            raise ComponentNotFound(
-                "Unable to find any PV inverters in the component graph."
+            logging.warning(
+                "Unable to find any PV inverters in the component graph. "
+                "Subscribing to the resampling actor with a non-existing "
+                "component id, so that `0` values are sent from the formula."
             )
+            # If there are no PV inverters, we have to send 0 values as the same
+            # frequency as the other streams.  So we subscribe with a non-existing
+            # component id, just to get a `None` message at the resampling interval.
+            await builder.push_component_metric(
+                NON_EXISTING_COMPONENT_ID, nones_are_zeros=True
+            )
+            return builder.build()
 
         for idx, comp in enumerate(pv_inverters):
             if idx > 0:


### PR DESCRIPTION
Earlier, the automatically generated formulas for `pv_power` and `battery_power` were raising exception in cases where pv or battery inverters were not found in the component graph, preventing us from having a single high level formula that can be reused in all locations.

This is solved by subscribing to a non-existing component id, so that we can still send out 0 values at the same rate as the resampler.