### PR TITLE
Wait for a short time after starting the test actors

### DIFF
--- a/src/frequenz/sdk/timeseries/_resampling.py
+++ b/src/frequenz/sdk/timeseries/_resampling.py
@@ -102,7 +102,7 @@ class ResamplerConfig:
     """Resampler configuration."""
 
     resampling_period_s: float
-    """The resapmling period in seconds.
+    """The resampling period in seconds.
 
     This is the time it passes between resampled data should be calculated.
     """

--- a/tests/timeseries/mock_microgrid.py
+++ b/tests/timeseries/mock_microgrid.py
@@ -80,7 +80,9 @@ class MockMicrogrid:
         """
         await self._server.start()
         await asyncio.sleep(0.1)
-        return await self._init_client_and_actors()
+        ret = await self._init_client_and_actors()
+        await asyncio.sleep(0.1)
+        return ret
 
     @classmethod
     async def new(


### PR DESCRIPTION
This is to fix some async scheduling issues in python 3.8 leading to
test failures.