### PR TITLE
Handle `NaN` values in FormulaEngine

### DIFF
--- a/src/frequenz/sdk/timeseries/logical_meter/_formula_engine.py
+++ b/src/frequenz/sdk/timeseries/logical_meter/_formula_engine.py
@@ -10,6 +10,7 @@ import logging
 import weakref
 from collections import deque
 from datetime import datetime
+from math import isinf, isnan
 from typing import Dict, List, Optional, Set, Tuple
 from uuid import UUID, uuid4
 
@@ -154,7 +155,11 @@ class FormulaEngine:
         if len(eval_stack) != 1:
             raise RuntimeError(f"Formula application failed: {self._name}")
 
-        return Sample(metric_ts, eval_stack[0])
+        res = eval_stack.pop()
+        if isnan(res) or isinf(res):
+            res = None
+
+        return Sample(metric_ts, res)
 
     async def _run(self) -> None:
         sender = self._channel.new_sender()

--- a/src/frequenz/sdk/timeseries/logical_meter/_formula_steps.py
+++ b/src/frequenz/sdk/timeseries/logical_meter/_formula_steps.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from math import isinf, isnan
 from typing import List, Optional
 
 from frequenz.channels import Receiver
@@ -57,10 +58,7 @@ class Adder(FormulaStep):
         """
         val2 = eval_stack.pop()
         val1 = eval_stack.pop()
-        if val1 is None or val2 is None:
-            res = None
-        else:
-            res = val1 + val2
+        res = val1 + val2
         eval_stack.append(res)
 
 
@@ -83,10 +81,7 @@ class Subtractor(FormulaStep):
         """
         val2 = eval_stack.pop()
         val1 = eval_stack.pop()
-        if val1 is None or val2 is None:
-            res = None
-        else:
-            res = val1 - val2
+        res = val1 - val2
         eval_stack.append(res)
 
 
@@ -109,10 +104,7 @@ class Multiplier(FormulaStep):
         """
         val2 = eval_stack.pop()
         val1 = eval_stack.pop()
-        if val1 is None or val2 is None:
-            res = None
-        else:
-            res = val1 * val2
+        res = val1 * val2
         eval_stack.append(res)
 
 
@@ -135,10 +127,7 @@ class Divider(FormulaStep):
         """
         val2 = eval_stack.pop()
         val1 = eval_stack.pop()
-        if val1 is None or val2 is None:
-            res = None
-        else:
-            res = val1 / val2
+        res = val1 / val2
         eval_stack.append(res)
 
 
@@ -265,7 +254,12 @@ class MetricFetcher(FormulaStep):
         """
         if self._next_value is None:
             raise RuntimeError("No next value available to append.")
-        if self._next_value.value is None and self._nones_are_zeros:
-            eval_stack.append(0.0)
+
+        next_value = self._next_value.value
+        if next_value is None or isnan(next_value) or isinf(next_value):
+            if self._nones_are_zeros:
+                eval_stack.append(0.0)
+            else:
+                eval_stack.append(float("NaN"))
         else:
             eval_stack.append(self._next_value.value)


### PR DESCRIPTION
While you are at this, it should probably be a good idea to also treat *NaN*'s specially (probably the same as `None`). You can check using `math.isnan()`.

(same for all steps)

**OR**, maybe replace `None` with *NaN* and it should have the same effect of propagating `None` manually as you are doing here, but it will be done automatically. Then you only need to convert the final *NaN* in the stack to `None` and you are set. This option is easier to write (as you don't have to touch every step) but it might be harder read (to figure out what's going on).

_Originally posted by @leandro-lucarella-frequenz in https://github.com/frequenz-floss/frequenz-sdk-python/pull/95#discussion_r1038228733_
      