### PR TITLE
Add 3-phase current formulas

### DIFF
--- a/src/frequenz/sdk/timeseries/__init__.py
+++ b/src/frequenz/sdk/timeseries/__init__.py
@@ -8,8 +8,6 @@ A timeseries is a stream (normally an async iterator) of
 [`Sample`][frequenz.sdk.timeseries.Sample]s.
 """
 
-from ._base_types import Sample
+from ._base_types import Sample, Sample3Phase
 
-__all__ = [
-    "Sample",
-]
+__all__ = ["Sample", "Sample3Phase"]

--- a/src/frequenz/sdk/timeseries/_base_types.py
+++ b/src/frequenz/sdk/timeseries/_base_types.py
@@ -26,3 +26,25 @@ class Sample:
 
     value: Optional[float] = field(compare=False, default=None)
     """The value of this sample."""
+
+
+@dataclass(frozen=True)
+class Sample3Phase:
+    """A 3-phase measurement made at a particular point in time.
+
+    Each of the `value` fields could be `None` if a component is malfunctioning
+    or data is lacking for another reason, but a sample still needs to be sent
+    to have a coherent view on a group of component metrics for a particular
+    timestamp.
+    """
+
+    timestamp: datetime
+    """The time when this sample was generated."""
+    value_p1: Optional[float]
+    """The value of the 1st phase in this sample."""
+
+    value_p2: Optional[float]
+    """The value of the 2nd phase in this sample."""
+
+    value_p3: Optional[float]
+    """The value of the 3rd phase in this sample."""

--- a/src/frequenz/sdk/timeseries/logical_meter/_formula_engine.py
+++ b/src/frequenz/sdk/timeseries/logical_meter/_formula_engine.py
@@ -406,9 +406,6 @@ class FormulaReceiver(BroadcastReceiver[Sample]):
         """
         return self._engine
 
-    def _deactivate(self) -> None:
-        self._active = False
-
     def clone(self) -> FormulaReceiver:
         """Create a new receiver from the formula engine.
 

--- a/src/frequenz/sdk/timeseries/logical_meter/_formula_generators/__init__.py
+++ b/src/frequenz/sdk/timeseries/logical_meter/_formula_generators/__init__.py
@@ -5,11 +5,13 @@
 
 from ._battery_power_formula import BatteryPowerFormula
 from ._battery_soc_formula import BatterySoCFormula
+from ._ev_charger_current_formula import EVChargerCurrentFormula
 from ._formula_generator import (
     ComponentNotFound,
     FormulaGenerationError,
     FormulaGenerator,
 )
+from ._grid_current_formula import GridCurrentFormula
 from ._grid_power_formula import GridPowerFormula
 from ._pv_power_formula import PVPowerFormula
 
@@ -19,12 +21,17 @@ __all__ = [
     #
     "FormulaGenerator",
     #
-    # Formula generators
+    # Power Formula generators
     #
     "GridPowerFormula",
     "BatteryPowerFormula",
     "BatterySoCFormula",
     "PVPowerFormula",
+    #
+    # Current formula generators
+    #
+    "GridCurrentFormula",
+    "EVChargerCurrentFormula",
     #
     # Exceptions
     #

--- a/src/frequenz/sdk/timeseries/logical_meter/_formula_generators/_ev_charger_current_formula.py
+++ b/src/frequenz/sdk/timeseries/logical_meter/_formula_generators/_ev_charger_current_formula.py
@@ -1,0 +1,90 @@
+# License: MIT
+# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+
+"""Formula generator from component graph for 3-phase Grid Current."""
+
+import logging
+from typing import List
+
+from .....sdk import microgrid
+from ....microgrid.component import Component, ComponentCategory, ComponentMetricId
+from .._formula_engine import FormulaEngine, FormulaEngine3Phase
+from ._formula_generator import NON_EXISTING_COMPONENT_ID, FormulaGenerator
+
+logger = logging.getLogger(__name__)
+
+
+class EVChargerCurrentFormula(FormulaGenerator):
+    """Create a formula engine from the component graph for calculating grid current."""
+
+    async def generate(self) -> FormulaEngine3Phase:
+        """Generate a formula for calculating total ev current from the component graph.
+
+        Returns:
+            A formula engine that calculates total 3-phase ev charger current values.
+
+        Raises:
+            ComponentNotFound: when the component graph doesn't have a `GRID` component.
+        """
+        component_graph = microgrid.get().component_graph
+        ev_chargers = [
+            comp
+            for comp in component_graph.components()
+            if comp.category == ComponentCategory.EV_CHARGER
+        ]
+
+        if not ev_chargers:
+            logger.warning(
+                "Unable to find any EV Chargers in the component graph. "
+                "Subscribing to the resampling actor with a non-existing "
+                "component id, so that `0` values are sent from the formula."
+            )
+            # If there are no EV Chargers, we have to send 0 values as the same
+            # frequency as the other streams.  So we subscribe with a non-existing
+            # component id, just to get a `None` message at the resampling interval.
+            builder = self._get_builder("ev-current", ComponentMetricId.ACTIVE_POWER)
+            await builder.push_component_metric(
+                NON_EXISTING_COMPONENT_ID, nones_are_zeros=True
+            )
+            engine = builder.build()
+            return FormulaEngine3Phase(
+                "ev-current",
+                (engine.new_receiver(), engine.new_receiver(), engine.new_receiver()),
+            )
+
+        return FormulaEngine3Phase(
+            "ev-current",
+            (
+                (
+                    await self._gen_phase_formula(
+                        ev_chargers, ComponentMetricId.CURRENT_PHASE_1
+                    )
+                ).new_receiver(),
+                (
+                    await self._gen_phase_formula(
+                        ev_chargers, ComponentMetricId.CURRENT_PHASE_2
+                    )
+                ).new_receiver(),
+                (
+                    await self._gen_phase_formula(
+                        ev_chargers, ComponentMetricId.CURRENT_PHASE_3
+                    )
+                ).new_receiver(),
+            ),
+        )
+
+    async def _gen_phase_formula(
+        self,
+        ev_chargers: List[Component],
+        metric_id: ComponentMetricId,
+    ) -> FormulaEngine:
+        builder = self._get_builder("ev-current", metric_id)
+
+        # generate a formula that just adds values from all ev-chargers.
+        for idx, comp in enumerate(ev_chargers):
+            if idx > 0:
+                builder.push_oper("+")
+
+            await builder.push_component_metric(comp.component_id, nones_are_zeros=True)
+
+        return builder.build()

--- a/src/frequenz/sdk/timeseries/logical_meter/_formula_generators/_formula_generator.py
+++ b/src/frequenz/sdk/timeseries/logical_meter/_formula_generators/_formula_generator.py
@@ -5,12 +5,13 @@
 
 import sys
 from abc import ABC, abstractmethod
+from typing import Generic
 
 from frequenz.channels import Sender
 
 from ....actor import ChannelRegistry, ComponentMetricRequest
 from ....microgrid.component import ComponentMetricId
-from .._formula_engine import FormulaEngine
+from .._formula_engine import _GenericEngine
 from .._resampled_formula_builder import ResampledFormulaBuilder
 
 
@@ -25,7 +26,7 @@ class ComponentNotFound(FormulaGenerationError):
 NON_EXISTING_COMPONENT_ID = sys.maxsize
 
 
-class FormulaGenerator(ABC):
+class FormulaGenerator(ABC, Generic[_GenericEngine]):
     """A class for generating formulas from the component graph."""
 
     def __init__(
@@ -60,5 +61,5 @@ class FormulaGenerator(ABC):
         return builder
 
     @abstractmethod
-    async def generate(self) -> FormulaEngine:
+    async def generate(self) -> _GenericEngine:
         """Generate a formula engine, based on the component graph."""

--- a/src/frequenz/sdk/timeseries/logical_meter/_formula_generators/_grid_current_formula.py
+++ b/src/frequenz/sdk/timeseries/logical_meter/_formula_generators/_grid_current_formula.py
@@ -1,0 +1,97 @@
+# License: MIT
+# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+
+"""Formula generator from component graph for 3-phase Grid Current."""
+
+from typing import Set
+
+from .....sdk import microgrid
+from ....microgrid.component import Component, ComponentCategory, ComponentMetricId
+from .._formula_engine import FormulaEngine, FormulaEngine3Phase
+from ._formula_generator import ComponentNotFound, FormulaGenerator
+
+
+class GridCurrentFormula(FormulaGenerator):
+    """Create a formula engine from the component graph for calculating grid current."""
+
+    async def generate(self) -> FormulaEngine3Phase:
+        """Generate a formula for calculating grid current from the component graph.
+
+        Returns:
+            A formula engine that will calculate 3-phase grid current values.
+
+        Raises:
+            ComponentNotFound: when the component graph doesn't have a `GRID` component.
+        """
+        component_graph = microgrid.get().component_graph
+        grid_component = next(
+            (
+                comp
+                for comp in component_graph.components()
+                if comp.category == ComponentCategory.GRID
+            ),
+            None,
+        )
+
+        if grid_component is None:
+            raise ComponentNotFound(
+                "Unable to find a GRID component from the component graph."
+            )
+
+        grid_successors = component_graph.successors(grid_component.component_id)
+
+        return FormulaEngine3Phase(
+            "grid-current",
+            (
+                (
+                    await self._gen_phase_formula(
+                        grid_successors, ComponentMetricId.CURRENT_PHASE_1
+                    )
+                ).new_receiver(),
+                (
+                    await self._gen_phase_formula(
+                        grid_successors, ComponentMetricId.CURRENT_PHASE_2
+                    )
+                ).new_receiver(),
+                (
+                    await self._gen_phase_formula(
+                        grid_successors, ComponentMetricId.CURRENT_PHASE_3
+                    )
+                ).new_receiver(),
+            ),
+        )
+
+    async def _gen_phase_formula(
+        self,
+        grid_successors: Set[Component],
+        metric_id: ComponentMetricId,
+    ) -> FormulaEngine:
+        builder = self._get_builder("grid-current", metric_id)
+
+        # generate a formula that just adds values from all components that are
+        # directly connected to the grid.
+        for idx, comp in enumerate(grid_successors):
+            if idx > 0:
+                builder.push_oper("+")
+
+            # When inverters or ev chargers produce `None` samples, those
+            # inverters are excluded from the calculation by treating their
+            # `None` values as `0`s.
+            #
+            # This is not possible for Meters, so when they produce `None`
+            # values, those values get propagated as the output.
+            if comp.category in (
+                ComponentCategory.INVERTER,
+                ComponentCategory.EV_CHARGER,
+            ):
+                nones_are_zeros = True
+            elif comp.category == ComponentCategory.METER:
+                nones_are_zeros = False
+            else:
+                continue
+
+            await builder.push_component_metric(
+                comp.component_id, nones_are_zeros=nones_are_zeros
+            )
+
+        return builder.build()

--- a/tests/timeseries/test_formula_engine.py
+++ b/tests/timeseries/test_formula_engine.py
@@ -67,7 +67,10 @@ class TestFormulaEngine:
                 builder.push_oper(token.value)
         engine = builder.build()
 
-        assert repr(engine._steps) == postfix  # pylint: disable=protected-access
+        assert (
+            repr(engine._evaluator._steps)  # pylint: disable=protected-access
+            == postfix
+        )
 
         now = datetime.now()
         tests_passed = 0
@@ -81,7 +84,9 @@ class TestFormulaEngine:
                     ]
                 )
             )
-            next_val = await engine._apply()  # pylint: disable=protected-access
+            next_val = (
+                await engine._evaluator.apply()  # pylint: disable=protected-access
+            )
             assert (next_val).value == io_output
             tests_passed += 1
         await engine._stop()  # pylint: disable=protected-access
@@ -575,7 +580,9 @@ class TestFormulaAverager:
                     ]
                 )
             )
-            next_val = await engine._apply()  # pylint: disable=protected-access
+            next_val = (
+                await engine._evaluator.apply()  # pylint: disable=protected-access
+            )
             assert (next_val).value == io_output
             tests_passed += 1
         await engine._stop()  # pylint: disable=protected-access


### PR DESCRIPTION
This PR introduces some new types for streaming 3-phase data:
- `Sample3Phase` :: for holding a 3-phase measurement.
- `FormulaChannel3Phase/FormulaReceiver3Phase` :: composable channel/receiver types for streaming `Sample3Phase` objects.
- `FormulaEngine3Phase` :: for combining `Sample` objects from `FormulaEngine` into `Sample3Phase` objects.
- `HigherOrderFormulaBuilder3Phase` :: For composing `FormulaReceiver3Phase` and generating new `FormulaEngine3Phase` from them.

It also adds formula generators for 3-phase `grid_current` and `ev_charger_current`,  and exposes them through the `LogicalMeter`.