### PR TITLE
Change copyright year to 2023 in all files.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 Frequenz Energy-as-a-Service GmbH
+Copyright (c) 2023 Frequenz Energy-as-a-Service GmbH
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/benchmarks/data_ingestion/benchmark_microgrid_data.py
+++ b/benchmarks/data_ingestion/benchmark_microgrid_data.py
@@ -1,5 +1,5 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """Benchmark for microgrid data."""
 

--- a/benchmarks/power_distribution/power_distributor.py
+++ b/benchmarks/power_distribution/power_distributor.py
@@ -1,5 +1,5 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """Check how long it takes to distribute power."""
 

--- a/benchmarks/timeseries/resampling.py
+++ b/benchmarks/timeseries/resampling.py
@@ -1,5 +1,5 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """Benchmark resampling."""
 

--- a/docs/mkdocstrings_autoapi.py
+++ b/docs/mkdocstrings_autoapi.py
@@ -1,5 +1,5 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """Generate the code reference pages.
 

--- a/examples/__init__.py
+++ b/examples/__init__.py
@@ -1,4 +1,4 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """Examples for the sdk."""

--- a/examples/power_distribution.py
+++ b/examples/power_distribution.py
@@ -1,5 +1,5 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """Frequenz Python SDK usage examples.
 

--- a/examples/resampling.py
+++ b/examples/resampling.py
@@ -1,5 +1,5 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """Frequenz Python SDK resampling example."""
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,5 +1,5 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """Automation for code quality checks and unit tests for the Frequenz SDK.
 

--- a/src/frequenz/sdk/__init__.py
+++ b/src/frequenz/sdk/__init__.py
@@ -1,4 +1,4 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """Frequenz Python SDK."""

--- a/src/frequenz/sdk/_api_client/__init__.py
+++ b/src/frequenz/sdk/_api_client/__init__.py
@@ -1,5 +1,5 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """Common items to be shared across all API clients."""
 

--- a/src/frequenz/sdk/_api_client/api_client.py
+++ b/src/frequenz/sdk/_api_client/api_client.py
@@ -1,5 +1,5 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """An abstract API client."""
 

--- a/src/frequenz/sdk/_data_handling/__init__.py
+++ b/src/frequenz/sdk/_data_handling/__init__.py
@@ -1,5 +1,5 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """Tools for handling historical data."""
 

--- a/src/frequenz/sdk/_data_handling/formula.py
+++ b/src/frequenz/sdk/_data_handling/formula.py
@@ -1,5 +1,5 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """Helper class for creating custom algebraic formulas from strings or SymPy expressions."""
 

--- a/src/frequenz/sdk/_data_handling/gen_historic_data_features.py
+++ b/src/frequenz/sdk/_data_handling/gen_historic_data_features.py
@@ -1,5 +1,5 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """Auxiliary functions for generating features when loading historic data."""
 

--- a/src/frequenz/sdk/_data_handling/handle_historic_data.py
+++ b/src/frequenz/sdk/_data_handling/handle_historic_data.py
@@ -1,5 +1,5 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """Module for handling loaded historic data from different components.
 

--- a/src/frequenz/sdk/_data_handling/power.py
+++ b/src/frequenz/sdk/_data_handling/power.py
@@ -1,5 +1,5 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """Provides support for processing power measurements from different microgrid components."""
 

--- a/src/frequenz/sdk/_data_handling/time_series.py
+++ b/src/frequenz/sdk/_data_handling/time_series.py
@@ -1,5 +1,5 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """Helper classes for tracking values from time-series data streams."""
 from __future__ import annotations

--- a/src/frequenz/sdk/_data_ingestion/__init__.py
+++ b/src/frequenz/sdk/_data_ingestion/__init__.py
@@ -1,5 +1,5 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """Tools for data ingestion."""
 

--- a/src/frequenz/sdk/_data_ingestion/component_info.py
+++ b/src/frequenz/sdk/_data_ingestion/component_info.py
@@ -1,5 +1,5 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """Definition of component infos."""
 

--- a/src/frequenz/sdk/_data_ingestion/constants.py
+++ b/src/frequenz/sdk/_data_ingestion/constants.py
@@ -1,5 +1,5 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """Functions for generating DataColletor with necessary fields from ComponentInfo."""
 # PROTOBUF METRICS:

--- a/src/frequenz/sdk/_data_ingestion/formula_calculator.py
+++ b/src/frequenz/sdk/_data_ingestion/formula_calculator.py
@@ -1,5 +1,5 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """Class for evaluating formulas."""
 

--- a/src/frequenz/sdk/_data_ingestion/gen_component_receivers.py
+++ b/src/frequenz/sdk/_data_ingestion/gen_component_receivers.py
@@ -1,5 +1,5 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """Functions for generating DataColletor with necessary fields from ComponentInfo."""
 

--- a/src/frequenz/sdk/_data_ingestion/load_historic_data.py
+++ b/src/frequenz/sdk/_data_ingestion/load_historic_data.py
@@ -1,5 +1,5 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """
 LoadHistoricData is a tool for loading historic parquet files.

--- a/src/frequenz/sdk/_data_ingestion/microgrid_data.py
+++ b/src/frequenz/sdk/_data_ingestion/microgrid_data.py
@@ -1,5 +1,5 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """
 Actor for combining stream data from different components using TimeSeriesFormula.

--- a/src/frequenz/sdk/_internal/__init__.py
+++ b/src/frequenz/sdk/_internal/__init__.py
@@ -1,5 +1,5 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """Utility types and functions for internal use."""
 

--- a/src/frequenz/sdk/_internal/asyncio.py
+++ b/src/frequenz/sdk/_internal/asyncio.py
@@ -1,5 +1,5 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """General purpose async tools."""
 

--- a/src/frequenz/sdk/_internal/singleton_meta.py
+++ b/src/frequenz/sdk/_internal/singleton_meta.py
@@ -1,5 +1,5 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """Definition of Singleton metaclass."""
 

--- a/src/frequenz/sdk/actor/__init__.py
+++ b/src/frequenz/sdk/actor/__init__.py
@@ -1,5 +1,5 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """A base class for creating simple composable actors."""
 

--- a/src/frequenz/sdk/actor/_channel_registry.py
+++ b/src/frequenz/sdk/actor/_channel_registry.py
@@ -1,5 +1,5 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """A class that would dynamically create, own and provide access to channels."""
 

--- a/src/frequenz/sdk/actor/_config_managing.py
+++ b/src/frequenz/sdk/actor/_config_managing.py
@@ -1,5 +1,5 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """Read and update config variables."""
 

--- a/src/frequenz/sdk/actor/_data_sourcing/__init__.py
+++ b/src/frequenz/sdk/actor/_data_sourcing/__init__.py
@@ -1,5 +1,5 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """The DataSourcingActor."""
 

--- a/src/frequenz/sdk/actor/_data_sourcing/data_sourcing.py
+++ b/src/frequenz/sdk/actor/_data_sourcing/data_sourcing.py
@@ -1,5 +1,5 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """The DataSourcing Actor."""
 

--- a/src/frequenz/sdk/actor/_data_sourcing/microgrid_api_source.py
+++ b/src/frequenz/sdk/actor/_data_sourcing/microgrid_api_source.py
@@ -1,5 +1,5 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """The Microgrid API data source for the DataSourcingActor."""
 

--- a/src/frequenz/sdk/actor/_decorator.py
+++ b/src/frequenz/sdk/actor/_decorator.py
@@ -1,5 +1,5 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """A decorator for creating simple composable actors.
 

--- a/src/frequenz/sdk/actor/_resampling.py
+++ b/src/frequenz/sdk/actor/_resampling.py
@@ -1,5 +1,5 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """An actor to resample microgrid component metrics."""
 

--- a/src/frequenz/sdk/actor/power_distributing/__init__.py
+++ b/src/frequenz/sdk/actor/power_distributing/__init__.py
@@ -1,5 +1,5 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """This module provides feature to set power between many batteries.
 

--- a/src/frequenz/sdk/actor/power_distributing/_battery_pool_status.py
+++ b/src/frequenz/sdk/actor/power_distributing/_battery_pool_status.py
@@ -1,5 +1,5 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 """Class that stores pool of batteries and manage them."""
 
 from __future__ import annotations

--- a/src/frequenz/sdk/actor/power_distributing/power_distributing.py
+++ b/src/frequenz/sdk/actor/power_distributing/power_distributing.py
@@ -1,5 +1,5 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """Actor to distribute power between batteries.
 

--- a/src/frequenz/sdk/actor/power_distributing/request.py
+++ b/src/frequenz/sdk/actor/power_distributing/request.py
@@ -1,5 +1,5 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 """Definition of the user request."""
 
 from dataclasses import dataclass

--- a/src/frequenz/sdk/actor/power_distributing/result.py
+++ b/src/frequenz/sdk/actor/power_distributing/result.py
@@ -1,5 +1,5 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """Results from PowerDistributingActor."""
 

--- a/src/frequenz/sdk/config/__init__.py
+++ b/src/frequenz/sdk/config/__init__.py
@@ -1,5 +1,5 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """Config interface."""
 

--- a/src/frequenz/sdk/config/_config.py
+++ b/src/frequenz/sdk/config/_config.py
@@ -1,5 +1,5 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """Read and update config variables."""
 

--- a/src/frequenz/sdk/microgrid/__init__.py
+++ b/src/frequenz/sdk/microgrid/__init__.py
@@ -1,5 +1,5 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """Microgrid monitoring and control system.
 

--- a/src/frequenz/sdk/microgrid/_battery/__init__.py
+++ b/src/frequenz/sdk/microgrid/_battery/__init__.py
@@ -1,5 +1,5 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """Microgrid battery utils module.
 

--- a/src/frequenz/sdk/microgrid/_battery/_status.py
+++ b/src/frequenz/sdk/microgrid/_battery/_status.py
@@ -1,5 +1,5 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 """Class to return battery status."""
 
 from __future__ import annotations

--- a/src/frequenz/sdk/microgrid/_graph.py
+++ b/src/frequenz/sdk/microgrid/_graph.py
@@ -1,5 +1,5 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """Defines a graph representation of how microgrid components are connected.
 

--- a/src/frequenz/sdk/microgrid/_microgrid.py
+++ b/src/frequenz/sdk/microgrid/_microgrid.py
@@ -1,5 +1,5 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """Microgrid singleton abstraction.
 

--- a/src/frequenz/sdk/microgrid/client/__init__.py
+++ b/src/frequenz/sdk/microgrid/client/__init__.py
@@ -1,5 +1,5 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """Microgrid API client.
 

--- a/src/frequenz/sdk/microgrid/client/_client.py
+++ b/src/frequenz/sdk/microgrid/client/_client.py
@@ -1,5 +1,5 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """Client for requests to the Microgrid API."""
 

--- a/src/frequenz/sdk/microgrid/client/_connection.py
+++ b/src/frequenz/sdk/microgrid/client/_connection.py
@@ -1,5 +1,5 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """Defines the connections between microgrid components."""
 

--- a/src/frequenz/sdk/microgrid/client/_retry.py
+++ b/src/frequenz/sdk/microgrid/client/_retry.py
@@ -1,5 +1,5 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """Implementations for retry strategies."""
 

--- a/src/frequenz/sdk/microgrid/component/__init__.py
+++ b/src/frequenz/sdk/microgrid/component/__init__.py
@@ -1,5 +1,5 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """Microgrid component abstractions.
 

--- a/src/frequenz/sdk/microgrid/component/_component.py
+++ b/src/frequenz/sdk/microgrid/component/_component.py
@@ -1,5 +1,5 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """Defines the components that can be used in a microgrid."""
 

--- a/src/frequenz/sdk/microgrid/component/_component_data.py
+++ b/src/frequenz/sdk/microgrid/component/_component_data.py
@@ -1,5 +1,5 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """Component data types for data coming from a microgrid."""
 from __future__ import annotations

--- a/src/frequenz/sdk/microgrid/component/_component_states.py
+++ b/src/frequenz/sdk/microgrid/component/_component_states.py
@@ -1,5 +1,5 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """Defines states of components that can be used in a microgrid."""
 from __future__ import annotations

--- a/src/frequenz/sdk/power/__init__.py
+++ b/src/frequenz/sdk/power/__init__.py
@@ -1,5 +1,5 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """Utilities to manage power in a microgrid."""
 

--- a/src/frequenz/sdk/power/_distribution_algorithm.py
+++ b/src/frequenz/sdk/power/_distribution_algorithm.py
@@ -1,5 +1,5 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """Power distribution algorithm to distribute power between batteries."""
 

--- a/src/frequenz/sdk/timeseries/__init__.py
+++ b/src/frequenz/sdk/timeseries/__init__.py
@@ -1,5 +1,5 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """
 Handling of timeseries streams.

--- a/src/frequenz/sdk/timeseries/_base_types.py
+++ b/src/frequenz/sdk/timeseries/_base_types.py
@@ -1,5 +1,5 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """Timeseries basic types."""
 

--- a/src/frequenz/sdk/timeseries/_resampling.py
+++ b/src/frequenz/sdk/timeseries/_resampling.py
@@ -1,5 +1,5 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """Timeseries resampler."""
 

--- a/src/frequenz/sdk/timeseries/logical_meter/__init__.py
+++ b/src/frequenz/sdk/timeseries/logical_meter/__init__.py
@@ -1,5 +1,5 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """A logical meter for calculating high level metrics for a microgrid."""
 

--- a/src/frequenz/sdk/timeseries/logical_meter/_exceptions.py
+++ b/src/frequenz/sdk/timeseries/logical_meter/_exceptions.py
@@ -1,5 +1,5 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """Formula Engine Exceptions."""
 

--- a/src/frequenz/sdk/timeseries/logical_meter/_formula_engine.py
+++ b/src/frequenz/sdk/timeseries/logical_meter/_formula_engine.py
@@ -1,5 +1,5 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """A formula engine that can apply formulas on streaming data."""
 

--- a/src/frequenz/sdk/timeseries/logical_meter/_formula_generators/__init__.py
+++ b/src/frequenz/sdk/timeseries/logical_meter/_formula_generators/__init__.py
@@ -1,5 +1,5 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """Generators for formulas from component graphs."""
 

--- a/src/frequenz/sdk/timeseries/logical_meter/_formula_generators/_battery_power_formula.py
+++ b/src/frequenz/sdk/timeseries/logical_meter/_formula_generators/_battery_power_formula.py
@@ -1,5 +1,5 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """Formula generator from component graph for Grid Power."""
 

--- a/src/frequenz/sdk/timeseries/logical_meter/_formula_generators/_battery_soc_formula.py
+++ b/src/frequenz/sdk/timeseries/logical_meter/_formula_generators/_battery_soc_formula.py
@@ -1,5 +1,5 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """Formula generator from component graph for Grid Power."""
 

--- a/src/frequenz/sdk/timeseries/logical_meter/_formula_generators/_formula_generator.py
+++ b/src/frequenz/sdk/timeseries/logical_meter/_formula_generators/_formula_generator.py
@@ -1,5 +1,5 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """Base class for formula generators that use the component graphs."""
 

--- a/src/frequenz/sdk/timeseries/logical_meter/_formula_generators/_grid_power_formula.py
+++ b/src/frequenz/sdk/timeseries/logical_meter/_formula_generators/_grid_power_formula.py
@@ -1,5 +1,5 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """Formula generator from component graph for Grid Power."""
 

--- a/src/frequenz/sdk/timeseries/logical_meter/_formula_generators/_pv_power_formula.py
+++ b/src/frequenz/sdk/timeseries/logical_meter/_formula_generators/_pv_power_formula.py
@@ -1,5 +1,5 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """Formula generator for PV Power, from the component graph."""
 

--- a/src/frequenz/sdk/timeseries/logical_meter/_formula_steps.py
+++ b/src/frequenz/sdk/timeseries/logical_meter/_formula_steps.py
@@ -1,5 +1,5 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """Steps for building formula engines with."""
 

--- a/src/frequenz/sdk/timeseries/logical_meter/_logical_meter.py
+++ b/src/frequenz/sdk/timeseries/logical_meter/_logical_meter.py
@@ -1,5 +1,5 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """A logical meter for calculating high level metrics for a microgrid."""
 

--- a/src/frequenz/sdk/timeseries/logical_meter/_resampled_formula_builder.py
+++ b/src/frequenz/sdk/timeseries/logical_meter/_resampled_formula_builder.py
@@ -1,5 +1,5 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """A builder for creating formula engines that operate on resampled component metrics."""
 

--- a/src/frequenz/sdk/timeseries/logical_meter/_tokenizer.py
+++ b/src/frequenz/sdk/timeseries/logical_meter/_tokenizer.py
@@ -1,5 +1,5 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """A tokenizer for data pipeline formulas."""
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,4 +1,4 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """Frequenz Python SDK Tests."""

--- a/tests/actor/__init__.py
+++ b/tests/actor/__init__.py
@@ -1,4 +1,4 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """Tests for the actor package."""

--- a/tests/actor/test_battery_pool.py
+++ b/tests/actor/test_battery_pool.py
@@ -1,5 +1,5 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 """Tests for BatteryPoolStatus module."""
 
 from dataclasses import dataclass

--- a/tests/actor/test_channel_registry.py
+++ b/tests/actor/test_channel_registry.py
@@ -1,5 +1,5 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """Tests for the ChannelRegistry."""
 

--- a/tests/actor/test_config_manager.py
+++ b/tests/actor/test_config_manager.py
@@ -1,5 +1,5 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """Test for ConfigManager"""
 import pathlib

--- a/tests/actor/test_data_sourcing.py
+++ b/tests/actor/test_data_sourcing.py
@@ -1,5 +1,5 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """
 Tests for the DataSourcingActor.

--- a/tests/actor/test_decorator.py
+++ b/tests/actor/test_decorator.py
@@ -1,5 +1,5 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """Simple test for the BaseActor."""
 from frequenz.channels import Broadcast, Receiver, Sender

--- a/tests/actor/test_resampling.py
+++ b/tests/actor/test_resampling.py
@@ -1,5 +1,5 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """Frequenz Python SDK resampling example."""
 import dataclasses

--- a/tests/api_client/__init__.py
+++ b/tests/api_client/__init__.py
@@ -1,4 +1,4 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """Tests for the api client."""

--- a/tests/api_client/test_api_client.py
+++ b/tests/api_client/test_api_client.py
@@ -1,5 +1,5 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """Tests for the `ApiClient` class."""
 

--- a/tests/config/__init__.py
+++ b/tests/config/__init__.py
@@ -1,4 +1,4 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """Tests for the config manager."""

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -1,5 +1,5 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """Test for Config"""
 import pathlib

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,5 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """Setup for all the tests."""
 import pytest

--- a/tests/data_ingestion/__init__.py
+++ b/tests/data_ingestion/__init__.py
@@ -1,4 +1,4 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """Tests for the data ingestion module."""

--- a/tests/data_ingestion/base_microgrid_data_test.py
+++ b/tests/data_ingestion/base_microgrid_data_test.py
@@ -1,5 +1,5 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """Base test class for the `MicrogridData`."""
 

--- a/tests/data_ingestion/test_formulas.py
+++ b/tests/data_ingestion/test_formulas.py
@@ -1,5 +1,5 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """
 Test for the `TimeSeriesFormula`

--- a/tests/data_ingestion/test_gen_component_receivers.py
+++ b/tests/data_ingestion/test_gen_component_receivers.py
@@ -1,5 +1,5 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """
 Tests for the `MicrogridData` actor

--- a/tests/data_ingestion/test_microgrid_data.py
+++ b/tests/data_ingestion/test_microgrid_data.py
@@ -1,5 +1,5 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """
 Tests for the `MicrogridData` actor

--- a/tests/data_ingestion/test_microgrid_data_config_formula_updates.py
+++ b/tests/data_ingestion/test_microgrid_data_config_formula_updates.py
@@ -1,10 +1,10 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """
 Test for the `MicrogridData` when config manager fires an update about Config change
 
-Copyright © 2022 Frequenz Energy-as-a-Service GmbH.  All rights reserved.
+Copyright © 2023 Frequenz Energy-as-a-Service GmbH.  All rights reserved.
 """
 import asyncio
 from tempfile import NamedTemporaryFile

--- a/tests/data_ingestion/test_microgrid_data_config_updates.py
+++ b/tests/data_ingestion/test_microgrid_data_config_updates.py
@@ -1,10 +1,10 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """
 Test for the `MicrogridData` when config manager fires an update about Config change
 
-Copyright © 2022 Frequenz Energy-as-a-Service GmbH.  All rights reserved.
+Copyright © 2023 Frequenz Energy-as-a-Service GmbH.  All rights reserved.
 """
 import asyncio
 from tempfile import NamedTemporaryFile

--- a/tests/data_ingestion/test_microgrid_data_grid_load.py
+++ b/tests/data_ingestion/test_microgrid_data_grid_load.py
@@ -1,5 +1,5 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """
 Test for the `MicrogridData` when meter is on the grid's side

--- a/tests/data_ingestion/test_microgrid_data_overlapping_formulas.py
+++ b/tests/data_ingestion/test_microgrid_data_overlapping_formulas.py
@@ -1,5 +1,5 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """
 Test for the `MicrogridData` when two formulas are overlapping

--- a/tests/data_ingestion/test_microgrid_data_with_custom_formula.py
+++ b/tests/data_ingestion/test_microgrid_data_with_custom_formula.py
@@ -1,5 +1,5 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """
 Test for the `MicrogridData` when meter is on the grid's side

--- a/tests/data_ingestion/test_microgrid_data_with_division_by_zero.py
+++ b/tests/data_ingestion/test_microgrid_data_with_division_by_zero.py
@@ -1,5 +1,5 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """
 Test for the `MicrogridData` when one formula crashes

--- a/tests/data_ingestion/test_microgrid_data_with_ev_charger.py
+++ b/tests/data_ingestion/test_microgrid_data_with_ev_charger.py
@@ -1,5 +1,5 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """
 Test for the `MicrogridData` when meter is on the grid's side

--- a/tests/data_ingestion/test_microgrid_data_with_missing_symbols.py
+++ b/tests/data_ingestion/test_microgrid_data_with_missing_symbols.py
@@ -1,5 +1,5 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """
 Test for the `MicrogridData` when meter is on the grid's side

--- a/tests/microgrid/__init__.py
+++ b/tests/microgrid/__init__.py
@@ -1,4 +1,4 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """Tests for the microgrid package."""

--- a/tests/microgrid/mock_api.py
+++ b/tests/microgrid/mock_api.py
@@ -1,5 +1,5 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """Mock implementation of the microgrid gRPC API.
 

--- a/tests/microgrid/test_client.py
+++ b/tests/microgrid/test_client.py
@@ -1,5 +1,5 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """
 Tests for the microgrid client thin wrapper.

--- a/tests/microgrid/test_component.py
+++ b/tests/microgrid/test_component.py
@@ -1,5 +1,5 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """
 Tests for the microgrid component wrapper.

--- a/tests/microgrid/test_component_data.py
+++ b/tests/microgrid/test_component_data.py
@@ -1,5 +1,5 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """
 Tests for the microgrid component data.

--- a/tests/microgrid/test_connection.py
+++ b/tests/microgrid/test_connection.py
@@ -1,5 +1,5 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """
 Tests for the microgrid Connection type.

--- a/tests/microgrid/test_graph.py
+++ b/tests/microgrid/test_graph.py
@@ -1,5 +1,5 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """
 Tests for the microgrid component graph.

--- a/tests/microgrid/test_microgrid_api.py
+++ b/tests/microgrid/test_microgrid_api.py
@@ -1,5 +1,5 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """Tests of MicrogridApi"""
 import asyncio

--- a/tests/microgrid/test_mock_api.py
+++ b/tests/microgrid/test_mock_api.py
@@ -1,5 +1,5 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """
 Tests for the microgrid mock api.

--- a/tests/microgrid/test_retry.py
+++ b/tests/microgrid/test_retry.py
@@ -1,5 +1,5 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """Tests for retry strategies."""
 

--- a/tests/microgrid/test_timeout.py
+++ b/tests/microgrid/test_timeout.py
@@ -1,5 +1,5 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """Benchmark for microgrid data."""
 import time

--- a/tests/power/__init__.py
+++ b/tests/power/__init__.py
@@ -1,4 +1,4 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """Test power distribution module."""

--- a/tests/power/test_distribution_algorithm.py
+++ b/tests/power/test_distribution_algorithm.py
@@ -1,5 +1,5 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 # pylint: disable=too-many-lines
 """Tests for distribution algorithm."""

--- a/tests/test_data_handling/__init__.py
+++ b/tests/test_data_handling/__init__.py
@@ -1,4 +1,4 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """Tests for the data_handling package."""

--- a/tests/test_data_handling/test_formula.py
+++ b/tests/test_data_handling/test_formula.py
@@ -1,5 +1,5 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """Tests for the frequenz.sdk._data_handling.formula module."""
 from datetime import datetime, timedelta, timezone

--- a/tests/test_data_handling/test_gen_historic_data_features.py
+++ b/tests/test_data_handling/test_gen_historic_data_features.py
@@ -1,5 +1,5 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """Tests for the frequenz.sdk._data_handling.gen_historic_data_features module."""
 

--- a/tests/test_data_handling/test_handle_historic_data.py
+++ b/tests/test_data_handling/test_handle_historic_data.py
@@ -1,5 +1,5 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """Tests for the handle_historic_data package."""
 

--- a/tests/test_data_handling/test_power.py
+++ b/tests/test_data_handling/test_power.py
@@ -1,5 +1,5 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """Tests for the frequenz.sdk._data_handling.power module."""
 

--- a/tests/test_data_handling/test_time_series.py
+++ b/tests/test_data_handling/test_time_series.py
@@ -1,5 +1,5 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """Tests for the frequenz.sdk._data_handling.time_series module."""
 

--- a/tests/test_microgrid_data_no_unnecessary_computations.py
+++ b/tests/test_microgrid_data_no_unnecessary_computations.py
@@ -1,5 +1,5 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """
 Test for the `MicrogridData` when meter is on the grid's side

--- a/tests/test_sdk.py
+++ b/tests/test_sdk.py
@@ -1,5 +1,5 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """
 Top level tests for the `frequenz.sdk` pacakge

--- a/tests/timeseries/__init__.py
+++ b/tests/timeseries/__init__.py
@@ -1,4 +1,4 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """Timeseries tests."""

--- a/tests/timeseries/mock_microgrid.py
+++ b/tests/timeseries/mock_microgrid.py
@@ -1,5 +1,5 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """A configurable mock microgrid for testing logical meter formulas."""
 

--- a/tests/timeseries/test_formula_engine.py
+++ b/tests/timeseries/test_formula_engine.py
@@ -1,5 +1,5 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """Tests for the FormulaEngine and the Tokenizer."""
 

--- a/tests/timeseries/test_logical_meter.py
+++ b/tests/timeseries/test_logical_meter.py
@@ -1,5 +1,5 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """Tests for the logical meter."""
 

--- a/tests/timeseries/test_resampling.py
+++ b/tests/timeseries/test_resampling.py
@@ -1,5 +1,5 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """
 Tests for the `TimeSeriesResampler`

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -1,5 +1,5 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """Utilities for testing purposes."""
 

--- a/tests/utils/_a_sequence.py
+++ b/tests/utils/_a_sequence.py
@@ -1,5 +1,5 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """Helper class to compare two sequences without caring about the underlying type."""
 

--- a/tests/utils/data_generation.py
+++ b/tests/utils/data_generation.py
@@ -1,5 +1,5 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """Utility functions to generate data for testing purposes."""
 

--- a/tests/utils/factories.py
+++ b/tests/utils/factories.py
@@ -1,5 +1,5 @@
 # License: MIT
-# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """Utility factory functions to mock data returned by components."""
 


### PR DESCRIPTION
A simple search & replace to change all copyright years to 2023.
