### PR TITLE
Use MockMicrogridClient instead of a MockMicrogridServer in LogicalMeter tests

### DIFF
--- a/tests/actor/test_power_distributing.py
+++ b/tests/actor/test_power_distributing.py
@@ -84,7 +84,7 @@ class TestPowerDistributingActor:
         """Test if gets all necessary data."""
         components, connections = self.component_graph()
         mock_microgrid = MockMicrogridClient(components, connections)
-        await mock_microgrid.initialize(mocker)
+        mock_microgrid.initialize(mocker)
 
         channel = Bidirectional[Request, Result]("user1", "power_distributor")
         distributor = PowerDistributingActor({"user1": channel.service_handle})
@@ -101,7 +101,7 @@ class TestPowerDistributingActor:
         """
         components, connections = self.component_graph()
         microgrid = MockMicrogridClient(components, connections)
-        await microgrid.initialize(mocker)
+        microgrid.initialize(mocker)
 
         graph = microgrid.component_graph
         for battery in graph.components(component_category={ComponentCategory.BATTERY}):

--- a/tests/utils/mock_microgrid.py
+++ b/tests/utils/mock_microgrid.py
@@ -57,7 +57,7 @@ class MockMicrogridClient:
             id: channel.new_sender() for id, channel in inv_channels.items()
         }
 
-    async def initialize(self, mocker: MockerFixture) -> None:
+    def initialize(self, mocker: MockerFixture) -> None:
         """Mock `microgrid.get` call to return this mock_microgrid.
 
         Args:

--- a/tests/utils/mock_microgrid.py
+++ b/tests/utils/mock_microgrid.py
@@ -3,7 +3,7 @@
 
 """Mock microgrid definition."""
 from functools import partial
-from typing import Any, Dict, Set, Union
+from typing import Any, Dict, Set
 from unittest.mock import AsyncMock, MagicMock
 
 from frequenz.channels import Broadcast, Receiver
@@ -17,6 +17,7 @@ from frequenz.sdk.microgrid.component import (
     BatteryData,
     Component,
     ComponentCategory,
+    ComponentData,
     InverterData,
 )
 
@@ -89,7 +90,7 @@ class MockMicrogridClient:
         """
         return self._component_graph
 
-    async def send(self, data: Union[BatteryData, InverterData]) -> bool:
+    async def send(self, data: ComponentData) -> bool:
         """Send component data using channel.
 
         This simulates component sending data. Right now only battery and inverter

--- a/tests/utils/mock_microgrid.py
+++ b/tests/utils/mock_microgrid.py
@@ -42,13 +42,15 @@ class MockMicrogridClient:
         """
         self._component_graph = _MicrogridComponentGraph(components, connections)
 
+        self._components = components
+
         bat_channels = self._create_battery_channels()
         inv_channels = self._create_inverter_channels()
         meter_channels = self._create_meter_channels()
         ev_charger_channels = self._create_ev_charger_channels()
 
         mock_api = self._create_mock_api(
-            components, bat_channels, inv_channels, meter_channels, ev_charger_channels
+            bat_channels, inv_channels, meter_channels, ev_charger_channels
         )
         kwargs: Dict[str, Any] = {
             "api_client": mock_api,
@@ -199,7 +201,6 @@ class MockMicrogridClient:
 
     def _create_mock_api(
         self,
-        components: Set[Component],
         bat_channels: Dict[int, Broadcast[BatteryData]],
         inv_channels: Dict[int, Broadcast[InverterData]],
         meter_channels: Dict[int, Broadcast[MeterData]],
@@ -218,7 +219,7 @@ class MockMicrogridClient:
             Magic mock instance of MicrogridApiClient.
         """
         api = MagicMock()
-        api.components = AsyncMock(return_value=components)
+        api.components = AsyncMock(return_value=self._components)
         # NOTE that has to be partial, because battery_data has id argument and takes
         # channel based on the argument.
         api.battery_data = AsyncMock(


### PR DESCRIPTION
Closes #177 