### PR TITLE
Add an `EVChargerPool` implementation

### DIFF
--- a/src/frequenz/sdk/microgrid/component/__init__.py
+++ b/src/frequenz/sdk/microgrid/component/__init__.py
@@ -14,7 +14,7 @@ from ._component_data import (
     InverterData,
     MeterData,
 )
-from ._component_states import EVChargerCableState
+from ._component_states import EVChargerCableState, EVChargerComponentState
 
 __all__ = [
     "BatteryData",
@@ -23,6 +23,7 @@ __all__ = [
     "ComponentCategory",
     "ComponentMetricId",
     "EVChargerCableState",
+    "EVChargerComponentState",
     "EVChargerData",
     "InverterData",
     "InverterType",

--- a/src/frequenz/sdk/microgrid/component/_component_data.py
+++ b/src/frequenz/sdk/microgrid/component/_component_data.py
@@ -14,7 +14,7 @@ import frequenz.api.microgrid.inverter_pb2 as inverter_pb
 import frequenz.api.microgrid.microgrid_pb2 as microgrid_pb
 import pytz
 
-from ._component_states import EVChargerCableState
+from ._component_states import EVChargerCableState, EVChargerComponentState
 
 
 @dataclass(frozen=True)
@@ -257,6 +257,9 @@ class EVChargerData(ComponentData):
     cable_state: EVChargerCableState
     """The state of the ev charger's cable."""
 
+    component_state: EVChargerComponentState
+    """The state of the ev charger."""
+
     @classmethod
     def from_proto(cls, raw: microgrid_pb.ComponentData) -> EVChargerData:
         """Create EVChargerData from a protobuf message.
@@ -282,6 +285,9 @@ class EVChargerData(ComponentData):
                 raw.ev_charger.data.ac.phase_3.voltage.value,
             ),
             cable_state=EVChargerCableState.from_pb(raw.ev_charger.state.cable_state),
+            component_state=EVChargerComponentState.from_pb(
+                raw.ev_charger.state.component_state
+            ),
         )
         ev_charger_data._set_raw(raw=raw)
         return ev_charger_data

--- a/src/frequenz/sdk/microgrid/component/_component_states.py
+++ b/src/frequenz/sdk/microgrid/component/_component_states.py
@@ -39,3 +39,36 @@ class EVChargerCableState(Enum):
             return cls.UNSPECIFIED
 
         return EVChargerCableState(evc_state)
+
+
+class EVChargerComponentState(Enum):
+    """Component State of an EV Charger."""
+
+    UNSPECIFIED = ev_charger_pb.ComponentState.COMPONENT_STATE_UNSPECIFIED
+    STARTING = ev_charger_pb.ComponentState.COMPONENT_STATE_STARTING
+    NOT_READY = ev_charger_pb.ComponentState.COMPONENT_STATE_NOT_READY
+    READY = ev_charger_pb.ComponentState.COMPONENT_STATE_READY
+    CHARGING = ev_charger_pb.ComponentState.COMPONENT_STATE_CHARGING
+    DISCHARGING = ev_charger_pb.ComponentState.COMPONENT_STATE_DISCHARGING
+    ERROR = ev_charger_pb.ComponentState.COMPONENT_STATE_ERROR
+    AUTHORIZATION_REJECTED = (
+        ev_charger_pb.ComponentState.COMPONENT_STATE_AUTHORIZATION_REJECTED
+    )
+    INTERRUPTED = ev_charger_pb.ComponentState.COMPONENT_STATE_INTERRUPTED
+
+    @classmethod
+    def from_pb(
+        cls, evc_state: ev_charger_pb.ComponentState.ValueType
+    ) -> EVChargerComponentState:
+        """Convert a protobuf ComponentState value to EVChargerComponentState enum.
+
+        Args:
+            evc_state: protobuf component state to convert.
+
+        Returns:
+            Enum value corresponding to the protobuf message.
+        """
+        if not any(t.value == evc_state for t in EVChargerComponentState):
+            return cls.UNSPECIFIED
+
+        return EVChargerComponentState(evc_state)

--- a/src/frequenz/sdk/timeseries/ev_charger_pool/__init__.py
+++ b/src/frequenz/sdk/timeseries/ev_charger_pool/__init__.py
@@ -1,0 +1,12 @@
+# License: MIT
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
+
+"""Interactions with EV Chargers."""
+
+from ._ev_charger_pool import EVChargerPool, EVChargerPoolStates, EVChargerState
+
+__all__ = [
+    "EVChargerPool",
+    "EVChargerPoolStates",
+    "EVChargerState",
+]

--- a/src/frequenz/sdk/timeseries/ev_charger_pool/_ev_charger_pool.py
+++ b/src/frequenz/sdk/timeseries/ev_charger_pool/_ev_charger_pool.py
@@ -1,0 +1,202 @@
+# License: MIT
+# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+
+"""Interactions with pools of ev chargers."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Iterator
+from dataclasses import dataclass
+from enum import Enum
+from typing import Optional
+
+from frequenz.channels import Broadcast, Receiver
+from frequenz.channels.util import Merge
+
+from ... import microgrid
+from ..._internal.asyncio import cancel_and_await
+from ...microgrid.component import (
+    ComponentCategory,
+    EVChargerCableState,
+    EVChargerComponentState,
+    EVChargerData,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class EVChargerState(Enum):
+    """State of individual ev charger."""
+
+    UNSPECIFIED = "UNSPECIFIED"
+    IDLE = "IDLE"
+    EV_PLUGGED = "EV_PLUGGED"
+    EV_LOCKED = "EV_LOCKED"
+    ERROR = "ERROR"
+
+    @classmethod
+    def from_ev_charger_data(cls, data: EVChargerData) -> EVChargerState:
+        """Create an `EVChargerState` instance from component data.
+
+        Args:
+            data: ev charger data coming from microgrid.
+
+        Returns:
+            An `EVChargerState` instance.
+        """
+        if data.component_state in (
+            EVChargerComponentState.AUTHORIZATION_REJECTED,
+            EVChargerComponentState.ERROR,
+        ):
+            return EVChargerState.ERROR
+        if data.cable_state == EVChargerCableState.EV_LOCKED:
+            return EVChargerState.EV_LOCKED
+        if data.cable_state == EVChargerCableState.EV_PLUGGED:
+            return EVChargerState.EV_PLUGGED
+        return EVChargerState.IDLE
+
+
+@dataclass(frozen=True)
+class EVChargerPoolStates:
+    """States of all ev chargers in the pool."""
+
+    _states: dict[int, EVChargerState]
+    _changed_component: Optional[int] = None
+
+    def __iter__(self) -> Iterator[tuple[int, EVChargerState]]:
+        """Iterate over states of all ev chargers.
+
+        Returns:
+            An iterator over all ev charger states.
+        """
+        return iter(self._states.items())
+
+    def latest_change(self) -> Optional[tuple[int, EVChargerState]]:
+        """Return the most recent ev charger state change.
+
+        Returns:
+            A tuple with the component ID of an ev charger that just had a state
+                change, and its new state.
+        """
+        if self._changed_component is None:
+            return None
+        return (
+            self._changed_component,
+            self._states.setdefault(
+                self._changed_component, EVChargerState.UNSPECIFIED
+            ),
+        )
+
+
+class _StateTracker:
+    """A class for keeping track of the states of all ev chargers in a pool."""
+
+    def __init__(self, comp_states: dict[int, EVChargerState]) -> None:
+        """Create a `_StateTracker` instance.
+
+        Args:
+            comp_states: initial states of all ev chargers in the pool.
+        """
+        self._states = comp_states
+
+    def get(self) -> EVChargerPoolStates:
+        """Get a representation of the current states of all ev chargers.
+
+        Returns:
+            An `EVChargerPoolStates` instance.
+        """
+        return EVChargerPoolStates(self._states)
+
+    def update(
+        self,
+        data: EVChargerData,
+    ) -> Optional[EVChargerPoolStates]:
+        """Update the state of an ev charger, from a new data point.
+
+        Args:
+            data: component data from the microgrid, for an ev charger in the pool.
+
+        Returns:
+            A new `EVChargerPoolStates` instance representing all the ev chargers in
+                the pool, in case there has been a state change for any of the ev
+                chargers, or `None` otherwise.
+        """
+        evc_id = data.component_id
+        new_state = EVChargerState.from_ev_charger_data(data)
+        if evc_id not in self._states or self._states[evc_id] != new_state:
+            self._states[evc_id] = new_state
+            return EVChargerPoolStates(self._states, evc_id)
+        return None
+
+
+class EVChargerPool:
+    """Interactions with EV Chargers."""
+
+    def __init__(
+        self,
+        component_ids: Optional[set[int]] = None,
+    ) -> None:
+        """Create an `EVChargerPool` instance.
+
+        Args:
+            component_ids: An optional list of component_ids belonging to this pool.  If
+                not specified, IDs of all ev chargers in the microgrid will be fetched
+                from the component graph.
+        """
+        self._component_ids = set()
+        if component_ids is not None:
+            self._component_ids = component_ids
+        else:
+            graph = microgrid.get().component_graph
+            self._component_ids = {
+                evc.component_id
+                for evc in graph.components(
+                    component_category={ComponentCategory.EV_CHARGER}
+                )
+            }
+        self._channel = Broadcast[EVChargerPoolStates](
+            "EVCharger States", resend_latest=True
+        )
+        self._task: Optional[asyncio.Task[None]] = None
+        self._merged_stream: Optional[Merge] = None
+
+    async def _run(self) -> None:
+        logger.debug("Starting EVChargerPool for components: %s", self._component_ids)
+        api_client = microgrid.get().api_client
+        streams: list[Receiver[EVChargerData]] = await asyncio.gather(
+            *[api_client.ev_charger_data(cid) for cid in self._component_ids]
+        )
+
+        latest_messages: list[EVChargerData] = await asyncio.gather(
+            *[stream.receive() for stream in streams]
+        )
+        states = {
+            msg.component_id: EVChargerState.from_ev_charger_data(msg)
+            for msg in latest_messages
+        }
+        state_tracker = _StateTracker(states)
+        self._merged_stream = Merge(*streams)
+        sender = self._channel.new_sender()
+        await sender.send(state_tracker.get())
+        async for data in self._merged_stream:
+            if updated_states := state_tracker.update(data):
+                await sender.send(updated_states)
+
+    async def _stop(self) -> None:
+        if self._task:
+            await cancel_and_await(self._task)
+        if self._merged_stream:
+            await self._merged_stream.stop()
+
+    def states(self) -> Receiver[EVChargerPoolStates]:
+        """Return a receiver that streams ev charger states.
+
+        Returns:
+            A receiver that streams the states of all ev chargers in the pool, every
+                time the states of any of them change.
+        """
+        if self._task is None or self._task.done():
+            self._task = asyncio.create_task(self._run())
+        return self._channel.new_receiver()

--- a/src/frequenz/sdk/timeseries/logical_meter/_formula_engine.py
+++ b/src/frequenz/sdk/timeseries/logical_meter/_formula_engine.py
@@ -85,7 +85,7 @@ class FormulaEvaluator:
             RuntimeError: when some streams have no value, or when the synchronization
                 of timestamps fails.
         """
-        metrics_by_ts: Dict[datetime, str] = {}
+        metrics_by_ts: Dict[datetime, list[str]] = {}
         for metric in metrics:
             result = metric.result()
             name = metric.get_name()

--- a/tests/timeseries/mock_microgrid.py
+++ b/tests/timeseries/mock_microgrid.py
@@ -79,6 +79,8 @@ class MockMicrogrid:  # pylint: disable=too-many-instance-attributes
         self.evc_ids: list[int] = []
         self.meter_ids: list[int] = [4]
 
+        self.evc_states: dict[int, ev_charger_pb2.State] = {}
+
         self._streaming_coros: list[typing.Coroutine[None, None, None]] = []
         self._streaming_tasks: list[asyncio.Task[None]] = []
         self._actors: list[typing.Any] = []
@@ -206,11 +208,12 @@ class MockMicrogrid:  # pylint: disable=too-many-instance-attributes
                                         current=common_pb2.Metric(value=value + 12.0)
                                     ),
                                 )
-                            )
+                            ),
+                            state=self.evc_states[evc_id],
                         ),
-                    )
+                    ),
                 ),
-            )
+            ),
         )
 
     def add_batteries(self, count: int) -> None:
@@ -294,7 +297,10 @@ class MockMicrogrid:  # pylint: disable=too-many-instance-attributes
             self._id_increment += 1
 
             self.evc_ids.append(evc_id)
-
+            self.evc_states[evc_id] = ev_charger_pb2.State(
+                cable_state=ev_charger_pb2.CABLE_STATE_UNPLUGGED,
+                component_state=ev_charger_pb2.COMPONENT_STATE_READY,
+            )
             self._components.add(
                 Component(
                     evc_id,

--- a/tests/timeseries/test_ev_charger_pool.py
+++ b/tests/timeseries/test_ev_charger_pool.py
@@ -1,0 +1,81 @@
+# License: MIT
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
+
+"""Tests for the `EVChargerPool`."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Optional
+
+from frequenz.api.microgrid import ev_charger_pb2
+from pytest_mock import MockerFixture
+
+from frequenz.sdk.timeseries.ev_charger_pool import (
+    EVChargerPool,
+    EVChargerPoolStates,
+    EVChargerState,
+)
+from tests.timeseries.mock_microgrid import MockMicrogrid
+
+
+class TestEVChargerPool:
+    """Tests for the `EVChargerPool`."""
+
+    async def test_state_updates(self, mocker: MockerFixture) -> None:
+        """Test ev charger state updates are visible."""
+
+        mockgrid = MockMicrogrid(grid_side_meter=False, sample_rate_s=0.01)
+        mockgrid.add_ev_chargers(5)
+        await mockgrid.start(mocker)
+
+        pool = EVChargerPool()
+
+        states = pool.states()
+
+        async def check_next_state(
+            expected: dict[int, EVChargerState],
+            latest: Optional[tuple[int, EVChargerState]],
+        ) -> EVChargerPoolStates:
+            pool_states = await states.receive()
+            assert pool_states.latest_change() == latest
+            assert pool_states._states == expected  # pylint: disable=protected-access
+            return pool_states
+
+        ## check that all chargers are in idle state.
+        expected_states = {evc_id: EVChargerState.IDLE for evc_id in mockgrid.evc_ids}
+        assert len(expected_states) == 5
+        await check_next_state(expected_states, None)
+
+        ## check that EV_PLUGGED state gets set
+        await asyncio.sleep(0.02)
+        evc_2_id = mockgrid.evc_ids[2]
+        mockgrid.evc_states[evc_2_id] = ev_charger_pb2.State(
+            component_state=ev_charger_pb2.COMPONENT_STATE_READY,
+            cable_state=ev_charger_pb2.CABLE_STATE_EV_PLUGGED,
+        )
+        expected_states[evc_2_id] = EVChargerState.EV_PLUGGED
+        await check_next_state(expected_states, (evc_2_id, EVChargerState.EV_PLUGGED))
+
+        ## check that EV_LOCKED state gets set
+        await asyncio.sleep(0.03)
+        evc_3_id = mockgrid.evc_ids[3]
+        mockgrid.evc_states[evc_3_id] = ev_charger_pb2.State(
+            component_state=ev_charger_pb2.COMPONENT_STATE_READY,
+            cable_state=ev_charger_pb2.CABLE_STATE_EV_LOCKED,
+        )
+        expected_states[evc_3_id] = EVChargerState.EV_LOCKED
+        await check_next_state(expected_states, (evc_3_id, EVChargerState.EV_LOCKED))
+
+        ## check that ERROR state gets set
+        await asyncio.sleep(0.1)
+        evc_1_id = mockgrid.evc_ids[1]
+        mockgrid.evc_states[evc_1_id] = ev_charger_pb2.State(
+            component_state=ev_charger_pb2.COMPONENT_STATE_ERROR,
+            cable_state=ev_charger_pb2.CABLE_STATE_EV_LOCKED,
+        )
+        expected_states[evc_1_id] = EVChargerState.ERROR
+        await check_next_state(expected_states, (evc_1_id, EVChargerState.ERROR))
+
+        await pool._stop()  # pylint: disable=protected-access
+        await mockgrid.cleanup()


### PR DESCRIPTION
Currently just has a method for streaming state changes for ev chargers.

The ev charger power and current formulas will get moved from the logical meter to here, in a subsequent PR.