### PR TITLE
Add 3.11 to the supported Python versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A development kit to interact with the Frequenz development platform.
 
 ## Supported Python versions
 
-* For x86_64 Python 3.8 - 3.10 are supported (tested).
+* For x86_64 Python 3.8 - 3.11 are supported (tested).
 * For arm64 only Python 3.8 is supported (due to some dependencies that only support 3.8).
 
 ## Contributing


### PR DESCRIPTION
Support was added a while ago.