### PR TITLE
Move dev dependencies to pyproject.toml

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -85,7 +85,7 @@ jobs:
       - name: Install build dependencies
         run: |
           python -m pip install -U pip
-          python -m pip install .[docs]
+          python -m pip install .[docs-gen]
 
       - name: Generate the documentation
         env:
@@ -163,7 +163,7 @@ jobs:
         if: steps.mike-metadata.outputs.version
         run: |
           python -m pip install -U pip
-          python -m pip install .[docs]
+          python -m pip install .[docs-gen]
 
       - name: Fetch the gh-pages branch
         if: steps.mike-metadata.outputs.version

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,33 +18,55 @@ all the dependencies too):
 python -m pip install -e .
 ```
 
-You can also use `nox` to run the tests and other checks:
+Or you can install all development dependencies (`mypy`, `pylint`, `pytest`,
+etc.) in one go too:
+```sh
+python -m pip install -e .[dev]
+```
+
+If you don't want to install all the dependencies, you can also use `nox` to
+run the tests and other checks creating its own virtual environments:
 
 ```sh
-python -m pip install nox toml tomli
+python -m pip install nox toml
 nox
 ```
 
 You can also use `nox -R` to reuse the current testing environment to speed up
 test at the expense of a higher chance to end up with a dirty test environment.
 
-### Running tests individually
+### Running tests / checks individually
 
 For a better development test cycle you can install the runtime and test
 dependencies and run `pytest` manually.
 
 ```sh
-python -m pip install .
-python -m pip install pytest pytest-asyncio pytest-mock time_machine async_solipsism
+python -m pip install .[pytest]  # included in .[dev] too
 
 # And for example
 pytest tests/test_sdk.py
 ```
 
-To build the documentation, first install the dependencies:
+Or you can use `nox`:
 
 ```sh
-python -m pip install -e .[docs]
+nox -R -s pytest -- test/test_sdk.py
+```
+
+The same appliest to `pylint` or `mypy` for example:
+
+```sh
+nox -R -s pylint -- test/test_sdk.py
+nox -R -s mypy -- test/test_sdk.py
+```
+
+### Building the documentation
+
+To build the documentation, first install the dependencies (if you didn't
+install all `dev` dependencies):
+
+```sh
+python -m pip install -e .[docs-gen]
 ```
 
 Then you can build the documentation (it will be written in the `site/`

--- a/noxfile.py
+++ b/noxfile.py
@@ -84,20 +84,6 @@ def min_dependencies() -> List[str]:
     return min_deps
 
 
-FMT_DEPS = ["black", "isort"]
-DOCSTRING_DEPS = ["pydocstyle", "darglint"]
-PYTEST_DEPS = [
-    "pytest",
-    "pytest-cov",
-    "pytest-mock",
-    "pytest-asyncio",
-    "time-machine",
-    "async-solipsism",
-]
-MYPY_DEPS = ["mypy", "pandas-stubs", "grpc-stubs"]
-MIN_DEPS = min_dependencies()
-
-
 def _source_file_paths(session: nox.Session) -> List[str]:
     """Return the file paths to run the checks on.
 
@@ -145,9 +131,7 @@ def ci_checks_max(session: nox.Session) -> None:
     Args:
         session: the nox session.
     """
-    session.install(
-        ".[docs]", "pylint", "nox", *PYTEST_DEPS, *FMT_DEPS, *DOCSTRING_DEPS, *MYPY_DEPS
-    )
+    session.install(".[dev]")
 
     formatting(session, False)
     mypy(session, False)
@@ -165,7 +149,7 @@ def formatting(session: nox.Session, install_deps: bool = True) -> None:
         install_deps: True if dependencies should be installed.
     """
     if install_deps:
-        session.install(*FMT_DEPS)
+        session.install(".[format]")
 
     paths = _source_file_paths(session)
     session.run("black", "--check", *paths)
@@ -183,7 +167,7 @@ def mypy(session: nox.Session, install_deps: bool = True) -> None:
     if install_deps:
         # install the package itself as editable, so that it is possible to do
         # fast local tests with `nox -R -e mypy`.
-        session.install("-e", ".[docs]", "nox", *MYPY_DEPS, *PYTEST_DEPS)
+        session.install("-e", ".[mypy]")
 
     common_args = [
         "--install-types",
@@ -228,7 +212,7 @@ def pylint(session: nox.Session, install_deps: bool = True) -> None:
     if install_deps:
         # install the package itself as editable, so that it is possible to do
         # fast local tests with `nox -R -e pylint`.
-        session.install("-e", ".[docs]", "pylint", "nox", *PYTEST_DEPS)
+        session.install("-e", ".[pylint]")
 
     paths = _source_file_paths(session)
     session.run(
@@ -250,7 +234,7 @@ def docstrings(session: nox.Session, install_deps: bool = True) -> None:
         install_deps: True if dependencies should be installed.
     """
     if install_deps:
-        session.install(*DOCSTRING_DEPS, "toml")
+        session.install(".[docs-lint]")
 
     paths = _source_file_paths(session)
     session.run("pydocstyle", *paths)
@@ -281,7 +265,7 @@ def pytest_max(session: nox.Session, install_deps: bool = True) -> None:
     if install_deps:
         # install the package itself as editable, so that it is possible to do
         # fast local tests with `nox -R -e pytest_max`.
-        session.install("-e", ".", *PYTEST_DEPS)
+        session.install("-e", ".[pytest]")
 
     _pytest_impl(session, "max")
 
@@ -297,7 +281,7 @@ def pytest_min(session: nox.Session, install_deps: bool = True) -> None:
     if install_deps:
         # install the package itself as editable, so that it is possible to do
         # fast local tests with `nox -R -e pytest_min`.
-        session.install("-e", ".", *PYTEST_DEPS, *MIN_DEPS)
+        session.install("-e", ".[pytest]", *min_dependencies())
 
     _pytest_impl(session, "min")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,13 +48,48 @@ name ="Frequenz Energy-as-a-Service GmbH"
 email = "floss@frequenz.com"
 
 [project.optional-dependencies]
-docs = [
+docs-gen = [
     "mike >= 1.1.2, < 2",
     "mkdocs-gen-files >= 0.4.0, < 0.5.0",
     "mkdocs-literate-nav >= 0.4.0, < 0.5.0",
     "mkdocs-material >= 8.5.7, < 9",
     "mkdocs-section-index >= 0.3.4, < 0.4.0",
     "mkdocstrings[python] >= 0.19.0, < 0.20.0",
+]
+docs-lint = [
+    "pydocstyle",
+    "darglint",
+]
+format = [
+    "black",
+    "isort",
+]
+nox = [
+    "nox",
+    "toml",
+]
+pytest = [
+    "pytest",
+    "pytest-cov",
+    "pytest-mock",
+    "pytest-asyncio",
+    "time-machine",
+    "async-solipsism",
+]
+mypy = [
+    "mypy",
+    "pandas-stubs",
+    "grpc-stubs",
+    # For checking the noxfile, docs/ script, and tests
+    "frequenz-sdk[docs-gen,nox,pytest]",
+]
+pylint = [
+    "pylint",
+    # For checking the noxfile, docs/ script, and tests
+    "frequenz-sdk[docs-gen,nox,pytest]",
+]
+dev = [
+    "frequenz-sdk[docs-gen,docs-lint,format,nox,pytest,mypy,pylint]",
 ]
 
 [project.urls]


### PR DESCRIPTION
With this we have only one central place where dependencies are declared, so we can make sure we have a consistent view on the dependencies.

As a side effect, the `formatting` session will install some extra unneded dependencies (the package dependencies), but this allow us to pin the tools versions and be sure everyone will use the same version.

A new alias is also added, so users wanting to setup a local development enviroment can now just do a `pip install .[dev]` and that's it.

The CONTRIBUTING guide is updated to reflect this.
