### PR TITLE
Add a run() method to run/wait for actors completion

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,17 +2,16 @@
 
 ## Summary
 
+<!-- Here goes a general summary of what this release is about -->
+
 ## Upgrading
+
+<!-- Here goes notes on how to upgrade from previous versions, including deprecations and what they should be replaced with -->
 
 ## New Features
 
-* A new class `OrderedRingBuffer` is now available, providing a sorted ring buffer of datetime-value pairs with tracking of any values that have not yet been written.
-* Add logical meter formula for EV power.
-* A `MovingWindow` class has been added that consumes a data stream from a logical meter and updates an `OrderedRingBuffer`.
-* Add EVChargerPool implementation. It has only streaming state changes for ev chargers, now.
-* Add 3-phase current formulas: `3-phase grid_current` and `3-phase ev_charger_current` to the LogicalMeter.
 * A new class `SerializableRingbuffer` is now available, extending the `OrderedRingBuffer` class with the ability to load & dump the data to disk.
 
 ## Bug Fixes
 
-* Add COMPONENT_STATE_DISCHARGING as valid state for the inverter. DISCHARGING state was missing by mistake and this caused the power distributor to error out if the inverter is already discharging.
+<!-- Here goes notable bug fixes that are worth a special mention or explanation -->

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -11,6 +11,7 @@
 ## New Features
 
 * A new class `SerializableRingbuffer` is now available, extending the `OrderedRingBuffer` class with the ability to load & dump the data to disk.
+* Add the `run(*actors)` function for running and synchronizing the execution of actors. This new function simplifies the way actors are managed on the client side, allowing for a cleaner and more streamlined approach. Users/apps can now run actors simply by calling run(actor1, actor2, actor3...) without the need to manually call join() and deal with linting errors.
 
 ## Bug Fixes
 

--- a/examples/power_distribution.py
+++ b/examples/power_distribution.py
@@ -18,14 +18,13 @@ from typing import List, Optional, Set
 
 from frequenz.channels import Bidirectional, Broadcast, Receiver, Sender
 
-from frequenz.sdk import microgrid
+from frequenz.sdk import actor, microgrid
 from frequenz.sdk.actor import (
     ChannelRegistry,
     ComponentMetricRequest,
     ComponentMetricsResamplingActor,
     DataSourcingActor,
     ResamplerConfig,
-    actor,
 )
 from frequenz.sdk.actor.power_distributing import (
     PowerDistributingActor,
@@ -42,7 +41,7 @@ HOST = "microgrid.sandbox.api.frequenz.io"  # it should be the host name.
 PORT = 61060
 
 
-@actor
+@actor.actor
 class DecisionMakingActor:
     """Actor that receives set receives power for given batteries."""
 
@@ -112,7 +111,7 @@ class DecisionMakingActor:
                 _logger.info("Set power with %d succeed.", power_to_set)
 
 
-@actor
+@actor.actor
 class DataCollectingActor:
     """Actor that makes decisions about how much to charge/discharge batteries."""
 
@@ -227,10 +226,7 @@ async def run() -> None:
         active_power_data=await logical_meter.grid_power(),
     )
 
-    # pylint: disable=no-member
-    await service_actor.join()  # type: ignore[attr-defined]
-    await client_actor.join()  # type: ignore[attr-defined]
-    await power_distributor.join()  # type: ignore[attr-defined]
+    await actor.run(service_actor, client_actor, power_distributor)
 
 
 asyncio.run(run())

--- a/src/frequenz/sdk/actor/__init__.py
+++ b/src/frequenz/sdk/actor/__init__.py
@@ -9,6 +9,7 @@ from ._config_managing import ConfigManagingActor
 from ._data_sourcing import ComponentMetricRequest, DataSourcingActor
 from ._decorator import actor
 from ._resampling import ComponentMetricsResamplingActor
+from ._run_utils import run
 
 __all__ = [
     "ChannelRegistry",
@@ -18,4 +19,5 @@ __all__ = [
     "DataSourcingActor",
     "ResamplerConfig",
     "actor",
+    "run",
 ]

--- a/src/frequenz/sdk/actor/_decorator.py
+++ b/src/frequenz/sdk/actor/_decorator.py
@@ -207,10 +207,8 @@ def actor(cls: Type[Any]) -> Type[Any]:
                 except asyncio.CancelledError:
                     logger.debug("Cancelling actor: %s", cls.__name__)
                     raise
-                except Exception as err:  # pylint: disable=broad-except
-                    logger.exception(
-                        "Actor (%s) crashed with error: %s", cls.__name__, err
-                    )
+                except Exception:  # pylint: disable=broad-except
+                    logger.exception("Actor (%s) crashed", cls.__name__)
                     if (
                         self.restart_limit is None
                         or number_of_restarts < self.restart_limit

--- a/src/frequenz/sdk/actor/_run_utils.py
+++ b/src/frequenz/sdk/actor/_run_utils.py
@@ -5,9 +5,12 @@
 
 
 import asyncio
+import logging
 from typing import Any
 
 from ._decorator import BaseActor
+
+_logger = logging.getLogger(__name__)
 
 
 async def run(*actors: Any) -> None:
@@ -24,4 +27,27 @@ async def run(*actors: Any) -> None:
     for actor in actors:
         assert isinstance(actor, BaseActor), f"{actor} is not an instance of BaseActor"
 
-    await asyncio.gather(*(actor.join() for actor in actors))
+    pending_tasks = set()
+    for actor in actors:
+        pending_tasks.add(asyncio.create_task(actor.join(), name=str(actor)))
+
+    # Currently the actor decorator manages the life-cycle of the actor tasks
+    while pending_tasks:
+        done_tasks, pending_tasks = await asyncio.wait(
+            pending_tasks, return_when=asyncio.FIRST_COMPLETED
+        )
+
+        # This should always be only one task, but we handle many for extra safety
+        for task in done_tasks:
+            # Cancellation needs to be checked first, otherwise the other methods
+            # could raise a CancelledError
+            if task.cancelled():
+                _logger.info("The actor %s was cancelled", task.get_name())
+            elif exception := task.exception():
+                _logger.error(
+                    "The actor %s was finished due to an uncaught exception",
+                    task.get_name(),
+                    exc_info=exception,
+                )
+            else:
+                _logger.info("The actor %s finished normally", task.get_name())

--- a/src/frequenz/sdk/actor/_run_utils.py
+++ b/src/frequenz/sdk/actor/_run_utils.py
@@ -1,0 +1,27 @@
+# License: MIT
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
+
+"""Utility functions to run and synchronize the execution of actors."""
+
+
+import asyncio
+from typing import Any
+
+from ._decorator import BaseActor
+
+
+async def run(*actors: Any) -> None:
+    """Await the completion of all actors.
+
+    Args:
+        actors: the actors to be awaited.
+
+    Raises:
+        AssertionError: if any of the actors is not an instance of BaseActor.
+    """
+    # Check that each actor is an instance of BaseActor at runtime,
+    # due to the indirection created by the actor decorator.
+    for actor in actors:
+        assert isinstance(actor, BaseActor), f"{actor} is not an instance of BaseActor"
+
+    await asyncio.gather(*(actor.join() for actor in actors))

--- a/tests/actor/test_decorator.py
+++ b/tests/actor/test_decorator.py
@@ -5,7 +5,7 @@
 from frequenz.channels import Broadcast, Receiver, Sender
 from frequenz.channels.util import Select
 
-from frequenz.sdk.actor import actor
+from frequenz.sdk.actor import actor, run
 
 
 @actor
@@ -111,5 +111,4 @@ async def test_actor_does_not_restart() -> None:
     )
 
     await channel.new_sender().send(1)
-    # pylint: disable=no-member
-    await _faulty_actor.join()  # type: ignore
+    await run(_faulty_actor)

--- a/tests/actor/test_resampling.py
+++ b/tests/actor/test_resampling.py
@@ -2,6 +2,7 @@
 # Copyright © 2022 Frequenz Energy-as-a-Service GmbH
 
 """Frequenz Python SDK resampling example."""
+import asyncio
 import dataclasses
 from datetime import datetime, timezone
 from typing import Iterator
@@ -9,7 +10,6 @@ from typing import Iterator
 import async_solipsism
 import pytest
 import time_machine
-from async_solipsism.socket import asyncio
 from frequenz.channels import Broadcast
 
 from frequenz.sdk.actor import (

--- a/tests/actor/test_resampling.py
+++ b/tests/actor/test_resampling.py
@@ -26,7 +26,7 @@ from frequenz.sdk.timeseries import Sample
 
 
 @pytest.fixture(autouse=True)
-def fake_loop() -> Iterator[async_solipsism.EventLoop]:
+def event_loop() -> Iterator[async_solipsism.EventLoop]:
     """Replace the loop with one that doesn't interact with the outside world."""
     loop = async_solipsism.EventLoop()
     yield loop

--- a/tests/actor/test_resampling.py
+++ b/tests/actor/test_resampling.py
@@ -25,7 +25,8 @@ from frequenz.sdk.timeseries import Sample
 #
 
 
-@pytest.fixture(autouse=True)
+# Setting 'autouse' has no effect as this method replaces the event loop for all tests in the file.
+@pytest.fixture()
 def event_loop() -> Iterator[async_solipsism.EventLoop]:
     """Replace the loop with one that doesn't interact with the outside world."""
     loop = async_solipsism.EventLoop()

--- a/tests/actor/test_run_utils.py
+++ b/tests/actor/test_run_utils.py
@@ -1,0 +1,120 @@
+# License: MIT
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
+
+"""Simple tests for the actor runner."""
+
+import asyncio
+import time
+from typing import Iterator
+
+import async_solipsism
+import pytest
+import time_machine
+
+from frequenz.sdk.actor import actor, run
+
+
+@pytest.fixture(autouse=True)
+def event_loop() -> Iterator[async_solipsism.EventLoop]:
+    """Replace the loop with one that doesn't interact with the outside world."""
+    loop = async_solipsism.EventLoop()
+    yield loop
+    loop.close()
+
+
+@pytest.fixture
+def fake_time() -> Iterator[time_machine.Coordinates]:
+    """Replace real time with a time machine that doesn't automatically tick."""
+    with time_machine.travel(0, tick=False) as traveller:
+        yield traveller
+
+
+@actor
+class FaultyActor:
+    """A test faulty actor."""
+
+    def __init__(self, name: str) -> None:
+        """Initialize the faulty actor.
+
+        Args:
+            name: the name of the faulty actor.
+        """
+        self.name = name
+        self.is_cancelled = False
+
+    async def run(self) -> None:
+        """Run the faulty actor.
+
+        Raises:
+            CancelledError: the exception causes the actor to be cancelled
+        """
+        self.is_cancelled = True
+        raise asyncio.CancelledError(f"Faulty Actor {self.name} failed")
+
+
+@actor
+class SleepyActor:
+    """A test actor that sleeps a short time."""
+
+    def __init__(self, name: str, sleep_duration: float) -> None:
+        """Initialize the sleepy actor.
+
+        Args:
+            name: the name of the sleepy actor.
+            sleep_duration: the virtual duration to sleep while running.
+        """
+        self.name = name
+        self.sleep_duration = sleep_duration
+        self.is_joined = False
+
+    async def run(self) -> None:
+        """Run the sleepy actor."""
+        while time.time() < self.sleep_duration:
+            await asyncio.sleep(0.1)
+
+        self.is_joined = True
+
+
+# pylint: disable=redefined-outer-name
+async def test_all_actors_done(fake_time: time_machine.Coordinates) -> None:
+    """Test the completion of all actors."""
+
+    sleepy_actor_1 = SleepyActor("sleepy_actor_1", sleep_duration=1.0)
+    sleepy_actor_2 = SleepyActor("sleepy_actor_2", sleep_duration=2.0)
+
+    test_task = asyncio.create_task(run(sleepy_actor_1, sleepy_actor_2))
+
+    sleep_duration = time.time()
+
+    assert sleep_duration == 0
+    assert sleepy_actor_1.is_joined is False
+    assert sleepy_actor_2.is_joined is False
+
+    while not test_task.done():
+        if sleep_duration < 1:
+            assert sleepy_actor_1.is_joined is False
+            assert sleepy_actor_2.is_joined is False
+        elif sleep_duration < 2:
+            assert sleepy_actor_1.is_joined is True
+            assert sleepy_actor_2.is_joined is False
+        elif sleep_duration == 2:
+            assert sleepy_actor_1.is_joined is True
+            assert sleepy_actor_2.is_joined is True
+
+        fake_time.shift(0.5)
+        sleep_duration = time.time()
+        await asyncio.sleep(1)
+
+    assert sleepy_actor_1.is_joined
+    assert sleepy_actor_2.is_joined
+
+
+async def test_actors_cancelled() -> None:
+    """Test the completion of actors being cancelled."""
+
+    faulty_actors = [FaultyActor(f"faulty_actor_{idx}") for idx in range(5)]
+
+    await asyncio.wait_for(run(*faulty_actors), timeout=1.0)
+
+    for faulty_actor in faulty_actors:
+        assert faulty_actor.is_cancelled

--- a/tests/actor/test_run_utils.py
+++ b/tests/actor/test_run_utils.py
@@ -14,7 +14,8 @@ import time_machine
 from frequenz.sdk.actor import actor, run
 
 
-@pytest.fixture(autouse=True)
+# Setting 'autouse' has no effect as this method replaces the event loop for all tests in the file.
+@pytest.fixture()
 def event_loop() -> Iterator[async_solipsism.EventLoop]:
     """Replace the loop with one that doesn't interact with the outside world."""
     loop = async_solipsism.EventLoop()

--- a/tests/timeseries/test_resampling.py
+++ b/tests/timeseries/test_resampling.py
@@ -38,7 +38,7 @@ from ..utils import a_sequence
 
 
 @pytest.fixture(autouse=True)
-def fake_loop() -> Iterator[async_solipsism.EventLoop]:
+def event_loop() -> Iterator[async_solipsism.EventLoop]:
     """Replace the loop with one that doesn't interact with the outside world."""
     loop = async_solipsism.EventLoop()
     yield loop

--- a/tests/timeseries/test_resampling.py
+++ b/tests/timeseries/test_resampling.py
@@ -37,7 +37,8 @@ from ..utils import a_sequence
 # pylint: disable=too-many-locals,redefined-outer-name
 
 
-@pytest.fixture(autouse=True)
+# Setting 'autouse' has no effect as this method replaces the event loop for all tests in the file.
+@pytest.fixture()
 def event_loop() -> Iterator[async_solipsism.EventLoop]:
     """Replace the loop with one that doesn't interact with the outside world."""
     loop = async_solipsism.EventLoop()


### PR DESCRIPTION
Adds the `run()` method which awaits the completion of all actors. The method takes a variable number of actors as parameter and uses `asyncio.gather()` to wait for all actors to complete their tasks.

This will allow us to find better methods to wait for all actors to finish. It also simplify the way the actors are manually `join()` on the client side.

Partially addresses #36 