### PR TITLE
Add COMPONENT_STATE_DISCHARGING to valid inverter states

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,21 +2,17 @@
 
 ## Summary
 
-<!-- Here goes a general summary of what this release is about -->
-
 ## Upgrading
 
-<!-- Here goes notes on how to upgrade from previous versions, including deprecations and what they should be replaced with -->
-
 ## New Features
-
-<!-- Here goes the main new features and examples or instructions on how to use them -->
 
 * A new class `OrderedRingBuffer` is now available, providing a sorted ring buffer of datetime-value pairs with tracking of any values that have not yet been written.
 * Add logical meter formula for EV power.
 * A `MovingWindow` class has been added that consumes a data stream from a logical meter and updates an `OrderedRingBuffer`.
+* Add EVChargerPool implementation. It has only streaming state changes for ev chargers, now.
+* Add 3-phase current formulas: `3-phase grid_current` and `3-phase ev_charger_current` to the LogicalMeter.
+
 
 ## Bug Fixes
 
 * Add COMPONENT_STATE_DISCHARGING as valid state for the inverter. DISCHARGING state was missing by mistake and this caused the power distributor to error out if the inverter is already discharging.
-<!-- Here goes notable bug fixes that are worth a special mention or explanation -->

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -18,4 +18,5 @@
 
 ## Bug Fixes
 
+* Add COMPONENT_STATE_DISCHARGING as valid state for the inverter. DISCHARGING state was missing by mistake and this caused the power distributor to error out if the inverter is already discharging.
 <!-- Here goes notable bug fixes that are worth a special mention or explanation -->

--- a/src/frequenz/sdk/actor/power_distributing/_battery_status.py
+++ b/src/frequenz/sdk/actor/power_distributing/_battery_status.py
@@ -147,7 +147,7 @@ class BatteryStatusTracker:
         InverterComponentState.COMPONENT_STATE_STANDBY,
         InverterComponentState.COMPONENT_STATE_IDLE,
         InverterComponentState.COMPONENT_STATE_CHARGING,
-        InverterComponentState.COMPONENT_STATE_STANDBY,
+        InverterComponentState.COMPONENT_STATE_DISCHARGING,
     }
 
     def __init__(  # pylint: disable=too-many-arguments


### PR DESCRIPTION
DISCHARGING state was missing by mistake and this caused the power distributor to error out if the inverter is already discharging.