### PR TITLE
Change battery status when component stopped sending data

### DIFF
--- a/examples/battery_status.py
+++ b/examples/battery_status.py
@@ -1,0 +1,44 @@
+# License: MIT
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
+
+"""Example how to run BatteryPoolStatus as separate instance.
+
+This is not needed for user but simplifies testing and debugging and understanding
+this feature.
+"""
+
+import asyncio
+import logging
+
+from frequenz.sdk import microgrid
+from frequenz.sdk.actor.power_distributing._battery_pool_status import BatteryPoolStatus
+from frequenz.sdk.microgrid.component import ComponentCategory
+
+_logger = logging.getLogger(__name__)
+HOST = "microgrid.sandbox.api.frequenz.io"  # it should be the host name.
+PORT = 61060
+
+
+async def main() -> None:
+    """Start BatteryPoolStatus to see how it works."""
+    logging.basicConfig(
+        level=logging.DEBUG, format="%(asctime)s %(name)s %(levelname)s:%(message)s"
+    )
+    await microgrid.initialize(HOST, PORT)
+    batteries = {
+        bat.component_id
+        for bat in microgrid.get().component_graph.components(
+            component_category={ComponentCategory.BATTERY}
+        )
+    }
+
+    batteries_status = BatteryPoolStatus(
+        battery_ids=batteries,
+        max_data_age_sec=5,
+        max_blocking_duration_sec=30,
+    )
+
+    await batteries_status.join()
+
+
+asyncio.run(main())

--- a/src/frequenz/sdk/actor/power_distributing/_battery_pool_status.py
+++ b/src/frequenz/sdk/actor/power_distributing/_battery_pool_status.py
@@ -123,6 +123,17 @@ class BatteryPoolStatus:
 
         self._task = asyncio.create_task(self._run())
 
+    async def join(self) -> None:
+        """Await for the battery pool, and return when the task completes.
+
+        It will not terminate the program while BatteryPool is working.
+        BatteryPool can be stopped with the `stop` method.
+        This method is not needed in source code, because BatteryPool is owned
+        by the internal code.
+        It is needed only when user needs to run his own instance of the BatteryPool.
+        """
+        await self._task
+
     async def stop(self) -> None:
         """Stop tracking batteries status."""
         await cancel_and_await(self._task)

--- a/src/frequenz/sdk/actor/power_distributing/_battery_pool_status.py
+++ b/src/frequenz/sdk/actor/power_distributing/_battery_pool_status.py
@@ -94,8 +94,8 @@ class BatteryPoolStatus:
         self._current_status = BatteryStatus(working=set(), uncertain=set())
 
         # Channel for sending results of requests to the batteries
-        request_result_channel = Broadcast[SetPowerResult]("battery_request_status")
-        self._request_result_sender = request_result_channel.new_sender()
+        set_power_result_channel = Broadcast[SetPowerResult]("battery_request_status")
+        self._set_power_result_sender = set_power_result_channel.new_sender()
 
         self._batteries: Dict[str, BatteryStatusTracker] = {}
 
@@ -112,7 +112,7 @@ class BatteryPoolStatus:
                 max_data_age_sec=max_data_age_sec,
                 max_blocking_duration_sec=max_blocking_duration_sec,
                 status_sender=channel.sender,
-                request_result_receiver=request_result_channel.new_receiver(
+                set_power_result_receiver=set_power_result_channel.new_receiver(
                     f"battery_{battery_id}_request_status"
                 ),
             )
@@ -189,7 +189,7 @@ class BatteryPoolStatus:
             succeed_batteries: Batteries that succeed request
             failed_batteries: Batteries that failed request
         """
-        await self._request_result_sender.send(
+        await self._set_power_result_sender.send(
             SetPowerResult(succeed_batteries, failed_batteries)
         )
 

--- a/src/frequenz/sdk/actor/power_distributing/_battery_status.py
+++ b/src/frequenz/sdk/actor/power_distributing/_battery_status.py
@@ -164,7 +164,7 @@ class BatteryStatusTracker:
         max_data_age_sec: float,
         max_blocking_duration_sec: float,
         status_sender: Sender[Status],
-        request_result_receiver: Receiver[SetPowerResult],
+        set_power_result_receiver: Receiver[SetPowerResult],
     ) -> None:
         """Create class instance.
 
@@ -177,7 +177,7 @@ class BatteryStatusTracker:
             max_blocking_duration_sec: This value tell what should be the maximum
                 timeout used for blocking failing component.
             status_sender: Channel to send status updates.
-            request_result_receiver: Channel to receive results of the requests to the
+            set_power_result_receiver: Channel to receive results of the requests to the
                 components.
 
         Raises:
@@ -204,7 +204,7 @@ class BatteryStatusTracker:
         self._select = None
 
         self._task = asyncio.create_task(
-            self._run(status_sender, request_result_receiver)
+            self._run(status_sender, set_power_result_receiver)
         )
 
     @property
@@ -226,15 +226,15 @@ class BatteryStatusTracker:
     async def _run(
         self,
         status_sender: Sender[Status],
-        request_result_receiver: Receiver[SetPowerResult],
+        set_power_result_receiver: Receiver[SetPowerResult],
     ) -> None:
-        """Process data from the components and request_result_receiver.
+        """Process data from the components and set_power_result_receiver.
 
         New status is send only when it change.
 
         Args:
             status_sender: Channel to send status updates.
-            request_result_receiver: Channel to receive results of the requests to the
+            set_power_result_receiver: Channel to receive results of the requests to the
                 components.
         """
         api_client = get_microgrid().api_client
@@ -247,7 +247,7 @@ class BatteryStatusTracker:
             battery_timer=self._battery.data_recv_timer,
             inverter_timer=self._inverter.data_recv_timer,
             inverter=inverter_receiver,
-            request_result=request_result_receiver,
+            set_power_result=set_power_result_receiver,
         )
 
         while True:
@@ -280,7 +280,7 @@ class BatteryStatusTracker:
             self._inverter.last_msg_timestamp = msg.inner.timestamp
             self._inverter.data_recv_timer.reset()
 
-        elif msg := select.request_result:
+        elif msg := select.set_power_result:
             result: SetPowerResult = msg.inner
             if self.battery_id in result.succeed:
                 self._blocking_status.unblock()

--- a/tests/actor/test_battery_status.py
+++ b/tests/actor/test_battery_status.py
@@ -190,21 +190,30 @@ class Message(Generic[T]):
 class FakeSelect:
     """Helper class to mock Select object used in BatteryStatusTracker"""
 
-    def __init__(
+    # This is just number of Select instance attributes.
+    def __init__(  # pylint: disable=too-many-arguments
         self,
         battery: Optional[BatteryData] = None,
         inverter: Optional[InverterData] = None,
         request_result: Optional[SetPowerResult] = None,
+        battery_timer_flag: bool = False,
+        inverter_timer_flag: bool = False,
     ) -> None:
         """Create FakeSelect instance
 
         Args:
             battery: Expected battery message. Defaults to None.
             inverter: Expected inverter message. Defaults to None.
+            battery_timer_flag: If true the battery data timer will be set to indicate
+                that no messages have been received for a while.
+            inverter_timer_flag: If true the inverter data timer will be set to indicate
+                that no messages have been received for a while.
             request_result: Expected SetPowerResult message. Defaults to None.
         """
         self.battery = None if battery is None else Message(battery)
         self.inverter = None if inverter is None else Message(inverter)
+        self.inverter_timer = inverter_timer_flag
+        self.battery_timer = battery_timer_flag
         self.request_result = (
             None if request_result is None else Message(request_result)
         )
@@ -536,13 +545,6 @@ class TestBatteryStatus:
                 assert tracker._update_status(select) is None  # type: ignore[arg-type]
                 time.shift(timeout)
 
-            # Battery message should be to old after 5 seconds.
-            select = FakeSelect(
-                request_result=SetPowerResult(succeed={1}, failed={106})
-            )
-            status = tracker._update_status(select)  # type: ignore[arg-type]
-            assert status is Status.NOT_WORKING
-
             await tracker.stop()
 
     @time_machine.travel("2022-01-01 00:00 UTC", tick=False)
@@ -595,6 +597,69 @@ class TestBatteryStatus:
         select = FakeSelect(inverter=inverter_data(component_id=INVERTER_ID))
         assert tracker._update_status(select) is Status.WORKING  # type: ignore[arg-type]
 
+        await tracker.stop()
+
+    @time_machine.travel("2022-01-01 00:00 UTC", tick=False)
+    async def test_timers(
+        self, mock_microgrid: MockMicrogridClient, mocker: MockerFixture
+    ) -> None:
+        """Test if messages changes battery status/
+
+        Tests uses FakeSelect to test status in sync way.
+        Otherwise we would have lots of async calls and waiting.
+
+        Args:
+            mock_microgrid: mock_microgrid fixture
+            mocker: pytest mocker instance
+        """
+        status_channel = Broadcast[Status]("battery_status")
+        request_result_channel = Broadcast[SetPowerResult]("request_result")
+
+        tracker = BatteryStatusTracker(
+            BATTERY_ID,
+            max_data_age_sec=5,
+            max_blocking_duration_sec=30,
+            status_sender=status_channel.new_sender(),
+            request_result_receiver=request_result_channel.new_receiver(),
+        )
+
+        battery_timer_spy = mocker.spy(tracker._battery.data_recv_timer, "reset")
+        inverter_timer_spy = mocker.spy(tracker._inverter.data_recv_timer, "reset")
+
+        assert tracker.battery_id == BATTERY_ID
+        assert tracker._last_status == Status.NOT_WORKING
+
+        select = FakeSelect(inverter=inverter_data(component_id=INVERTER_ID))
+        assert tracker._update_status(select) is None  # type: ignore[arg-type]
+
+        select = FakeSelect(battery=battery_data(component_id=BATTERY_ID))
+        assert tracker._update_status(select) is Status.WORKING  # type: ignore[arg-type]
+
+        assert battery_timer_spy.call_count == 1
+
+        select = FakeSelect(battery_timer_flag=True)
+        assert tracker._update_status(select) is Status.NOT_WORKING  # type: ignore[arg-type]
+
+        assert battery_timer_spy.call_count == 1
+
+        select = FakeSelect(battery=battery_data(component_id=BATTERY_ID))
+        assert tracker._update_status(select) is Status.WORKING  # type: ignore[arg-type]
+
+        assert battery_timer_spy.call_count == 2
+
+        select = FakeSelect(inverter_timer_flag=True)
+        assert tracker._update_status(select) is Status.NOT_WORKING  # type: ignore[arg-type]
+
+        select = FakeSelect(battery_timer_flag=True)
+        assert tracker._update_status(select) is None  # type: ignore[arg-type]
+
+        select = FakeSelect(battery=battery_data(component_id=BATTERY_ID))
+        assert tracker._update_status(select) is None  # type: ignore[arg-type]
+
+        select = FakeSelect(inverter=inverter_data(component_id=INVERTER_ID))
+        assert tracker._update_status(select) is Status.WORKING  # type: ignore[arg-type]
+
+        assert inverter_timer_spy.call_count == 2
         await tracker.stop()
 
     @time_machine.travel("2022-01-01 00:00 UTC", tick=False)


### PR DESCRIPTION
Set timer for battery and inverter messages. If no message was received for some time, check timestamp and update battery status.
Previously the timestamp was checked after received request result. Because of that BatteryStatus could not work alone (without instance that sends request result).
