### PR TITLE
Rename microgrid.Microgrid to microgrid.ConnectionManager and its Insecure-companion

### DIFF
--- a/src/frequenz/sdk/microgrid/__init__.py
+++ b/src/frequenz/sdk/microgrid/__init__.py
@@ -9,11 +9,11 @@ for monitoring and adjusting the state of a microgrid.
 
 from . import client, component
 from ._graph import ComponentGraph
-from ._microgrid import Microgrid, get, initialize
+from ._microgrid import ConnectionManager, get, initialize
 
 __all__ = [
     "ComponentGraph",
-    "Microgrid",
+    "ConnectionManager",
     "get",
     "initialize",
     "client",

--- a/src/frequenz/sdk/microgrid/_microgrid.py
+++ b/src/frequenz/sdk/microgrid/_microgrid.py
@@ -1,7 +1,7 @@
 # License: MIT
 # Copyright © 2022 Frequenz Energy-as-a-Service GmbH
 
-"""Microgrid singleton abstraction.
+"""Microgrid Connection Manager singleton abstraction.
 
 This module provides a singleton abstraction over the microgrid. The main
 purpose is to provide the connection the microgrid API client and the microgrid
@@ -22,7 +22,7 @@ _DEFAULT_MICROGRID_HOST = "[::1]"
 _DEFAULT_MICROGRID_PORT = 443
 
 
-class Microgrid(ABC):
+class ConnectionManager(ABC):
     """Creates and stores core features."""
 
     def __init__(self, host: str, port: int) -> None:
@@ -81,7 +81,7 @@ class Microgrid(ABC):
         """Initialize the object. This function should be called only once."""
 
 
-class _MicrogridInsecure(Microgrid):
+class _InsecureConnectionManager(ConnectionManager):
     """Microgrid Api with insecure channel implementation."""
 
     def __init__(
@@ -137,7 +137,7 @@ class _MicrogridInsecure(Microgrid):
         await self._graph.refresh_from_api(self._api)
 
 
-_MICROGRID: Optional[Microgrid] = None
+_MICROGRID: Optional[ConnectionManager] = None
 
 
 async def initialize(host: str, port: int) -> None:
@@ -157,7 +157,7 @@ async def initialize(host: str, port: int) -> None:
     if _MICROGRID is not None:
         raise AssertionError("MicrogridApi was already initialized.")
 
-    microgrid_api = _MicrogridInsecure(host, port)
+    microgrid_api = _InsecureConnectionManager(host, port)
     await microgrid_api._initialize()  # pylint: disable=protected-access
 
     # Check again that _MICROGRID_API is None in case somebody had the great idea of
@@ -168,7 +168,7 @@ async def initialize(host: str, port: int) -> None:
     _MICROGRID = microgrid_api
 
 
-def get() -> Microgrid:
+def get() -> ConnectionManager:
     """Get the MicrogridApi instance created by initialize().
 
     This function should be only called after initialize().

--- a/tests/utils/mock_microgrid.py
+++ b/tests/utils/mock_microgrid.py
@@ -10,7 +10,7 @@ from frequenz.channels import Broadcast, Receiver
 from google.protobuf.empty_pb2 import Empty  # pylint: disable=no-name-in-module
 from pytest_mock import MockerFixture
 
-from frequenz.sdk.microgrid import Microgrid
+from frequenz.sdk.microgrid import ConnectionManager
 from frequenz.sdk.microgrid._graph import ComponentGraph, _MicrogridComponentGraph
 from frequenz.sdk.microgrid.client import Connection
 from frequenz.sdk.microgrid.component import (
@@ -57,7 +57,7 @@ class MockMicrogridClient:
             "component_graph": self._component_graph,
         }
 
-        self._mock_microgrid = MagicMock(spec=Microgrid, **kwargs)
+        self._mock_microgrid = MagicMock(spec=ConnectionManager, **kwargs)
         self._battery_data_senders = {
             id: channel.new_sender() for id, channel in bat_channels.items()
         }
@@ -83,7 +83,7 @@ class MockMicrogridClient:
         )
 
     @property
-    def mock_microgrid(self) -> Microgrid:
+    def mock_microgrid(self) -> ConnectionManager:
         """Return mock microgrid.
 
         This is needed to patch existing microgrid.get() method.


### PR DESCRIPTION
Closes #90

Mind, I did not rename from `microgrid.Microgrid` to `microgrid.MicrogridConnectionManager` but to `microgrid.ConnectionManager` as this reads way less repeatitive. Also, this "type is not meant to be used by users directly". :)