### PR TITLE
Update MockMicrogrid for use with datasourcing benchmark

### DIFF
--- a/tests/timeseries/mock_microgrid.py
+++ b/tests/timeseries/mock_microgrid.py
@@ -53,8 +53,16 @@ class MockMicrogrid:  # pylint: disable=too-many-instance-attributes
 
     _microgrid: MockMicrogridClient
 
-    def __init__(self, grid_side_meter: bool, sample_rate_s: float = 0.01):
-        """Create a new instance."""
+    def __init__(
+        self, grid_side_meter: bool, num_values: int = 2000, sample_rate_s: float = 0.01
+    ):
+        """Create a new instance.
+
+        Args:
+            grid_side_meter: whether the main meter should be on the grid side or not.
+            num_values: number of values to generate for each component.
+            sample_rate_s: sample rate in seconds.
+        """
         self._components: Set[Component] = set(
             [
                 Component(1, ComponentCategory.GRID),
@@ -64,6 +72,7 @@ class MockMicrogrid:  # pylint: disable=too-many-instance-attributes
         self._connections: Set[Connection] = set([Connection(1, 4)])
         self._id_increment = 0
         self._grid_side_meter = grid_side_meter
+        self._num_values = num_values
         self._sample_rate_s = sample_rate_s
 
         self._connect_to = self.grid_id
@@ -106,7 +115,7 @@ class MockMicrogrid:  # pylint: disable=too-many-instance-attributes
     async def _comp_data_send_task(
         self, comp_id: int, make_comp_data: Callable[[int, datetime], ComponentData]
     ) -> None:
-        for value in range(1, 2000):
+        for value in range(1, self._num_values + 1):
             timestamp = datetime.now(tz=timezone.utc)
             val_to_send = value + int(comp_id / 10)
             # for inverters with component_id > 100, send only half the messages.


### PR DESCRIPTION
Extends the mock microgrid with features required for the datasourcing actor
benchmark which will be added in a later PR

- Add num_values to have a configurable amount of iterations
- MockMicrogrid: Make it work outside of pytest as well
- Add start_mock_client method
