### PR TITLE
[Experiment] Synchronous send()

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -12,6 +12,8 @@
 * Add EVChargerPool implementation. It has only streaming state changes for ev chargers, now.
 * Add 3-phase current formulas: `3-phase grid_current` and `3-phase ev_charger_current` to the LogicalMeter.
 * A new class `SerializableRingbuffer` is now available, extending the `OrderedRingBuffer` class with the ability to load & dump the data to disk.
+* The datasourcing actor now automatically closes all sending channels when the input channel closes.
+* The datasourcing actor no longer creates an extra task for every single sample and sender
 
 ## Bug Fixes
 

--- a/benchmarks/power_distribution/power_distributor.py
+++ b/benchmarks/power_distribution/power_distributor.py
@@ -53,7 +53,7 @@ async def run_user(user: User, batteries: Set[int], request_num: int) -> List[Re
     """
     result: List[Result] = []
     for _ in range(request_num):
-        await user.channel.send(
+        user.channel.send(
             Request(power=random.randrange(100000, 1000000), batteries=batteries)
         )
         try:

--- a/benchmarks/timeseries/benchmark_datasourcing.py
+++ b/benchmarks/timeseries/benchmark_datasourcing.py
@@ -1,0 +1,114 @@
+import asyncio
+from time import perf_counter
+from typing import Tuple
+from unittest.mock import patch
+
+from frequenz.channels import Broadcast, ReceiverStoppedError
+from pytest_mock import MockerFixture
+
+from frequenz.sdk import microgrid
+from frequenz.sdk.actor import (
+    ChannelRegistry,
+    ComponentMetricRequest,
+    DataSourcingActor,
+)
+from frequenz.sdk.microgrid.component import ComponentMetricId
+from tests.timeseries.mock_microgrid import MockMicrogrid
+from tests.utils.mock_microgrid import MockMicrogridClient
+
+
+def enable_mock_client(client: MockMicrogridClient) -> None:
+    """Callback to enable the mock microgrid client.
+
+    Args:
+        client: the mock microgrid client to enable.
+    """
+    microgrid._microgrid._MICROGRID = client
+
+
+@patch("frequenz.sdk.microgrid._microgrid._MICROGRID")
+async def benchmark_data_sourcing(
+    num_evc_chargers: int, num_msgs_per_battery: int, mock_microgrid: MockerFixture
+) -> None:
+    """Benchmark the data sourcing actor.
+
+    Args:
+        num_evc_chargers: number of EV Chargers to create for the mock microgrid.
+        num_msgs_per_battery: number of messages to send out for each battery.
+
+    Returns:
+        A tuple of (number of messages sent, time taken to stream the messages).
+    """
+    COMPONENT_METRIC_IDS = [
+        ComponentMetricId.CURRENT_PHASE_1,
+        ComponentMetricId.CURRENT_PHASE_2,
+        ComponentMetricId.CURRENT_PHASE_3,
+    ]
+    NUM_EXPECTED_MESSAGES = (
+        num_evc_chargers * len(COMPONENT_METRIC_IDS) * num_msgs_per_battery
+    )
+
+    mock_grid = MockMicrogrid(
+        grid_side_meter=False, num_values=num_msgs_per_battery, sample_rate_s=0.0
+    )
+
+    mock_grid.add_ev_chargers(num_evc_chargers)
+    mock_grid.start_mock_client(enable_mock_client)
+
+    request_channel = Broadcast[ComponentMetricRequest](
+        "DataSourcingActor Request Channel"
+    )
+
+    channel_registry = ChannelRegistry(name="Microgrid Channel Registry")
+    request_receiver = request_channel.new_receiver(
+        "datasourcing-benchmark", maxsize=(num_evc_chargers * len(COMPONENT_METRIC_IDS))
+    )
+    request_sender = request_channel.new_sender()
+
+    consume_tasks = []
+
+    start_time = perf_counter()
+    samples_sent = 0
+
+    for evc_id in mock_grid.evc_ids:
+        for component_metric_id in COMPONENT_METRIC_IDS:
+            request = ComponentMetricRequest(
+                "current_phase_requests", evc_id, component_metric_id, None
+            )
+
+            recv_channel = channel_registry.new_receiver(request.get_channel_name())
+
+            async def consume(channel):
+                while True:
+                    try:
+                        await channel.ready()
+                        channel.consume()
+                    except ReceiverStoppedError as e:
+                        return
+
+                    nonlocal samples_sent
+                    samples_sent += 1
+
+            await request_sender.send(request)
+            consume_tasks.append(asyncio.create_task(consume(recv_channel)))
+
+    DataSourcingActor(request_receiver, channel_registry)
+
+    await asyncio.gather(*consume_tasks)
+
+    time_taken = perf_counter() - start_time
+
+    await mock_grid.cleanup()
+
+    print(f"Samples Sent: {samples_sent}, time taken: {time_taken}")
+    print(f"Samples per second: {samples_sent / time_taken}")
+    print(
+        f"Expected samples: {NUM_EXPECTED_MESSAGES}, missing: {NUM_EXPECTED_MESSAGES - samples_sent}"
+    )
+    print(
+        f"Missing per EVC: {(NUM_EXPECTED_MESSAGES - samples_sent) / num_evc_chargers}"
+    )
+
+
+if __name__ == "__main__":
+    asyncio.run(benchmark_data_sourcing(300, 100))

--- a/benchmarks/timeseries/benchmark_datasourcing.py
+++ b/benchmarks/timeseries/benchmark_datasourcing.py
@@ -111,4 +111,6 @@ async def benchmark_data_sourcing(
 
 
 if __name__ == "__main__":
-    asyncio.run(benchmark_data_sourcing(300, 100))
+    import sys
+
+    asyncio.run(benchmark_data_sourcing(int(sys.argv[1]), int(sys.argv[2])))

--- a/benchmarks/timeseries/benchmark_datasourcing.py
+++ b/benchmarks/timeseries/benchmark_datasourcing.py
@@ -89,7 +89,7 @@ async def benchmark_data_sourcing(
                     nonlocal samples_sent
                     samples_sent += 1
 
-            await request_sender.send(request)
+            request_sender.send(request)
             consume_tasks.append(asyncio.create_task(consume(recv_channel)))
 
     DataSourcingActor(request_receiver, channel_registry)

--- a/src/frequenz/sdk/actor/_channel_registry.py
+++ b/src/frequenz/sdk/actor/_channel_registry.py
@@ -49,3 +49,15 @@ class ChannelRegistry:
         if key not in self._channels:
             self._channels[key] = Broadcast(f"{self._name}-{key}")
         return self._channels[key].new_receiver()
+
+    async def _close_channel(self, key: str) -> None:
+        """Close a channel with the given key.
+
+        This method is private and should only be used in special cases.
+
+        Args:
+            key: A key to identify the channel.
+        """
+        if key in self._channels:
+            await self._channels[key].close()
+            del self._channels[key]

--- a/src/frequenz/sdk/actor/_config_managing.py
+++ b/src/frequenz/sdk/actor/_config_managing.py
@@ -67,7 +67,7 @@ class ConfigManagingActor:
         """Send config file using a broadcast channel."""
         conf_vars = self._read_config()
         config = Config(conf_vars)
-        await self._output.send(config)
+        self._output.send(config)
 
     async def run(self) -> None:
         """Watch config file and update when modified.

--- a/src/frequenz/sdk/actor/_data_sourcing/microgrid_api_source.py
+++ b/src/frequenz/sdk/actor/_data_sourcing/microgrid_api_source.py
@@ -345,15 +345,10 @@ class MicrogridApiSource:
             )
         api_data_receiver = self.comp_data_receivers[comp_id]
 
-        def process_msg(data: Any) -> None:
-            tasks = []
+        async for data in api_data_receiver:
             for extractor, senders in stream_senders:
                 for sender in senders:
-                    tasks.append(sender.send(Sample(data.timestamp, extractor(data))))
-            asyncio.gather(*tasks)
-
-        async for data in api_data_receiver:
-            process_msg(data)
+                    await sender.send(Sample(data.timestamp, extractor(data)))
 
     async def _update_streams(
         self,

--- a/src/frequenz/sdk/actor/_data_sourcing/microgrid_api_source.py
+++ b/src/frequenz/sdk/actor/_data_sourcing/microgrid_api_source.py
@@ -348,7 +348,7 @@ class MicrogridApiSource:
         async for data in api_data_receiver:
             for extractor, senders in stream_senders:
                 for sender in senders:
-                    await sender.send(Sample(data.timestamp, extractor(data)))
+                    sender.send(Sample(data.timestamp, extractor(data)))
 
         await asyncio.gather(
             *[

--- a/src/frequenz/sdk/actor/_decorator.py
+++ b/src/frequenz/sdk/actor/_decorator.py
@@ -94,9 +94,9 @@ def actor(cls: Type[Any]) -> Type[Any]:
             select = Select(channel_1=self._recv1, channel_2=self._recv2)
             while await select.ready():
                 if msg := select.channel_1:
-                    await self._output.send(msg.inner)
+                    self._output.send(msg.inner)
                 elif msg := select.channel_2:
-                    await self._output.send(msg.inner)
+                    self._output.send(msg.inner)
 
 
     input_chan_1: Broadcast[bool] = Broadcast("input_chan_1")
@@ -112,7 +112,7 @@ def actor(cls: Type[Any]) -> Type[Any]:
     )
     echo_rx = echo_chan.new_receiver()
 
-    await input_chan_2.new_sender().send(True)
+    input_chan_2.new_sender().send(True)
     msg = await echo_rx.receive()
     ```
 
@@ -132,7 +132,7 @@ def actor(cls: Type[Any]) -> Type[Any]:
 
         async def run(self) -> None:
             async for msg in self._recv:
-                await self._output.send(msg)
+                self._output.send(msg)
 
 
     @actor
@@ -149,7 +149,7 @@ def actor(cls: Type[Any]) -> Type[Any]:
 
         async def run(self) -> None:
             async for msg in self._recv:
-                await self._output.send(msg)
+                self._output.send(msg)
 
 
     input_chan: Broadcast[bool] = Broadcast("Input to A1")
@@ -168,7 +168,7 @@ def actor(cls: Type[Any]) -> Type[Any]:
 
     a2_rx = a2_chan.new_receiver()
 
-    await input_chan.new_sender().send(True)
+    input_chan.new_sender().send(True)
     msg = await a2_rx.receive()
     ```
 

--- a/src/frequenz/sdk/actor/_resampling.py
+++ b/src/frequenz/sdk/actor/_resampling.py
@@ -73,7 +73,7 @@ class ComponentMetricsResamplingActor:
             request, namespace=request.namespace + ":Source"
         )
         data_source_channel_name = data_source_request.get_channel_name()
-        await self._data_sourcing_request_sender.send(data_source_request)
+        self._data_sourcing_request_sender.send(data_source_request)
         receiver = self._channel_registry.new_receiver(data_source_channel_name)
 
         # This is a temporary hack until the Sender implementation uses
@@ -81,8 +81,7 @@ class ComponentMetricsResamplingActor:
         sender = self._channel_registry.new_sender(request.get_channel_name())
 
         async def sink_adapter(sample: Sample) -> None:
-            if not await sender.send(sample):
-                raise RuntimeError(f"Error while sending with sender {sender}", sender)
+            sender.send(sample)
 
         self._resampler.add_timeseries(request_channel_name, receiver, sink_adapter)
 

--- a/src/frequenz/sdk/actor/power_distributing/_battery_pool_status.py
+++ b/src/frequenz/sdk/actor/power_distributing/_battery_pool_status.py
@@ -189,7 +189,7 @@ class BatteryPoolStatus:
             succeed_batteries: Batteries that succeed request
             failed_batteries: Batteries that failed request
         """
-        await self._set_power_result_sender.send(
+        self._set_power_result_sender.send(
             SetPowerResult(succeed_batteries, failed_batteries)
         )
 

--- a/src/frequenz/sdk/actor/power_distributing/_battery_status.py
+++ b/src/frequenz/sdk/actor/power_distributing/_battery_status.py
@@ -258,7 +258,7 @@ class BatteryStatusTracker:
                     new_status = self._update_status(self._select)
 
                     if new_status is not None:
-                        await status_sender.send(new_status)
+                        status_sender.send(new_status)
 
             except Exception as err:  # pylint: disable=broad-except
                 _logger.exception("BatteryStatusTracker crashed with error: %s", err)

--- a/src/frequenz/sdk/microgrid/client/_client.py
+++ b/src/frequenz/sdk/microgrid/client/_client.py
@@ -342,7 +342,7 @@ class MicrogridGrpcClient(MicrogridApiClient):
                 # grpc.aio is missing types and mypy thinks this is not
                 # async iterable, but it is
                 async for msg in call:  # type: ignore[attr-defined]
-                    await sender.send(transform(msg))
+                    sender.send(transform(msg))
             except grpc.aio.AioRpcError as err:
                 api_details = f"Microgrid API: {self.target}."
                 logger.exception(

--- a/src/frequenz/sdk/timeseries/_formula_engine/_formula_engine.py
+++ b/src/frequenz/sdk/timeseries/_formula_engine/_formula_engine.py
@@ -197,7 +197,7 @@ class FormulaEngine:
                     "Formula application failed: %s. Error: %s", self._name, err
                 )
             else:
-                await sender.send(msg)
+                sender.send(msg)
 
     async def _stop(self) -> None:
         """Stop a running formula engine."""
@@ -265,7 +265,7 @@ class FormulaEngine3Phase:
                 logger.exception("FormulaEngine task cancelled: %s", self._name)
                 break
             else:
-                await sender.send(msg)
+                sender.send(msg)
 
     async def _stop(self) -> None:
         """Stop a running formula engine."""

--- a/src/frequenz/sdk/timeseries/_formula_engine/_resampled_formula_builder.py
+++ b/src/frequenz/sdk/timeseries/_formula_engine/_resampled_formula_builder.py
@@ -55,7 +55,7 @@ class ResampledFormulaBuilder(FormulaBuilder):
             A receiver to stream resampled data for the given component id.
         """
         request = ComponentMetricRequest(self._namespace, component_id, metric_id, None)
-        await self._resampler_subscription_sender.send(request)
+        self._resampler_subscription_sender.send(request)
         return self._channel_registry.new_receiver(request.get_channel_name())
 
     async def push_component_metric(

--- a/src/frequenz/sdk/timeseries/ev_charger_pool/_state_tracker.py
+++ b/src/frequenz/sdk/timeseries/ev_charger_pool/_state_tracker.py
@@ -154,10 +154,10 @@ class StateTracker:
         }
         self._merged_stream = Merge(*streams)
         sender = self._channel.new_sender()
-        await sender.send(self._get())
+        sender.send(self._get())
         async for data in self._merged_stream:
             if updated_states := self._update(data):
-                await sender.send(updated_states)
+                sender.send(updated_states)
 
     def new_receiver(self) -> Receiver[EVChargerPoolStates]:
         """Return a receiver that streams ev charger states.

--- a/tests/actor/test_battery_pool_status.py
+++ b/tests/actor/test_battery_pool_status.py
@@ -59,26 +59,20 @@ class TestBatteryPoolStatus:
 
         batteries_list = list(batteries)
 
-        assert await mock_microgrid.send(battery_data(component_id=batteries_list[0]))
+        mock_microgrid.send(battery_data(component_id=batteries_list[0]))
         await asyncio.sleep(0.1)
         assert batteries_status.get_working_batteries(batteries) == expected_working
 
         expected_working.add(batteries_list[0])
-        assert await mock_microgrid.send(
-            inverter_data(component_id=batteries_list[0] - 1)
-        )
+        mock_microgrid.send(inverter_data(component_id=batteries_list[0] - 1))
         await asyncio.sleep(0.1)
         assert batteries_status.get_working_batteries(batteries) == expected_working
 
-        assert await mock_microgrid.send(
-            inverter_data(component_id=batteries_list[1] - 1)
-        )
-        assert await mock_microgrid.send(battery_data(component_id=batteries_list[1]))
+        mock_microgrid.send(inverter_data(component_id=batteries_list[1] - 1))
+        mock_microgrid.send(battery_data(component_id=batteries_list[1]))
 
-        assert await mock_microgrid.send(
-            inverter_data(component_id=batteries_list[2] - 1)
-        )
-        assert await mock_microgrid.send(battery_data(component_id=batteries_list[2]))
+        mock_microgrid.send(inverter_data(component_id=batteries_list[2] - 1))
+        mock_microgrid.send(battery_data(component_id=batteries_list[2]))
 
         expected_working = set(batteries_list)
         await asyncio.sleep(0.1)

--- a/tests/actor/test_battery_status.py
+++ b/tests/actor/test_battery_status.py
@@ -654,12 +654,12 @@ class TestBatteryStatus:
         await asyncio.sleep(0.01)
 
         with time_machine.travel("2022-01-01 00:00 UTC", tick=False) as time:
-            assert await mock_microgrid.send(inverter_data(component_id=INVERTER_ID))
-            assert await mock_microgrid.send(battery_data(component_id=BATTERY_ID))
+            mock_microgrid.send(inverter_data(component_id=INVERTER_ID))
+            mock_microgrid.send(battery_data(component_id=BATTERY_ID))
             status = await asyncio.wait_for(status_receiver.receive(), timeout=0.1)
             assert status is Status.WORKING
 
-            assert await set_power_result_sender.send(
+            set_power_result_sender.send(
                 SetPowerResult(succeed={}, failed={BATTERY_ID})
             )
             status = await asyncio.wait_for(status_receiver.receive(), timeout=0.1)
@@ -667,11 +667,11 @@ class TestBatteryStatus:
 
             time.shift(2)
 
-            assert await mock_microgrid.send(battery_data(component_id=BATTERY_ID))
+            mock_microgrid.send(battery_data(component_id=BATTERY_ID))
             status = await asyncio.wait_for(status_receiver.receive(), timeout=0.1)
             assert status is Status.WORKING
 
-            assert await mock_microgrid.send(
+            mock_microgrid.send(
                 inverter_data(
                     component_id=INVERTER_ID,
                     timestamp=datetime.now(tz=timezone.utc) - timedelta(seconds=7),
@@ -680,13 +680,13 @@ class TestBatteryStatus:
             status = await asyncio.wait_for(status_receiver.receive(), timeout=0.1)
             assert status is Status.NOT_WORKING
 
-            assert await set_power_result_sender.send(
+            set_power_result_sender.send(
                 SetPowerResult(succeed={}, failed={BATTERY_ID})
             )
             await asyncio.sleep(0.3)
             assert len(status_receiver) == 0
 
-            assert await mock_microgrid.send(inverter_data(component_id=INVERTER_ID))
+            mock_microgrid.send(inverter_data(component_id=INVERTER_ID))
             status = await asyncio.wait_for(status_receiver.receive(), timeout=0.1)
             assert status is Status.WORKING
 

--- a/tests/actor/test_channel_registry.py
+++ b/tests/actor/test_channel_registry.py
@@ -16,8 +16,8 @@ async def test_channel_registry() -> None:
     sender21 = reg.new_sender("21-hello")
     receiver21 = reg.new_receiver("21-hello")
 
-    await sender20.send(30)
-    await sender21.send(31)
+    sender20.send(30)
+    sender21.send(31)
 
     rcvd = await receiver21.receive()
     assert rcvd == 31

--- a/tests/actor/test_data_sourcing.py
+++ b/tests/actor/test_data_sourcing.py
@@ -66,19 +66,19 @@ class TestDataSourcingActor:
         active_power_recv = registry.new_receiver(
             active_power_request.get_channel_name()
         )
-        await req_sender.send(active_power_request)
+        req_sender.send(active_power_request)
 
         soc_request = ComponentMetricRequest(
             "test-namespace", 9, ComponentMetricId.SOC, None
         )
         soc_recv = registry.new_receiver(soc_request.get_channel_name())
-        await req_sender.send(soc_request)
+        req_sender.send(soc_request)
 
         soc2_request = ComponentMetricRequest(
             "test-namespace", 9, ComponentMetricId.SOC, None
         )
         soc2_recv = registry.new_receiver(soc2_request.get_channel_name())
-        await req_sender.send(soc2_request)
+        req_sender.send(soc2_request)
 
         for _ in range(3):
             sample = await soc_recv.receive()

--- a/tests/actor/test_decorator.py
+++ b/tests/actor/test_decorator.py
@@ -65,9 +65,9 @@ class EchoActor:
         select = Select(channel_1=self._recv1, channel_2=self._recv2)
         while await select.ready():
             if msg := select.channel_1:
-                await self._output.send(msg.inner)
+                self._output.send(msg.inner)
             elif msg := select.channel_2:
-                await self._output.send(msg.inner)
+                self._output.send(msg.inner)
 
 
 async def test_basic_actor() -> None:
@@ -87,12 +87,12 @@ async def test_basic_actor() -> None:
 
     echo_rx = echo_chan.new_receiver()
 
-    await input_chan_1.new_sender().send(True)
+    input_chan_1.new_sender().send(True)
 
     msg = await echo_rx.receive()
     assert msg is True
 
-    await input_chan_2.new_sender().send(False)
+    input_chan_2.new_sender().send(False)
 
     msg = await echo_rx.receive()
     assert msg is False
@@ -110,6 +110,6 @@ async def test_actor_does_not_restart() -> None:
         channel.new_receiver(),
     )
 
-    await channel.new_sender().send(1)
+    channel.new_sender().send(1)
     # pylint: disable=no-member
     await _faulty_actor.join()  # type: ignore

--- a/tests/actor/test_power_distributing.py
+++ b/tests/actor/test_power_distributing.py
@@ -111,7 +111,7 @@ class TestPowerDistributingActor:
 
         graph = microgrid.component_graph
         for battery in graph.components(component_category={ComponentCategory.BATTERY}):
-            assert await microgrid.send(
+            microgrid.send(
                 battery_msg(
                     battery.component_id,
                     capacity=Metric(98000),
@@ -122,7 +122,7 @@ class TestPowerDistributingActor:
 
         inverters = graph.components(component_category={ComponentCategory.INVERTER})
         for inverter in inverters:
-            assert await microgrid.send(
+            microgrid.send(
                 inverter_msg(
                     inverter.component_id,
                     power=Bound(-500, 500),
@@ -154,7 +154,7 @@ class TestPowerDistributingActor:
         distributor = PowerDistributingActor({"user1": channel.service_handle})
 
         client_handle = channel.client_handle
-        await client_handle.send(request)
+        client_handle.send(request)
 
         done, pending = await asyncio.wait(
             [asyncio.create_task(client_handle.receive())],
@@ -194,20 +194,18 @@ class TestPowerDistributingActor:
         distributor = PowerDistributingActor(service_channels)
 
         user1_handle = channel1.client_handle
-        task1 = user1_handle.send(
+        user1_handle.send(
             Request(
                 power=1200, batteries={106, 206}, request_timeout_sec=SAFETY_TIMEOUT
             )
         )
 
         user2_handle = channel2.client_handle
-        task2 = user2_handle.send(
+        user2_handle.send(
             Request(
                 power=1300, batteries={106, 206}, request_timeout_sec=SAFETY_TIMEOUT
             )
         )
-
-        await asyncio.gather(*[task1, task2])
 
         done, pending = await asyncio.wait(
             [
@@ -250,7 +248,7 @@ class TestPowerDistributingActor:
         distributor = PowerDistributingActor(service_channels)
 
         user1_handle = channel1.client_handle
-        await user1_handle.send(request)
+        user1_handle.send(request)
 
         done, _ = await asyncio.wait(
             [asyncio.create_task(user1_handle.receive())],
@@ -293,27 +291,25 @@ class TestPowerDistributingActor:
         distributor = PowerDistributingActor(service_channels)
 
         user1_handle = channel1.client_handle
-        task1 = user1_handle.send(
+        user1_handle.send(
             Request(
                 power=1200, batteries={106, 206}, request_timeout_sec=SAFETY_TIMEOUT
             )
         )
 
         user2_handle = channel2.client_handle
-        task2 = user2_handle.send(
+        user2_handle.send(
             Request(
                 power=1200, batteries={106, 306}, request_timeout_sec=SAFETY_TIMEOUT
             )
         )
 
         user3_handle = channel3.client_handle
-        task3 = user3_handle.send(
+        user3_handle.send(
             Request(
                 power=1200, batteries={106, 206}, request_timeout_sec=SAFETY_TIMEOUT
             )
         )
-
-        await asyncio.gather(*[task1, task2, task3])
 
         done, _ = await asyncio.wait(
             [
@@ -370,7 +366,7 @@ class TestPowerDistributingActor:
         distributor = PowerDistributingActor(service_channels)
 
         user1_handle = channel1.client_handle
-        await user1_handle.send(request)
+        user1_handle.send(request)
 
         done, pending = await asyncio.wait(
             [asyncio.create_task(user1_handle.receive())],
@@ -417,7 +413,7 @@ class TestPowerDistributingActor:
         distributor = PowerDistributingActor(service_channels)
 
         user1_handle = channel1.client_handle
-        await user1_handle.send(request)
+        user1_handle.send(request)
 
         done, pending = await asyncio.wait(
             [asyncio.create_task(user1_handle.receive())],
@@ -464,7 +460,7 @@ class TestPowerDistributingActor:
         distributor = PowerDistributingActor(service_channels)
 
         user1_handle = channel1.client_handle
-        await user1_handle.send(request)
+        user1_handle.send(request)
 
         done, pending = await asyncio.wait(
             [asyncio.create_task(user1_handle.receive())],
@@ -503,7 +499,7 @@ class TestPowerDistributingActor:
         distributor = PowerDistributingActor({"user1": channel.service_handle})
 
         client_handle = channel.client_handle
-        await client_handle.send(request)
+        client_handle.send(request)
 
         done, pending = await asyncio.wait(
             [asyncio.create_task(client_handle.receive())],

--- a/tests/actor/test_resampling.py
+++ b/tests/actor/test_resampling.py
@@ -60,7 +60,7 @@ async def _assert_resampling_works(
 
     fake_time.shift(0.1)
     sample = Sample(_now(), 3)  # ts = 0.3s
-    await timeseries_sender.send(sample)
+    timeseries_sender.send(sample)
 
     fake_time.shift(0.1)
     new_sample = await timeseries_receiver.receive()  # At 0.4s (timer)
@@ -71,7 +71,7 @@ async def _assert_resampling_works(
 
     fake_time.shift(0.05)
     sample = Sample(_now(), 4)  # ts = 0.45s
-    await timeseries_sender.send(sample)
+    timeseries_sender.send(sample)
     fake_time.shift(0.15)
     new_sample = await timeseries_receiver.receive()  # At 0.6s (timer)
     assert new_sample is not None
@@ -80,12 +80,12 @@ async def _assert_resampling_works(
     assert new_sample.timestamp == _now()
 
     fake_time.shift(0.05)
-    await timeseries_sender.send(Sample(_now(), 8))  # ts = 0.65s
+    timeseries_sender.send(Sample(_now(), 8))  # ts = 0.65s
     fake_time.shift(0.05)
-    await timeseries_sender.send(Sample(_now(), 1))  # ts = 0.7s
+    timeseries_sender.send(Sample(_now(), 1))  # ts = 0.7s
     fake_time.shift(0.05)
     sample = Sample(_now(), 9)  # ts = 0.75s
-    await timeseries_sender.send(sample)
+    timeseries_sender.send(sample)
     fake_time.shift(0.05)
     new_sample = await timeseries_receiver.receive()  # At 0.8s (timer)
     assert new_sample is not None
@@ -137,7 +137,7 @@ async def test_single_request(
         start_time=None,
     )
 
-    await resampling_req_sender.send(subs_req)
+    resampling_req_sender.send(subs_req)
     data_source_req = await data_source_req_recv.receive()
     assert data_source_req is not None
     assert data_source_req == dataclasses.replace(
@@ -183,11 +183,11 @@ async def test_duplicate_request(
         start_time=None,
     )
 
-    await resampling_req_sender.send(subs_req)
+    resampling_req_sender.send(subs_req)
     data_source_req = await data_source_req_recv.receive()
 
     # Send duplicate request
-    await resampling_req_sender.send(subs_req)
+    resampling_req_sender.send(subs_req)
     with pytest.raises(asyncio.TimeoutError):
         await asyncio.wait_for(data_source_req_recv.receive(), timeout=0.1)
 

--- a/tests/timeseries/mock_microgrid.py
+++ b/tests/timeseries/mock_microgrid.py
@@ -143,9 +143,9 @@ class MockMicrogrid:  # pylint: disable=too-many-instance-attributes
             # for inverters with component_id > 100, send only half the messages.
             if comp_id % 10 == self.inverter_id_suffix:
                 if comp_id < 100 or value <= 5:
-                    await self._microgrid.send(make_comp_data(val_to_send, timestamp))
+                    self._microgrid.send(make_comp_data(val_to_send, timestamp))
             else:
-                await self._microgrid.send(make_comp_data(val_to_send, timestamp))
+                self._microgrid.send(make_comp_data(val_to_send, timestamp))
             await asyncio.sleep(self._sample_rate_s)
 
         await self._microgrid.close_channel(comp_id)

--- a/tests/timeseries/mock_microgrid.py
+++ b/tests/timeseries/mock_microgrid.py
@@ -148,6 +148,8 @@ class MockMicrogrid:  # pylint: disable=too-many-instance-attributes
                 await self._microgrid.send(make_comp_data(val_to_send, timestamp))
             await asyncio.sleep(self._sample_rate_s)
 
+        await self._microgrid.close_channel(comp_id)
+
     def _start_meter_streaming(self, meter_id: int) -> None:
         self._streaming_coros.append(
             self._comp_data_send_task(

--- a/tests/timeseries/test_formula_engine.py
+++ b/tests/timeseries/test_formula_engine.py
@@ -80,14 +80,9 @@ class TestFormulaEngine:
         tests_passed = 0
         for io_pair in io_pairs:
             io_input, io_output = io_pair
-            assert all(
-                await asyncio.gather(
-                    *[
-                        chan.new_sender().send(Sample(now, value))
-                        for chan, value in zip(channels.values(), io_input)
-                    ]
-                )
-            )
+            for chan, value in zip(channels.values(), io_input):
+                chan.new_sender().send(Sample(now, value))
+
             next_val = (
                 await engine._evaluator.apply()  # pylint: disable=protected-access
             )
@@ -339,14 +334,8 @@ class TestFormulaChannel:
         tests_passed = 0
         for io_pair in io_pairs:
             io_input, io_output = io_pair
-            assert all(
-                await asyncio.gather(
-                    *[
-                        chan.new_sender().send(Sample(now, value))
-                        for chan, value in zip(channels, io_input)
-                    ]
-                )
-            )
+            for chan, value in zip(channels, io_input):
+                chan.new_sender().send(Sample(now, value))
             next_val = await result_chan.receive()
             assert next_val.value == io_output
             tests_passed += 1
@@ -576,14 +565,8 @@ class TestFormulaAverager:
         tests_passed = 0
         for io_pair in io_pairs:
             io_input, io_output = io_pair
-            assert all(
-                await asyncio.gather(
-                    *[
-                        chan.new_sender().send(Sample(now, value))
-                        for chan, value in zip(channels.values(), io_input)
-                    ]
-                )
-            )
+            for chan, value in zip(channels.values(), io_input):
+                chan.new_sender().send(Sample(now, value))
             next_val = (
                 await engine._evaluator.apply()  # pylint: disable=protected-access
             )

--- a/tests/timeseries/test_moving_window.py
+++ b/tests/timeseries/test_moving_window.py
@@ -26,7 +26,7 @@ async def push_lm_data(sender: Sender[Sample], test_seq: Sequence[float]) -> Non
     start_ts: datetime = datetime(2023, 1, 1)
     for i, j in zip(test_seq, range(0, len(test_seq))):
         timestamp = start_ts + timedelta(seconds=j)
-        await sender.send(Sample(timestamp, float(i)))
+        sender.send(Sample(timestamp, float(i)))
 
     await asyncio.sleep(0.0)
 

--- a/tests/utils/mock_microgrid.py
+++ b/tests/utils/mock_microgrid.py
@@ -49,6 +49,12 @@ class MockMicrogridClient:
         meter_channels = self._create_meter_channels()
         ev_charger_channels = self._create_ev_charger_channels()
 
+        self._all_channels: Dict[int, Broadcast[Any]] = {}
+        self._all_channels.update(bat_channels)
+        self._all_channels.update(inv_channels)
+        self._all_channels.update(meter_channels)
+        self._all_channels.update(ev_charger_channels)
+
         mock_api = self._create_mock_api(
             bat_channels, inv_channels, meter_channels, ev_charger_channels
         )
@@ -127,6 +133,15 @@ class MockMicrogridClient:
             return await self._ev_charger_data_senders[cid].send(data)
 
         raise RuntimeError(f"{type(data)} is not supported in MockMicrogridClient.")
+
+    async def close_channel(self, cid: int) -> None:
+        """Close channel for given component id.
+
+        Args:
+            cid: Component id
+        """
+        if cid in self._all_channels:
+            await self._all_channels[cid].close()
 
     def _create_battery_channels(self) -> Dict[int, Broadcast[BatteryData]]:
         """Create channels for the batteries.

--- a/tests/utils/mock_microgrid.py
+++ b/tests/utils/mock_microgrid.py
@@ -55,7 +55,7 @@ class MockMicrogridClient:
         self._all_channels.update(meter_channels)
         self._all_channels.update(ev_charger_channels)
 
-        mock_api = self._create_mock_api(
+        self.api_client = mock_api = self._create_mock_api(
             bat_channels, inv_channels, meter_channels, ev_charger_channels
         )
         kwargs: Dict[str, Any] = {
@@ -110,7 +110,7 @@ class MockMicrogridClient:
         """
         return self._component_graph
 
-    async def send(self, data: ComponentData) -> bool:
+    def send(self, data: ComponentData) -> bool:
         """Send component data using channel.
 
         This simulates component sending data. Right now only battery and inverter
@@ -124,13 +124,13 @@ class MockMicrogridClient:
         """
         cid = data.component_id
         if isinstance(data, BatteryData):
-            return await self._battery_data_senders[cid].send(data)
+            return self._battery_data_senders[cid].send(data)
         if isinstance(data, InverterData):
-            return await self._inverter_data_senders[cid].send(data)
+            return self._inverter_data_senders[cid].send(data)
         if isinstance(data, MeterData):
-            return await self._meter_data_senders[cid].send(data)
+            return self._meter_data_senders[cid].send(data)
         if isinstance(data, EVChargerData):
-            return await self._ev_charger_data_senders[cid].send(data)
+            return self._ev_charger_data_senders[cid].send(data)
 
         raise RuntimeError(f"{type(data)} is not supported in MockMicrogridClient.")
 


### PR DESCRIPTION
This PR tries together with https://github.com/frequenz-floss/frequenz-channels-python/pull/75 to make `sender.send()` synchronous.

It contains a few commits of my active PRs, but the main part are the changes in all the SDK to make the tests and existing code work when `send()` is synchronous. 
See the last 2 commits.

Motivation for this: Code **simplicity** and **speed**. In my benchmark, it changed the throughput from `30k/s` to `80k/s`.
You should be able to run the benchmark when you have checked out this branch using

`PYTHONPATH=. python benchmarks/timeseries/benchmark_datasourcing.py 15 1000 # 15 evcs, 1000 msgs per bat.`

This is to be seen as an experiment/prototype PR to test this idea. Feel free to check it out and find errors.
Locally, with the correct channels changes, all tests succeed for me.

**Note that you need the channel changes as well for this to work**
