### PR TITLE
Fix flaky LogicalMeter test_soc

### DIFF
--- a/tests/timeseries/mock_microgrid.py
+++ b/tests/timeseries/mock_microgrid.py
@@ -75,6 +75,7 @@ class MockMicrogrid:  # pylint: disable=too-many-instance-attributes
         self.battery_ids: list[int] = []
         self.evc_ids: list[int] = []
         self.meter_ids: list[int] = [4]
+        self.bat_inv_map: dict[int, int] = {}
 
         self.evc_component_states: dict[int, EVChargerComponentState] = {}
         self.evc_cable_states: dict[int, EVChargerCableState] = {}
@@ -179,6 +180,7 @@ class MockMicrogrid:  # pylint: disable=too-many-instance-attributes
             self.meter_ids.append(meter_id)
             self.battery_inverter_ids.append(inv_id)
             self.battery_ids.append(bat_id)
+            self.bat_inv_map[bat_id] = inv_id
 
             self._components.add(
                 Component(


### PR DESCRIPTION
In MockMicrogrid it is hardcoded that iverter with id > 100 send first 5 messages and then stop sending.
Tests assumed we have control over when the components starts sending data and in what order.
But that is not true in async.
Also inverter messages were not synchronized with rest of the data.