### PR TITLE
Make resampling window size constant

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -16,4 +16,4 @@
 
 ## Bug Fixes
 
-<!-- Here goes notable bug fixes that are worth a special mention or explanation -->
+* The resampler now correctly produces resampling windows of exact *resampling period* size, which only include samples emitted during the resampling window (see #170)

--- a/src/frequenz/sdk/timeseries/_resampling.py
+++ b/src/frequenz/sdk/timeseries/_resampling.py
@@ -661,14 +661,15 @@ class _ResamplingHelper:
         # We need to pass a dummy Sample to bisect because it only support
         # specifying a key extraction function in Python 3.10, so we need to
         # compare samples at the moment.
-        cut_index = bisect(self._buffer, Sample(minimum_relevant_timestamp, None))
+        min_index = bisect(self._buffer, Sample(minimum_relevant_timestamp, None))
+        max_index = bisect(self._buffer, Sample(timestamp, None))
         # Using itertools for slicing doesn't look very efficient, but
         # experiements with a custom (ring) buffer that can slice showed that
         # it is not that bad. See:
         # https://github.com/frequenz-floss/frequenz-sdk-python/pull/130
         # So if we need more performance beyond this point, we probably need to
         # resort to some C (or similar) implementation.
-        relevant_samples = list(itertools.islice(self._buffer, cut_index, None))
+        relevant_samples = list(itertools.islice(self._buffer, min_index, max_index))
         value = (
             conf.resampling_function(relevant_samples, conf, props)
             if relevant_samples

--- a/src/frequenz/sdk/timeseries/_resampling.py
+++ b/src/frequenz/sdk/timeseries/_resampling.py
@@ -346,8 +346,13 @@ class Resampler:
             config: The configuration for the resampler.
         """
         self._config = config
+        """The configuration for this resampler."""
+
         self._resamplers: dict[Source, _StreamingHelper] = {}
+        """A mapping between sources and the streaming helper handling that source."""
+
         self._timer: Timer = Timer(config.resampling_period_s)
+        """The timer to trigger the next resampling."""
 
     @property
     def config(self) -> ResamplerConfig:

--- a/tests/timeseries/test_resampling.py
+++ b/tests/timeseries/test_resampling.py
@@ -156,16 +156,14 @@ async def test_helper_buffer_too_big(
 
     _ = helper.resample(datetime.now(timezone.utc))
     # Ignore errors produced by wrongly finalized gRPC server in unrelated tests
-    assert _filter_logs(
+    assert (
+        "frequenz.sdk.timeseries._resampling",
+        logging.ERROR,
+        f"The new buffer length ({DEFAULT_BUFFER_LEN_MAX + 1}) "
+        f"for timeseries test is too big, using {DEFAULT_BUFFER_LEN_MAX} instead",
+    ) in _filter_logs(
         caplog.record_tuples,
-    ) == [
-        (
-            "frequenz.sdk.timeseries._resampling",
-            logging.ERROR,
-            f"The new buffer length ({DEFAULT_BUFFER_LEN_MAX + 1}) "
-            f"for timeseries test is too big, using {DEFAULT_BUFFER_LEN_MAX} instead",
-        )
-    ]
+    )
     # pylint: disable=protected-access
     assert helper._buffer.maxlen == DEFAULT_BUFFER_LEN_MAX
 

--- a/tests/timeseries/test_resampling.py
+++ b/tests/timeseries/test_resampling.py
@@ -115,10 +115,7 @@ async def test_resampler_config_len_warn(
     )
     assert config.initial_buffer_len == init_len
     # Ignore errors produced by wrongly finalized gRPC server in unrelated tests
-    assert _filter_logs(
-        caplog.record_tuples,
-        logger_name="frequenz.sdk.timeseries._resampling",
-    ) == [
+    assert _filter_logs(caplog.record_tuples) == [
         (
             "frequenz.sdk.timeseries._resampling",
             logging.WARNING,
@@ -161,7 +158,6 @@ async def test_helper_buffer_too_big(
     # Ignore errors produced by wrongly finalized gRPC server in unrelated tests
     assert _filter_logs(
         caplog.record_tuples,
-        logger_name="frequenz.sdk.timeseries._resampling",
     ) == [
         (
             "frequenz.sdk.timeseries._resampling",
@@ -890,7 +886,7 @@ def _get_buffer_len(resampler: Resampler, source_recvr: Source) -> int:
 def _filter_logs(
     record_tuples: list[tuple[str, int, str]],
     *,
-    logger_name: str,
+    logger_name: str = "frequenz.sdk.timeseries._resampling",
     logger_level: int | None = None,
 ) -> list[tuple[str, int, str]]:
     return [

--- a/tests/timeseries/test_resampling.py
+++ b/tests/timeseries/test_resampling.py
@@ -174,6 +174,88 @@ async def test_helper_buffer_too_big(
     assert helper._buffer.maxlen == DEFAULT_BUFFER_LEN_MAX
 
 
+async def test_resampling_window_size_is_constant(
+    fake_time: time_machine.Coordinates, source_chan: Broadcast[Sample]
+) -> None:
+    """Test resampling window size is consistent."""
+    timestamp = datetime.now(timezone.utc)
+
+    resampling_period_s = 2
+    expected_resampled_value = 42.0
+
+    resampling_fun_mock = MagicMock(
+        spec=ResamplingFunction, return_value=expected_resampled_value
+    )
+    config = ResamplerConfig(
+        resampling_period_s=resampling_period_s,
+        max_data_age_in_periods=1.0,
+        resampling_function=resampling_fun_mock,
+        initial_buffer_len=4,
+    )
+    resampler = Resampler(config)
+
+    source_receiver = source_chan.new_receiver()
+    source_sender = source_chan.new_sender()
+
+    sink_mock = AsyncMock(spec=Sink, return_value=True)
+
+    resampler.add_timeseries("test", source_receiver, sink_mock)
+    source_props = resampler.get_source_properties(source_receiver)
+
+    # Test timeline
+    #
+    # t(s)   0          1          2   2.5    3          4
+    #        |----------|----------R----|-----|----------R-----> (no more samples)
+    # value  5.0       12.0            2.0   4.0        5.0
+    #
+    # R = resampling is done
+
+    # Send a few samples and run a resample tick, advancing the fake time by one period
+    sample0s = Sample(timestamp, value=5.0)
+    sample1s = Sample(timestamp + timedelta(seconds=1), value=12.0)
+    await source_sender.send(sample0s)
+    await source_sender.send(sample1s)
+    fake_time.shift(resampling_period_s)  # timer matches resampling period
+    await resampler.resample(one_shot=True)
+
+    assert datetime.now(timezone.utc).timestamp() == 2
+    sink_mock.assert_called_once_with(
+        Sample(
+            timestamp + timedelta(seconds=resampling_period_s), expected_resampled_value
+        )
+    )
+    resampling_fun_mock.assert_called_once_with(
+        a_sequence(sample1s), config, source_props
+    )
+    sink_mock.reset_mock()
+    resampling_fun_mock.reset_mock()
+
+    # Second resampling run
+    sample2_5s = Sample(timestamp + timedelta(seconds=2.5), value=2.0)
+    sample3s = Sample(timestamp + timedelta(seconds=3), value=4.0)
+    sample4s = Sample(timestamp + timedelta(seconds=4), value=5.0)
+    await source_sender.send(sample2_5s)
+    await source_sender.send(sample3s)
+    await source_sender.send(sample4s)
+    fake_time.shift(resampling_period_s + 0.5)  # Timer fired with some delay
+    await resampler.resample(one_shot=True)
+
+    assert datetime.now(timezone.utc).timestamp() == 4.5
+    sink_mock.assert_called_once_with(
+        Sample(
+            # But the sample still gets 4s as timestamp, because we are keeping
+            # the window size constant, not dependent on when the timer fired
+            timestamp + timedelta(seconds=resampling_period_s * 2),
+            expected_resampled_value,
+        )
+    )
+    resampling_fun_mock.assert_called_once_with(
+        a_sequence(sample2_5s, sample3s, sample4s), config, source_props
+    )
+    sink_mock.reset_mock()
+    resampling_fun_mock.reset_mock()
+
+
 async def test_resampling_with_one_window(
     fake_time: time_machine.Coordinates, source_chan: Broadcast[Sample]
 ) -> None:

--- a/tests/timeseries/test_resampling.py
+++ b/tests/timeseries/test_resampling.py
@@ -349,6 +349,91 @@ async def test_timer_errors_are_logged(
     resampling_fun_mock.reset_mock()
 
 
+async def test_future_samples_not_included(
+    fake_time: time_machine.Coordinates, source_chan: Broadcast[Sample]
+) -> None:
+    """Test resampling window size is consistent."""
+    timestamp = datetime.now(timezone.utc)
+
+    resampling_period_s = 2
+    expected_resampled_value = 42.0
+
+    resampling_fun_mock = MagicMock(
+        spec=ResamplingFunction, return_value=expected_resampled_value
+    )
+    config = ResamplerConfig(
+        resampling_period_s=resampling_period_s,
+        max_data_age_in_periods=2.0,
+        resampling_function=resampling_fun_mock,
+        initial_buffer_len=4,
+    )
+    resampler = Resampler(config)
+
+    source_receiver = source_chan.new_receiver()
+    source_sender = source_chan.new_sender()
+
+    sink_mock = AsyncMock(spec=Sink, return_value=True)
+
+    resampler.add_timeseries("test", source_receiver, sink_mock)
+    source_props = resampler.get_source_properties(source_receiver)
+
+    # Test timeline
+    #
+    # t(s)   0          1      1.9  2          3          4  4.1 4.2
+    #        |----------|--------|--R----------|----------R--|---|------------>
+    # value  5.0                7.0           4.0            3.0 timer fires
+    #                       (with ts=2.1)
+    #
+    # R = resampling is done
+
+    # Send a few samples and run a resample tick, advancing the fake time by one period
+    sample0s = Sample(timestamp, value=5.0)
+    sample1s = Sample(timestamp + timedelta(seconds=1), value=12.0)
+    sample2_1s = Sample(timestamp + timedelta(seconds=2.1), value=7.0)
+    await source_sender.send(sample0s)
+    await source_sender.send(sample1s)
+    await source_sender.send(sample2_1s)
+    fake_time.shift(resampling_period_s)
+    await resampler.resample(one_shot=True)
+
+    assert datetime.now(timezone.utc).timestamp() == 2
+    sink_mock.assert_called_once_with(
+        Sample(
+            timestamp + timedelta(seconds=resampling_period_s), expected_resampled_value
+        )
+    )
+    resampling_fun_mock.assert_called_once_with(
+        a_sequence(sample0s, sample1s), config, source_props  # sample2_1s is not here
+    )
+    assert source_props == SourceProperties(
+        sampling_start=timestamp, received_samples=3, sampling_period_s=None
+    )
+    assert _get_buffer_len(resampler, source_receiver) == config.initial_buffer_len
+    sink_mock.reset_mock()
+    resampling_fun_mock.reset_mock()
+
+    # Second resampling run
+    sample3s = Sample(timestamp + timedelta(seconds=3), value=4.0)
+    sample4_1s = Sample(timestamp + timedelta(seconds=4.1), value=3.0)
+    await source_sender.send(sample3s)
+    await source_sender.send(sample4_1s)
+    fake_time.shift(resampling_period_s + 0.2)
+    await resampler.resample(one_shot=True)
+
+    assert datetime.now(timezone.utc).timestamp() == 4.2
+    sink_mock.assert_called_once_with(
+        Sample(
+            timestamp + timedelta(seconds=resampling_period_s * 2),
+            expected_resampled_value,
+        )
+    )
+    resampling_fun_mock.assert_called_once_with(
+        a_sequence(sample1s, sample2_1s, sample3s),
+        config,
+        source_props,  # sample4_1s is not here
+    )
+
+
 async def test_resampling_with_one_window(
     fake_time: time_machine.Coordinates, source_chan: Broadcast[Sample]
 ) -> None:


### PR DESCRIPTION
The resampler was using the timer timestamp to do the resampling, but this is wrong because the timer could (and probably always will) fire in the *future* (after the resampling period has passed).

The effect was that samples produced by the resampler were not perfectly spread using an exact resampling period, but they included the error produced by the timer firing

This PR fixes this issue and also fixes another bug found, samples in the future could have been included in a resampling window.  Now we only consider relevant samples that fit to the exact resampling window.

Part of #170.
