### PR TITLE
Fix bug in battery status

### DIFF
--- a/examples/resampling.py
+++ b/examples/resampling.py
@@ -108,6 +108,7 @@ async def run() -> None:  # pylint: disable=too-many-locals
     second_stage_resampler.add_timeseries(average_chan.new_receiver(), _print_sample)
 
     average_sender = average_chan.new_sender()
+
     # Needed until channels Senders raises exceptions on errors
     async def sink_adapter(sample: Sample) -> None:
         assert await average_sender.send(sample)

--- a/noxfile.py
+++ b/noxfile.py
@@ -11,7 +11,7 @@ from typing import List
 
 import nox
 
-FMT_DEPS = ["black", "isort"]
+FMT_DEPS = ["black==22.12.0", "isort==5.11.1"]
 DOCSTRING_DEPS = ["pydocstyle", "darglint"]
 PYTEST_DEPS = [
     "pytest",
@@ -21,7 +21,7 @@ PYTEST_DEPS = [
     "time-machine",
     "async-solipsism",
 ]
-MYPY_DEPS = ["mypy", "pandas-stubs", "grpc-stubs"]
+MYPY_DEPS = ["mypy==0.991", "pandas-stubs", "grpc-stubs"]
 
 
 def _source_file_paths(session: nox.Session) -> List[str]:
@@ -72,7 +72,13 @@ def ci_checks_max(session: nox.Session) -> None:
         session: the nox session.
     """
     session.install(
-        ".[docs]", "pylint", "nox", *PYTEST_DEPS, *FMT_DEPS, *DOCSTRING_DEPS, *MYPY_DEPS
+        ".[docs]",
+        "pylint==2.15.9",
+        "nox",
+        *PYTEST_DEPS,
+        *FMT_DEPS,
+        *DOCSTRING_DEPS,
+        *MYPY_DEPS,
     )
 
     formatting(session, False)
@@ -154,7 +160,7 @@ def pylint(session: nox.Session, install_deps: bool = True) -> None:
     if install_deps:
         # install the package itself as editable, so that it is possible to do
         # fast local tests with `nox -R -e pylint`.
-        session.install("-e", ".[docs]", "pylint", "nox", *PYTEST_DEPS)
+        session.install("-e", ".[docs]", "pylint==2.15.9", "nox", *PYTEST_DEPS)
 
     paths = _source_file_paths(session)
     session.run(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "frequenz-api-microgrid >= 0.11.0, < 0.12.0",
     "frequenz-channels >= 0.11.0, < 0.12.0",
     "google-api-python-client >= 2.71, < 3",
-    "grpcio >= 1.51.1, < 2",
+    "grpcio == 1.51.1",
     "grpcio-tools >= 1.51.1, < 2",
     "networkx >= 2.8, < 3",
     "pandas >= 1.5.2, < 2",

--- a/src/frequenz/sdk/_data_handling/time_series.py
+++ b/src/frequenz/sdk/_data_handling/time_series.py
@@ -478,7 +478,6 @@ class TimeSeriesFormula(Formula, Generic[Value]):
 
             # Symbol metadata is not available, e.g. component category
             if symbol_mapping is None:
-
                 # Component data is available and up to date
                 if cache_lookup_result.entry is not None:
                     kwargs[symbol] = cache_lookup_result.entry.value

--- a/src/frequenz/sdk/actor/_data_sourcing/microgrid_api_source.py
+++ b/src/frequenz/sdk/actor/_data_sourcing/microgrid_api_source.py
@@ -347,7 +347,7 @@ class MicrogridApiSource:
 
         def process_msg(data: Any) -> None:
             tasks = []
-            for (extractor, senders) in stream_senders:
+            for extractor, senders in stream_senders:
                 for sender in senders:
                     tasks.append(sender.send(Sample(data.timestamp, extractor(data))))
             asyncio.gather(*tasks)

--- a/src/frequenz/sdk/microgrid/_battery/_status.py
+++ b/src/frequenz/sdk/microgrid/_battery/_status.py
@@ -61,7 +61,7 @@ class StatusTracker:
         InverterComponentState.COMPONENT_STATE_STANDBY,
         InverterComponentState.COMPONENT_STATE_IDLE,
         InverterComponentState.COMPONENT_STATE_CHARGING,
-        InverterComponentState.COMPONENT_STATE_STANDBY,
+        InverterComponentState.COMPONENT_STATE_DISCHARGING,
     }
 
     def __init__(

--- a/tests/actor/test_power_distributing.py
+++ b/tests/actor/test_power_distributing.py
@@ -386,7 +386,6 @@ class TestPowerDistributingActor(IsolatedAsyncioTestCase):
         with mock.patch("asyncio.sleep", new_callable=AsyncMock) and mock.patch(
             "frequenz.sdk.microgrid.get", return_value=mock_microgrid
         ):
-
             distributor = PowerDistributingActor(service_channels)
 
             # Mock that all requested batteries are working.
@@ -446,7 +445,6 @@ class TestPowerDistributingActor(IsolatedAsyncioTestCase):
         with mock.patch("asyncio.sleep", new_callable=AsyncMock) and mock.patch(
             "frequenz.sdk.microgrid.get", return_value=mock_microgrid
         ):
-
             distributor = PowerDistributingActor(service_channels)
 
             # Mock that all requested batteries are working.
@@ -545,7 +543,6 @@ class TestPowerDistributingActor(IsolatedAsyncioTestCase):
         with mock.patch("asyncio.sleep", new_callable=AsyncMock) and mock.patch(
             "frequenz.sdk.microgrid.get", return_value=mock_microgrid
         ):
-
             distributor = PowerDistributingActor(service_channels)
 
             # Mock that all requested batteries are working.
@@ -612,7 +609,6 @@ class TestPowerDistributingActor(IsolatedAsyncioTestCase):
         with mock.patch("asyncio.sleep", new_callable=AsyncMock) and mock.patch(
             "frequenz.sdk.microgrid.get", return_value=mock_microgrid
         ):
-
             distributor = PowerDistributingActor(service_channels)
 
             # Mock that all requested batteries are working.
@@ -679,7 +675,6 @@ class TestPowerDistributingActor(IsolatedAsyncioTestCase):
         with mock.patch("asyncio.sleep", new_callable=AsyncMock) and mock.patch(
             "frequenz.sdk.microgrid.get", return_value=mock_microgrid
         ):
-
             distributor = PowerDistributingActor(service_channels)
 
             # Mock that all requested batteries are working.
@@ -739,7 +734,6 @@ class TestPowerDistributingActor(IsolatedAsyncioTestCase):
         with mock.patch("asyncio.sleep", new_callable=AsyncMock) and mock.patch(
             "frequenz.sdk.microgrid.get", return_value=mock_microgrid
         ):
-
             distributor = PowerDistributingActor({"user1": channel.service_handle})
 
             # Mock that all requested batteries are working.

--- a/tests/data_ingestion/base_microgrid_data_test.py
+++ b/tests/data_ingestion/base_microgrid_data_test.py
@@ -129,7 +129,6 @@ class BaseMicrogridDataTest(IsolatedAsyncioTestCase):
             metric: [] for metric in metrics
         }
         while await select.ready():
-
             for metric in metrics:
                 if msg := getattr(select, metric):
                     returned_data[metric].append(msg.inner)

--- a/tests/microgrid/test_graph.py
+++ b/tests/microgrid/test_graph.py
@@ -32,7 +32,6 @@ def _check_predecessors_and_successors(graph: gr.ComponentGraph) -> None:
     }
 
     for conn in graph.connections():
-
         if conn.end not in expected_predecessors:
             expected_predecessors[conn.end] = set()
         expected_predecessors[conn.end].add(components[conn.start])


### PR DESCRIPTION
Inverter that was discharging was considered as not working.
If inverter was discharging, then it was impossible to
set any command until it changed state.
