### PR TITLE
Change few resampler logs from info to debug

### DIFF
--- a/src/frequenz/sdk/timeseries/_resampling.py
+++ b/src/frequenz/sdk/timeseries/_resampling.py
@@ -524,7 +524,7 @@ class _ResamplingHelper:
             samples_time_delta.total_seconds()
         ) / props.received_samples
 
-        _logger.info(
+        _logger.debug(
             "New input sampling period calculated for %r: %ss",
             self._name,
             props.sampling_period_s,
@@ -580,7 +580,7 @@ class _ResamplingHelper:
         if new_buffer_len == self._buffer.maxlen:
             return False
 
-        _logger.info(
+        _logger.debug(
             "New buffer length calculated for %r: %s",
             self._name,
             new_buffer_len,


### PR DESCRIPTION
Because it pollutes the logs at startup.
And this logs seems to be important only for debugging.