### PR TITLE
Change PowerDistributor to ignore components with NaN metrics

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,6 +7,9 @@
 ## Upgrading
 
 * Remove `_soc` formula from the LogicalMeter. This feature has been moved to the BatteryPool.
+* Upgrade PowerDistributingActor to handle components with the NaN metrics (#247):
+    * if power bounds are NaN, then it tries to replace them with corresponding power bounds from adjacent component. If these components are also NaN, then it ignores battery.
+    * if other metrics metrics are NaN then it ignores battery.
 
 ## New Features
 

--- a/src/frequenz/sdk/actor/power_distributing/power_distributing.py
+++ b/src/frequenz/sdk/actor/power_distributing/power_distributing.py
@@ -266,7 +266,7 @@ class PowerDistributingActor:
 
             try:
                 pairs_data: List[InvBatPair] = self._get_components_data(
-                    self._all_battery_status.get_working_batteries(request.batteries)
+                    request.batteries
                 )
             except KeyError as err:
                 await user.channel.send(Error(request, str(err)))
@@ -548,8 +548,8 @@ class PowerDistributingActor:
             Pairs of battery and adjacent inverter data.
         """
         pairs_data: List[InvBatPair] = []
-
-        for battery_id in batteries:
+        working_batteries = self._all_battery_status.get_working_batteries(batteries)
+        for battery_id in working_batteries:
             if battery_id not in self._battery_receivers:
                 raise KeyError(
                     f"No battery {battery_id}, "


### PR DESCRIPTION
Each float metric returned from api can be float("NaN"). If that happen PowerDistributor would fail because it is impossible to make math calcuation on NaN value.
This PR is just a quick fix of this problem.
* if power bounds are NaN, then it tries to replace them with corresponding power bounds from adjacent component. If these components are also NaN, then it ignores battery.
* if other metrics metrics are NaN then it ignores battery.

More sophisticated solution should be done in the future, maybe use resampler. 