### PR TITLE
Change BatteryPool to send metrics only when they change

### DIFF
--- a/src/frequenz/sdk/timeseries/battery_pool/_metric_calculator.py
+++ b/src/frequenz/sdk/timeseries/battery_pool/_metric_calculator.py
@@ -12,7 +12,6 @@ from typing import Generic, Iterable, TypeVar
 
 from ... import microgrid
 from ...microgrid.component import ComponentCategory, ComponentMetricId, InverterType
-from ...timeseries import Sample
 from ._component_metrics import ComponentMetricsData
 from ._result_types import Bound, CapacityMetrics, PowerMetrics, SoCMetrics
 
@@ -59,7 +58,7 @@ def battery_inverter_mapping(batteries: Iterable[int]) -> dict[int, int]:
 
 # Formula output types class have no common interface
 # Print all possible types here.
-T = TypeVar("T", Sample, SoCMetrics, CapacityMetrics, PowerMetrics)
+T = TypeVar("T", SoCMetrics, CapacityMetrics, PowerMetrics)
 
 
 class MetricCalculator(ABC, Generic[T]):

--- a/src/frequenz/sdk/timeseries/battery_pool/_result_types.py
+++ b/src/frequenz/sdk/timeseries/battery_pool/_result_types.py
@@ -3,7 +3,7 @@
 
 """Methods for processing battery-inverter data."""
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime
 
 
@@ -22,7 +22,8 @@ class Bound:
 class CapacityMetrics:
     """Capacity metrics."""
 
-    timestamp: datetime
+    # compare = False tells the dataclass to not use name for comparison methods
+    timestamp: datetime = field(compare=False)
     """Timestamp of the metrics,"""
 
     total_capacity: float
@@ -53,7 +54,8 @@ class CapacityMetrics:
 class SoCMetrics:
     """Soc metrics."""
 
-    timestamp: datetime
+    # compare = False tells the dataclass to not use name for comparison methods
+    timestamp: datetime = field(compare=False)
     """Timestamp of the metrics."""
 
     average_soc: float
@@ -91,7 +93,8 @@ class SoCMetrics:
 class PowerMetrics:
     """Power bounds metrics."""
 
-    timestamp: datetime
+    # compare = False tells the dataclass to not use name for comparison methods
+    timestamp: datetime = field(compare=False)
     """Timestamp of the metrics."""
 
     supply_bound: Bound

--- a/tests/timeseries/_battery_pool/test_battery_pool.py
+++ b/tests/timeseries/_battery_pool/test_battery_pool.py
@@ -509,12 +509,7 @@ async def run_capacity_test(setup_args: SetupArgs) -> None:
         ),
         Scenario(
             batteries_in_pool[1],
-            {"capacity": 200, "soc_lower_bound": float("NaN")},
-            CapacityMetrics(now, 30, Bound(600, 2700)),
-        ),
-        Scenario(
-            batteries_in_pool[1],
-            {"soc_lower_bound": 20},
+            {"capacity": 200},
             CapacityMetrics(now, 230, Bound(4600, 20700)),
         ),
     ]
@@ -601,12 +596,7 @@ async def run_soc_test(setup_args: SetupArgs) -> None:
     scenarios: list[Scenario[SoCMetrics]] = [
         Scenario(
             batteries_in_pool[0],
-            {"capacity": 150},
-            SoCMetrics(now, 30, Bound(20, 80)),
-        ),
-        Scenario(
-            batteries_in_pool[0],
-            {"soc": 10},
+            {"capacity": 150, "soc": 10},
             SoCMetrics(now, 15, Bound(20, 80)),
         ),
         Scenario(
@@ -631,10 +621,12 @@ async def run_soc_test(setup_args: SetupArgs) -> None:
             {"soc": 30},
             SoCMetrics(now, 30, Bound(20, 80)),
         ),
+        # Final metric didn't change, so nothing should be received.
         Scenario(
             batteries_in_pool[0],
             {"capacity": 0, "soc_lower_bound": 10, "soc_upper_bound": 100},
-            SoCMetrics(now, 30, Bound(20, 80)),
+            None,
+            wait_for_result=False,
         ),
         # Test zero division error
         Scenario(
@@ -789,12 +781,20 @@ async def run_power_bounds_test(  # pylint: disable=too-many-locals
             PowerMetrics(now, Bound(-10, 0), Bound(0, 200)),
         ),
         Scenario(
+            batteries_in_pool[1],
+            {
+                "power_lower_bound": -100,
+                "power_upper_bound": float("NaN"),
+            },
+            PowerMetrics(now, Bound(-100, 0), Bound(0, 6000)),
+        ),
+        Scenario(
             bat_inv_map[batteries_in_pool[1]],
             {
                 "active_power_lower_bound": float("NaN"),
                 "active_power_upper_bound": float("NaN"),
             },
-            PowerMetrics(now, Bound(-10, 0), Bound(0, 200)),
+            PowerMetrics(now, Bound(-100, 0), Bound(0, 0)),
         ),
         # All components are sending NaN, can't calculate bounds
         Scenario(


### PR DESCRIPTION
We compared the metric result but with timestamp.
Because timestamps were different comparison was always True. Exclude timestamp to not it in the comparison methods. Remove Sample from the metric result types, because we don't return any Sample metric now and it is not consistent with the rest the result types, now.