### PR TITLE
Pin dev/test dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,8 +65,8 @@ format = [
     "isort >= 5.12.0, < 6",
 ]
 nox = [
-    "nox",
-    "toml",
+    "nox == 2022.11.21",
+    "toml >= 0.10.2, < 1",
 ]
 pytest = [
     "pytest",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,7 +84,7 @@ mypy = [
     "frequenz-sdk[docs-gen,nox,pytest]",
 ]
 pylint = [
-    "pylint",
+    "pylint >= 2.17.0, < 3",
     # For checking the noxfile, docs/ script, and tests
     "frequenz-sdk[docs-gen,nox,pytest]",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,9 +77,9 @@ pytest = [
     "async-solipsism",
 ]
 mypy = [
-    "mypy",
-    "pandas-stubs",
-    "grpc-stubs",
+    "mypy >= 1.0.1, < 2",
+    "pandas-stubs == 1.5.3.230304",
+    "grpc-stubs == 1.24.12",  # This dependency introduces breaking changes in patch releases
     # For checking the noxfile, docs/ script, and tests
     "frequenz-sdk[docs-gen,nox,pytest]",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,8 +61,8 @@ docs-lint = [
     "tomli",  # Needed by pydocstyle to read pyproject.toml
 ]
 format = [
-    "black",
-    "isort",
+    "black >= 23.1.0, < 24",
+    "isort >= 5.12.0, < 6",
 ]
 nox = [
     "nox",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,9 +56,9 @@ docs-gen = [
     "mkdocstrings[python] >= 0.19.0, < 0.20.0",
 ]
 docs-lint = [
-    "pydocstyle",
-    "darglint",
-    "tomli",  # Needed by pydocstyle to read pyproject.toml
+    "pydocstyle >= 6.3.0, < 7",
+    "darglint >= 1.8.1, < 2",
+    "tomli >= 2.0.1, < 3",  # Needed by pydocstyle to read pyproject.toml
 ]
 format = [
     "black >= 23.1.0, < 24",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,12 +69,12 @@ nox = [
     "toml >= 0.10.2, < 1",
 ]
 pytest = [
-    "pytest",
-    "pytest-cov",
-    "pytest-mock",
-    "pytest-asyncio",
-    "time-machine",
-    "async-solipsism",
+    "pytest >= 7.2.1, < 8",
+    "pytest-cov >= 4.0.0, < 5",
+    "pytest-mock >= 3.10.0, < 4",
+    "pytest-asyncio >= 0.20.3, < 1",
+    "time-machine >= 2.9.0, < 3",
+    "async-solipsism >= 0.5, < 1",
 ]
 mypy = [
     "mypy >= 1.0.1, < 2",


### PR DESCRIPTION
Currently the CI installs the latest dev and test dependencies, and this might cause troubles when patching or hot-fixing older releases due to breaking changes in the latest dependencies update.

Pin dev and  test dependences to avoid the CI to fail when patching or hot-fixing older releases.

Fixes: #243 