### PR TITLE
Remove pandas(-stubs) dependencies

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,8 +6,8 @@
 
 * Remove `_soc` formula from the LogicalMeter. This feature has been moved to the BatteryPool.
 * Upgrade PowerDistributingActor to handle components with the NaN metrics (#247):
-    * if power bounds are NaN, then it tries to replace them with corresponding power bounds from adjacent component. If these components are also NaN, then it ignores battery.
-    * if other metrics metrics are NaN then it ignores battery.
+  * if power bounds are NaN, then it tries to replace them with corresponding power bounds from adjacent component. If these components are also NaN, then it ignores battery.
+  * if other metrics metrics are NaN then it ignores battery.
 * BatteryStatus to track that a component stopped sending messages. If the battery or its adjacent inverter stopped sending messages, then the battery would be considered as not working. (#207)
 * PowerDistributing to send battery status to subscribed users (#205)
 * Rename microgrid.Microgrid to microgrid.ConnectionManager (#208)
@@ -21,12 +21,13 @@
 * BatteryPool implementation for aggregating battery-inverter metrics into higher level metrics. (#205)
 * Add EV power and current streams to `EVChargerPool` (#201)
 
-
 ## Bug Fixes
 
 * The resampler now correctly produces resampling windows of exact *resampling period* size, which only include samples emitted during the resampling window (see #170)
 
 ## Removing
+
 * Deprecated code (#232):
-    * frequenz.sdk._data_ingestion
-    * frequenz.sdk._data_handling
+  * frequenz.sdk._data_ingestion
+  * frequenz.sdk._data_handling
+* The pandas(-stubs) and pytz dependencies are no longer needed (#261).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "grpcio >= 1.51.1, < 2",
     "grpcio-tools >= 1.51.1, < 2",
     "networkx >= 2.8, < 3",
-    "pandas >= 1.5.2, < 2",
+    "numpy >= 1.24.2, < 2",
     "protobuf >= 4.21.6, < 5",
     "pydantic >= 1.9",
     "sympy >= 1.10.1, < 2",
@@ -78,7 +78,6 @@ pytest = [
 ]
 mypy = [
     "mypy >= 1.0.1, < 2",
-    "pandas-stubs == 1.5.3.230304",
     "grpc-stubs == 1.24.12",  # This dependency introduces breaking changes in patch releases
     # For checking the noxfile, docs/ script, and tests
     "frequenz-sdk[docs-gen,nox,pytest]",

--- a/src/frequenz/sdk/microgrid/component/_component_data.py
+++ b/src/frequenz/sdk/microgrid/component/_component_data.py
@@ -6,13 +6,12 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import List, Optional, Tuple
 
 import frequenz.api.microgrid.battery_pb2 as battery_pb
 import frequenz.api.microgrid.inverter_pb2 as inverter_pb
 import frequenz.api.microgrid.microgrid_pb2 as microgrid_pb
-import pytz
 
 from ._component_states import EVChargerCableState, EVChargerComponentState
 
@@ -93,7 +92,7 @@ class MeterData(ComponentData):
         """
         meter_data = cls(
             component_id=raw.id,
-            timestamp=raw.ts.ToDatetime(tzinfo=pytz.UTC),
+            timestamp=raw.ts.ToDatetime(tzinfo=timezone.utc),
             active_power=raw.meter.data.ac.power_active.value,
             current_per_phase=(
                 raw.meter.data.ac.phase_1.current.value,
@@ -166,7 +165,7 @@ class BatteryData(ComponentData):
         """
         battery_data = cls(
             component_id=raw.id,
-            timestamp=raw.ts.ToDatetime(tzinfo=pytz.UTC),
+            timestamp=raw.ts.ToDatetime(tzinfo=timezone.utc),
             soc=raw.battery.data.soc.avg,
             soc_lower_bound=raw.battery.data.soc.system_bounds.lower,
             soc_upper_bound=raw.battery.data.soc.system_bounds.upper,
@@ -221,7 +220,7 @@ class InverterData(ComponentData):
         """
         inverter_data = cls(
             component_id=raw.id,
-            timestamp=raw.ts.ToDatetime(tzinfo=pytz.UTC),
+            timestamp=raw.ts.ToDatetime(tzinfo=timezone.utc),
             active_power=raw.inverter.data.ac.power_active.value,
             active_power_lower_bound=raw.inverter.data.ac.power_active.system_bounds.lower,
             active_power_upper_bound=raw.inverter.data.ac.power_active.system_bounds.upper,
@@ -272,7 +271,7 @@ class EVChargerData(ComponentData):
         """
         ev_charger_data = cls(
             component_id=raw.id,
-            timestamp=raw.ts.ToDatetime(tzinfo=pytz.UTC),
+            timestamp=raw.ts.ToDatetime(tzinfo=timezone.utc),
             active_power=raw.ev_charger.data.ac.power_active.value,
             current_per_phase=(
                 raw.ev_charger.data.ac.phase_1.current.value,

--- a/tests/actor/test_battery_status.py
+++ b/tests/actor/test_battery_status.py
@@ -53,7 +53,7 @@ def battery_data(
     Args:
         component_id: component id
         timestamp: Timestamp of the component message.
-            Defaults to datetime.now(tz=pytz.utc).
+            Defaults to datetime.now(tz=timezone.utc).
         relay_state: Battery relay state.
             Defaults to BatteryRelayState.RELAY_STATE_CLOSED.
         component_state: Component state.
@@ -88,7 +88,7 @@ def inverter_data(
     Args:
         component_id: component id
         timestamp: Timestamp of the component message.
-            Defaults to datetime.now(tz=pytz.utc).
+            Defaults to datetime.now(tz=timezone.utc).
         component_state: Component state.
             Defaults to InverterState.CHARGING.
         errors: List of the components error. By default empty list will be created.


### PR DESCRIPTION
The pandas(-stubs) dependencies are no longer needed.

The package numpy was imported through pandas so it needs to be added to the dependency list once pandas get removed.