### PR TITLE
Add `component_data` method to EVChargerPool

### DIFF
--- a/src/frequenz/sdk/timeseries/ev_charger_pool/__init__.py
+++ b/src/frequenz/sdk/timeseries/ev_charger_pool/__init__.py
@@ -3,8 +3,12 @@
 
 """Interactions with EV Chargers."""
 
-from ._ev_charger_pool import EVChargerPool
+from ._ev_charger_pool import EVChargerData, EVChargerPool, EVChargerPoolError
+from ._state_tracker import EVChargerState
 
 __all__ = [
     "EVChargerPool",
+    "EVChargerData",
+    "EVChargerPoolError",
+    "EVChargerState",
 ]

--- a/src/frequenz/sdk/timeseries/ev_charger_pool/_ev_charger_pool.py
+++ b/src/frequenz/sdk/timeseries/ev_charger_pool/_ev_charger_pool.py
@@ -9,6 +9,7 @@ import asyncio
 import logging
 import uuid
 from asyncio import Task
+from collections import abc
 from dataclasses import dataclass
 
 from frequenz.channels import Broadcast, ChannelClosedError, Receiver, Sender
@@ -86,6 +87,15 @@ class EVChargerPool:
             self._channel_registry,
             self._resampler_subscription_sender,
         )
+
+    @property
+    def component_ids(self) -> abc.Set[int]:
+        """Return component IDs of all EV Chargers managed by this EVChargerPool.
+
+        Returns:
+            Set of managed component IDs.
+        """
+        return self._component_ids
 
     async def current(self) -> FormulaReceiver3Phase:
         """Fetch the total current for the EV Chargers in the pool.

--- a/src/frequenz/sdk/timeseries/ev_charger_pool/_ev_charger_pool.py
+++ b/src/frequenz/sdk/timeseries/ev_charger_pool/_ev_charger_pool.py
@@ -5,26 +5,40 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import uuid
+from asyncio import Task
+from dataclasses import dataclass
 
-from frequenz.channels import Sender
+from frequenz.channels import Broadcast, ChannelClosedError, Receiver, Sender
 
 from ...actor import ChannelRegistry, ComponentMetricRequest
 from ...microgrid import connection_manager
-from ...microgrid.component import ComponentCategory
+from ...microgrid.component import ComponentCategory, ComponentMetricId
+from .. import Sample, Sample3Phase
 from .._formula_engine import FormulaEnginePool, FormulaReceiver, FormulaReceiver3Phase
 from .._formula_engine._formula_generators import (
     EVChargerCurrentFormula,
     EVChargerPowerFormula,
     FormulaGeneratorConfig,
 )
+from ._state_tracker import EVChargerState, StateTracker
 
 logger = logging.getLogger(__name__)
 
 
 class EVChargerPoolError(Exception):
     """An error that occurred in any of the EVChargerPool methods."""
+
+
+@dataclass(frozen=True)
+class EVChargerData:
+    """Data for an EV Charger, including the 3-phase current and the component state."""
+
+    component_id: int
+    current: Sample3Phase
+    state: EVChargerState
 
 
 class EVChargerPool:
@@ -62,6 +76,10 @@ class EVChargerPool:
                     component_category={ComponentCategory.EV_CHARGER}
                 )
             }
+        self._state_tracker: StateTracker | None = None
+        self._status_streams: dict[
+            int, tuple[Task[None], Broadcast[EVChargerData]]
+        ] = {}
         self._namespace: str = f"ev-charger-pool-{uuid.uuid4()}"
         self._formula_pool: FormulaEnginePool = FormulaEnginePool(
             self._namespace,
@@ -148,3 +166,115 @@ class EVChargerPool:
             EVChargerPowerFormula,
             FormulaGeneratorConfig(component_ids={component_id}),
         )
+
+    async def component_data(self, component_id: int) -> Receiver[EVChargerData]:
+        """Stream 3-phase current values and state of an EV Charger.
+
+        Args:
+            component_id: id of the EV Charger for which data is requested.
+
+        Returns:
+            A receiver that streams objects containing 3-phase current and state of
+                an EV Charger.
+        """
+        if recv := self._status_streams.get(component_id, None):
+            task, output_chan = recv
+            if not task.done():
+                return output_chan.new_receiver()
+            logger.warning("Restarting component_status for id: %s", component_id)
+        else:
+            output_chan = Broadcast[EVChargerData](
+                f"evpool-component_status-{component_id}"
+            )
+
+        task = asyncio.create_task(
+            self._stream_component_data(component_id, output_chan.new_sender())
+        )
+
+        self._status_streams[component_id] = (task, output_chan)
+
+        return output_chan.new_receiver()
+
+    async def _get_current_streams(
+        self, component_id: int
+    ) -> tuple[Receiver[Sample], Receiver[Sample], Receiver[Sample]]:
+        """Fetch current streams from the resampler for each phase.
+
+        Args:
+            component_id: id of EV Charger for which current streams are being fetched.
+
+        Returns:
+            A tuple of 3 receivers stream resampled current values for the given
+                component id, one for each phase.
+        """
+
+        async def resampler_subscribe(metric_id: ComponentMetricId) -> Receiver[Sample]:
+            request = ComponentMetricRequest(
+                namespace="ev-pool",
+                component_id=component_id,
+                metric_id=metric_id,
+                start_time=None,
+            )
+            await self._resampler_subscription_sender.send(request)
+            return self._channel_registry.new_receiver(request.get_channel_name())
+
+        return (
+            await resampler_subscribe(ComponentMetricId.CURRENT_PHASE_1),
+            await resampler_subscribe(ComponentMetricId.CURRENT_PHASE_2),
+            await resampler_subscribe(ComponentMetricId.CURRENT_PHASE_3),
+        )
+
+    async def _stream_component_data(
+        self,
+        component_id: int,
+        sender: Sender[EVChargerData],
+    ) -> None:
+        """Stream 3-phase current values and state of an EV Charger.
+
+        Args:
+            component_id: id of the EV Charger for which data is requested.
+            sender: A sender to stream EV Charger data to.
+
+        Raises:
+            ChannelClosedError: If the channels from the resampler are closed.
+        """
+        if not self._state_tracker:
+            self._state_tracker = StateTracker(self._component_ids)
+
+        (phase_1_rx, phase_2_rx, phase_3_rx) = await self._get_current_streams(
+            component_id
+        )
+        while True:
+            try:
+                (phase_1, phase_2, phase_3) = (
+                    await phase_1_rx.receive(),
+                    await phase_2_rx.receive(),
+                    await phase_3_rx.receive(),
+                )
+            except ChannelClosedError:
+                logger.exception("Streams closed for component_id=%s.", component_id)
+                raise
+
+            sample = Sample3Phase(
+                timestamp=phase_1.timestamp,
+                value_p1=phase_1.value,
+                value_p2=phase_2.value,
+                value_p3=phase_3.value,
+            )
+
+            if (
+                phase_1.value is None
+                and phase_2.value is None
+                and phase_3.value is None
+            ):
+                state = EVChargerState.MISSING
+            else:
+                state = self._state_tracker.get(component_id)
+
+            await sender.send(
+                EVChargerData(
+                    component_id=component_id,
+                    current=sample,
+                    state=state,
+                )
+            )

--- a/src/frequenz/sdk/timeseries/ev_charger_pool/_ev_charger_pool.py
+++ b/src/frequenz/sdk/timeseries/ev_charger_pool/_ev_charger_pool.py
@@ -120,53 +120,6 @@ class EVChargerPool:
             FormulaGeneratorConfig(component_ids=self._component_ids),
         )
 
-    async def current(self, component_id: int) -> FormulaReceiver3Phase:
-        """Fetch the 3-phase current for the given EV Charger id.
-
-        Args:
-            component_id: id of the EV Charger to stream current values for.
-
-        Returns:
-            A *new* receiver that will stream 3-phase current values for the given
-                EV Charger.
-
-        Raises:
-            EVChargerPoolError: if the given component_id is not part of the pool.
-        """
-        if component_id not in self._component_ids:
-            raise EVChargerPoolError(
-                f"{component_id=} is not part of the EVChargerPool"
-                f" (with ids={self._component_ids})"
-            )
-        return await self._formula_pool.from_generator(
-            f"ev_charger_current_{component_id}",
-            EVChargerCurrentFormula,
-            FormulaGeneratorConfig(component_ids={component_id}),
-        )
-
-    async def power(self, component_id: int) -> FormulaReceiver:
-        """Fetch the power for the given EV Charger id.
-
-        Args:
-            component_id: id of the EV Charger to stream power values for.
-
-        Returns:
-            A *new* receiver that will stream power values for the given EV Charger.
-
-        Raises:
-            EVChargerPoolError: if the given component_id is not part of the pool.
-        """
-        if component_id not in self._component_ids:
-            raise EVChargerPoolError(
-                f"{component_id=} is not part of the EVChargerPool"
-                f" (with ids={self._component_ids})"
-            )
-        return await self._formula_pool.from_generator(
-            f"ev_charger_current_{component_id}",
-            EVChargerPowerFormula,
-            FormulaGeneratorConfig(component_ids={component_id}),
-        )
-
     async def component_data(self, component_id: int) -> Receiver[EVChargerData]:
         """Stream 3-phase current values and state of an EV Charger.
 

--- a/src/frequenz/sdk/timeseries/ev_charger_pool/_ev_charger_pool.py
+++ b/src/frequenz/sdk/timeseries/ev_charger_pool/_ev_charger_pool.py
@@ -87,7 +87,7 @@ class EVChargerPool:
             self._resampler_subscription_sender,
         )
 
-    async def total_current(self) -> FormulaReceiver3Phase:
+    async def current(self) -> FormulaReceiver3Phase:
         """Fetch the total current for the EV Chargers in the pool.
 
         If a formula engine to calculate EV Charger current is not already running, it
@@ -103,7 +103,7 @@ class EVChargerPool:
             FormulaGeneratorConfig(component_ids=self._component_ids),
         )
 
-    async def total_power(self) -> FormulaReceiver:
+    async def power(self) -> FormulaReceiver:
         """Fetch the total power for the EV Chargers in the pool.
 
         If a formula engine to calculate EV Charger power is not already running, it

--- a/src/frequenz/sdk/timeseries/ev_charger_pool/_state_tracker.py
+++ b/src/frequenz/sdk/timeseries/ev_charger_pool/_state_tracker.py
@@ -59,6 +59,14 @@ class EVChargerState(Enum):
             return EVChargerState.EV_PLUGGED
         return EVChargerState.IDLE
 
+    def is_ev_connected(self) -> bool:
+        """Check whether an EV is connected to the charger.
+
+        Returns:
+            Whether an EV is connected to the charger.
+        """
+        return self in (EVChargerState.EV_PLUGGED, EVChargerState.EV_LOCKED)
+
 
 class StateTracker:
     """A class for keeping track of the states of all EV Chargers in a pool."""

--- a/tests/timeseries/_formula_engine/test_formula_composition.py
+++ b/tests/timeseries/_formula_engine/test_formula_composition.py
@@ -126,7 +126,7 @@ class TestFormulaComposition:
         ev_pool = microgrid.ev_charger_pool()
 
         grid_current_recv = await logical_meter.grid_current()
-        ev_current_recv = await ev_pool.total_current()
+        ev_current_recv = await ev_pool.current()
 
         engine = (grid_current_recv.clone() - ev_current_recv.clone()).build(
             "net_current"

--- a/tests/timeseries/test_ev_charger_pool.py
+++ b/tests/timeseries/test_ev_charger_pool.py
@@ -97,7 +97,7 @@ class TestEVChargerPool:
             ComponentMetricId.ACTIVE_POWER,
         )
         grid_power_recv = await logical_meter.grid_power()
-        ev_power_recv = await ev_pool.total_power()
+        ev_power_recv = await ev_pool.power()
 
         await synchronize_receivers([grid_power_recv, main_meter_recv, ev_power_recv])
 


### PR DESCRIPTION
This PR:
1. introduces the `component_data` method to the EVChargerPool, which ties the resampled 3-phase current values for an ev charger with the component state, which comes directly from the microgrid,  streaming objects of type:

   ``` python
   @dataclass(frozen=True)
   class EVChargerData:
       """Data for an EV Charger, including the 3-phase current and the component state."""

       component_id: int
       current: Sample3Phase
       state: EVChargerState
   ```

   This is done so that the state-tracking code can piggy-back on the resampler to detect if a component is missing data, and switch its state to `MISSING` whenever that is the case.


3. adds these methods for `Sample3Phase`: `__iter__, min, max, map`.
