### PR TITLE
Configure dependabot to automated version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,12 @@ updates:
     versioning-strategy: auto
     # Allow up to 10 open pull requests for updates to dependency versions
     open-pull-requests-limit: 10
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "06:00"
+    labels:
+      - "part:tooling"
+      - "type:tech-debt"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "07:00"
+    labels:
+      - "part:tooling"
+      - "type:tech-debt"
+    # Default versioning-strategy. For other versioning-strategy see:
+    # https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#versioning-strategy
+    versioning-strategy: auto
+    # Allow up to 10 open pull requests for updates to dependency versions
+    open-pull-requests-limit: 10

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,42 +48,42 @@ email = "floss@frequenz.com"
 
 [project.optional-dependencies]
 docs-gen = [
-    "mike >= 1.1.2, < 2",
-    "mkdocs-gen-files >= 0.4.0, < 0.5.0",
-    "mkdocs-literate-nav >= 0.4.0, < 0.5.0",
-    "mkdocs-material >= 8.5.7, < 9",
-    "mkdocs-section-index >= 0.3.4, < 0.4.0",
-    "mkdocstrings[python] >= 0.19.0, < 0.20.0",
+    "mike == 1.1.2",
+    "mkdocs-gen-files == 0.4.0",
+    "mkdocs-literate-nav == 0.6.0",
+    "mkdocs-material == 8.5.11",
+    "mkdocs-section-index == 0.3.5",
+    "mkdocstrings[python] == 0.19.1",
 ]
 docs-lint = [
-    "pydocstyle >= 6.3.0, < 7",
-    "darglint >= 1.8.1, < 2",
-    "tomli >= 2.0.1, < 3",  # Needed by pydocstyle to read pyproject.toml
+    "pydocstyle == 6.3.0",
+    "darglint == 1.8.1",
+    "tomli == 2.0.1",  # Needed by pydocstyle to read pyproject.toml
 ]
 format = [
-    "black >= 23.1.0, < 24",
-    "isort >= 5.12.0, < 6",
+    "black == 23.1.0",
+    "isort == 5.12.0",
 ]
 nox = [
     "nox == 2022.11.21",
-    "toml >= 0.10.2, < 1",
+    "toml == 0.10.2",
 ]
 pytest = [
-    "pytest >= 7.2.1, < 8",
-    "pytest-cov >= 4.0.0, < 5",
-    "pytest-mock >= 3.10.0, < 4",
-    "pytest-asyncio >= 0.20.3, < 1",
-    "time-machine >= 2.9.0, < 3",
-    "async-solipsism >= 0.5, < 1",
+    "pytest == 7.2.1",
+    "pytest-cov == 4.0.0",
+    "pytest-mock == 3.10.0",
+    "pytest-asyncio == 0.20.3",
+    "time-machine == 2.9.0",
+    "async-solipsism == 0.5",
 ]
 mypy = [
-    "mypy >= 1.0.1, < 2",
+    "mypy == 1.0.1",
     "grpc-stubs == 1.24.12",  # This dependency introduces breaking changes in patch releases
     # For checking the noxfile, docs/ script, and tests
     "frequenz-sdk[docs-gen,nox,pytest]",
 ]
 pylint = [
-    "pylint >= 2.17.0, < 3",
+    "pylint == 2.17.0",
     # For checking the noxfile, docs/ script, and tests
     "frequenz-sdk[docs-gen,nox,pytest]",
 ]


### PR DESCRIPTION
Add dependabot configuration file to automate version updates for pip dependencies and github actions.

The security updates needs to be checked/enabled from the settings in the repo.

Fixes: #242 