### PR TITLE
Fix len() of the OrderedRingBuffer

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -16,3 +16,4 @@
 ## Bug Fixes
 
 * Change PowerDistributor to use all batteries if none is working (#258)
+* Update the ordered ring buffer to fix the len() function so that it returns a value equal to or greater than zero, as expected (#274)

--- a/src/frequenz/sdk/timeseries/_ringbuffer.py
+++ b/src/frequenz/sdk/timeseries/_ringbuffer.py
@@ -69,6 +69,8 @@ class OrderedRingBuffer(Generic[FloatArray]):
                 "2022-01-01 12:00:00" to "2022-01-02 12:00:00" (date chosen
                 arbitrarily here).
         """
+        assert len(buffer) > 0, "The buffer capacity must be higher than zero"
+
         self._buffer: FloatArray = buffer
         self._sampling_period: timedelta = sampling_period
         self._time_index_alignment: datetime = time_index_alignment

--- a/src/frequenz/sdk/timeseries/_ringbuffer.py
+++ b/src/frequenz/sdk/timeseries/_ringbuffer.py
@@ -490,5 +490,6 @@ class OrderedRingBuffer(Generic[FloatArray]):
         end_index = self.datetime_to_index(self._datetime_newest)
 
         if end_index < start_index:
-            return len(self._buffer) - start_index + end_index
-        return start_index - end_index
+            return len(self._buffer) - start_index + end_index + 1
+
+        return end_index + 1 - start_index

--- a/tests/timeseries/test_ringbuffer.py
+++ b/tests/timeseries/test_ringbuffer.py
@@ -298,3 +298,23 @@ def test_len_ringbuffer_samples_overwrite_buffer() -> None:
             buffer.update(Sample(timestamp, float(sample_value)))
 
         assert len(buffer) == half_buffer_size
+
+
+def test_ringbuffer_empty_buffer() -> None:
+    """Test capacity ordered ring buffer."""
+    empty_np_buffer = np.empty(shape=0, dtype=float)
+    empty_list_buffer: list[float] = []
+
+    assert len(empty_np_buffer) == len(empty_list_buffer) == 0
+
+    with pytest.raises(AssertionError):
+        OrderedRingBuffer(
+            empty_np_buffer,
+            sampling_period=timedelta(seconds=1),
+            time_index_alignment=datetime(1, 1, 1),
+        )
+        OrderedRingBuffer(
+            empty_list_buffer,
+            sampling_period=timedelta(seconds=1),
+            time_index_alignment=datetime(1, 1, 1),
+        )

--- a/tests/timeseries/test_ringbuffer.py
+++ b/tests/timeseries/test_ringbuffer.py
@@ -243,3 +243,58 @@ def test_timestamp_ringbuffer_missing_parameter_smoke(
             buffer.gaps,
             key=window_to_timestamp,
         )
+
+
+def test_len_ringbuffer_samples_fit_buffer_size() -> None:
+    """Test the length of ordered ring buffer.
+
+    The number of samples fits the ordered ring buffer size.
+    """
+    min_samples = 1
+    max_samples = 100
+
+    for num_samples in range(
+        min_samples, max_samples + 1
+    ):  # Include max_samples in the range
+        test_samples = range(num_samples)
+
+        buffer = OrderedRingBuffer(
+            np.empty(shape=len(test_samples), dtype=float),
+            sampling_period=timedelta(seconds=1),
+            time_index_alignment=datetime(1, 1, 1),
+        )
+
+        start_ts: datetime = datetime(2023, 1, 1)
+        for index, sample_value in enumerate(test_samples):
+            timestamp = start_ts + timedelta(seconds=index)
+            buffer.update(Sample(timestamp, float(sample_value)))
+
+        assert len(buffer) == len(test_samples)
+
+
+def test_len_ringbuffer_samples_overwrite_buffer() -> None:
+    """Test the length of ordered ring buffer.
+
+    The number of samples overwrites the ordered ring buffer.
+    """
+    min_samples = 2
+    max_samples = 100
+
+    for num_samples in range(
+        min_samples, max_samples + 1
+    ):  # Include max_samples in the range
+        test_samples = range(num_samples)
+        half_buffer_size = len(test_samples) // 2
+
+        buffer = OrderedRingBuffer(
+            np.empty(shape=half_buffer_size, dtype=float),
+            sampling_period=timedelta(seconds=1),
+            time_index_alignment=datetime(1, 1, 1),
+        )
+
+        start_ts: datetime = datetime(2023, 1, 1)
+        for index, sample_value in enumerate(test_samples):
+            timestamp = start_ts + timedelta(seconds=index)
+            buffer.update(Sample(timestamp, float(sample_value)))
+
+        assert len(buffer) == half_buffer_size


### PR DESCRIPTION
The len() function was returning negative numbers in certain use cases, causing assertions to be raised. This fix ensures that the function returns a value equal to or greater than zero, as expected.