### PR TITLE
Add a `EVChargerPool.set_bounds` method for setting current bounds

### DIFF
--- a/src/frequenz/sdk/_internal/asyncio.py
+++ b/src/frequenz/sdk/_internal/asyncio.py
@@ -13,11 +13,15 @@ from typing import Any
 async def cancel_and_await(task: asyncio.Task[Any]) -> None:
     """Cancel a task and wait for it to finish.
 
+    Exits immediately if the task is already done.
+
     The `CancelledError` is suppresed, but any other exception will be propagated.
 
     Args:
         task: The task to be cancelled and waited for.
     """
+    if task.done():
+        return
     task.cancel()
     try:
         await task

--- a/src/frequenz/sdk/timeseries/ev_charger_pool/__init__.py
+++ b/src/frequenz/sdk/timeseries/ev_charger_pool/__init__.py
@@ -4,9 +4,11 @@
 """Interactions with EV Chargers."""
 
 from ._ev_charger_pool import EVChargerData, EVChargerPool, EVChargerPoolError
+from ._set_current_bounds import ComponentCurrentLimit
 from ._state_tracker import EVChargerState
 
 __all__ = [
+    "ComponentCurrentLimit",
     "EVChargerPool",
     "EVChargerData",
     "EVChargerPoolError",

--- a/src/frequenz/sdk/timeseries/ev_charger_pool/_ev_charger_pool.py
+++ b/src/frequenz/sdk/timeseries/ev_charger_pool/_ev_charger_pool.py
@@ -173,7 +173,7 @@ class EVChargerPool:
 
         Args:
             component_id: ID of EV Charger to set the current bounds to.
-            max_amps: Current bound value to set for the EV Charger.
+            max_amps: maximum current in amps, that an EV can draw from this EV Charger.
         """
         if not self._bounds_setter:
             self._bounds_setter = BoundsSetter(self._repeat_interval)

--- a/src/frequenz/sdk/timeseries/ev_charger_pool/_ev_charger_pool.py
+++ b/src/frequenz/sdk/timeseries/ev_charger_pool/_ev_charger_pool.py
@@ -179,6 +179,13 @@ class EVChargerPool:
             self._bounds_setter = BoundsSetter(self._repeat_interval)
         await self._bounds_setter.set(component_id, max_amps)
 
+    async def stop(self) -> None:
+        """Stop all tasks and channels owned by the EVChargerPool."""
+        if self._bounds_setter:
+            await self._bounds_setter.stop()
+        if self._state_tracker:
+            await self._state_tracker.stop()
+
     async def _get_current_streams(
         self, component_id: int
     ) -> tuple[Receiver[Sample], Receiver[Sample], Receiver[Sample]]:

--- a/src/frequenz/sdk/timeseries/ev_charger_pool/_ev_charger_pool.py
+++ b/src/frequenz/sdk/timeseries/ev_charger_pool/_ev_charger_pool.py
@@ -25,7 +25,7 @@ from .._formula_engine._formula_generators import (
     EVChargerPowerFormula,
     FormulaGeneratorConfig,
 )
-from ._set_current_bounds import BoundsSetter
+from ._set_current_bounds import BoundsSetter, ComponentCurrentLimit
 from ._state_tracker import EVChargerState, StateTracker
 
 logger = logging.getLogger(__name__)
@@ -178,6 +178,19 @@ class EVChargerPool:
         if not self._bounds_setter:
             self._bounds_setter = BoundsSetter(self._repeat_interval)
         await self._bounds_setter.set(component_id, max_amps)
+
+    def new_bounds_sender(self) -> Sender[ComponentCurrentLimit]:
+        """Return a `Sender` for setting EV Charger current bounds with.
+
+        Bounds are used to limit the max current drawn by an EV, although the exact
+        value will be determined by the EV.
+
+        Returns:
+            A new `Sender`.
+        """
+        if not self._bounds_setter:
+            self._bounds_setter = BoundsSetter(self._repeat_interval)
+        return self._bounds_setter.new_bounds_sender()
 
     async def stop(self) -> None:
         """Stop all tasks and channels owned by the EVChargerPool."""

--- a/src/frequenz/sdk/timeseries/ev_charger_pool/_set_current_bounds.py
+++ b/src/frequenz/sdk/timeseries/ev_charger_pool/_set_current_bounds.py
@@ -55,7 +55,7 @@ class BoundsSetter:
 
         Args:
             component_id: ID of EV Charger to set the current bounds to.
-            max_amps: Current bound value to set for the EV Charger.
+            max_amps: maximum current in amps, that an EV can draw from this EV Charger.
         """
         await self._bounds_tx.send(ComponentCurrentLimit(component_id, max_amps))
 

--- a/src/frequenz/sdk/timeseries/ev_charger_pool/_set_current_bounds.py
+++ b/src/frequenz/sdk/timeseries/ev_charger_pool/_set_current_bounds.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 from datetime import timedelta
 from typing import Dict
 
-from frequenz.channels import Broadcast
+from frequenz.channels import Broadcast, Sender
 from frequenz.channels.util import Select, Timer
 
 from ..._internal.asyncio import cancel_and_await
@@ -58,6 +58,14 @@ class BoundsSetter:
             max_amps: Current bound value to set for the EV Charger.
         """
         await self._bounds_tx.send(ComponentCurrentLimit(component_id, max_amps))
+
+    def new_bounds_sender(self) -> Sender[ComponentCurrentLimit]:
+        """Return a `Sender` for setting EV Charger current bounds with.
+
+        Returns:
+            A new `Sender`.
+        """
+        return self._bounds_chan.new_sender()
 
     async def stop(self) -> None:
         """Stop the BoundsSetter."""

--- a/src/frequenz/sdk/timeseries/ev_charger_pool/_set_current_bounds.py
+++ b/src/frequenz/sdk/timeseries/ev_charger_pool/_set_current_bounds.py
@@ -1,0 +1,122 @@
+# License: MIT
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
+
+"""A task for sending EV Charger power bounds to the microgrid API."""
+
+import asyncio
+import logging
+from dataclasses import dataclass
+from datetime import timedelta
+from typing import Dict
+
+from frequenz.channels import Broadcast
+from frequenz.channels.util import Select, Timer
+
+from ..._internal.asyncio import cancel_and_await
+from ...microgrid import connection_manager
+from ...microgrid.component import ComponentCategory
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ComponentCurrentLimit:
+    """A current limit, to be sent to the EV Charger."""
+
+    component_id: int
+    max_amps: float
+
+
+class BoundsSetter:
+    """A task for sending EV Charger power bounds to the microgrid API.
+
+    Also, periodically resends the last set bounds to the microgrid API, if no new
+    bounds have been set.
+    """
+
+    _NUM_PHASES = 3
+
+    def __init__(self, repeat_interval: timedelta) -> None:
+        """Create a `BoundsSetter` instance.
+
+        Args:
+            repeat_interval: Interval after which to repeat the last set bounds to the
+                microgrid API, if no new calls to `set_bounds` have been made.
+        """
+        self._repeat_interval = repeat_interval
+
+        self._task: asyncio.Task[None] = asyncio.create_task(self._run())
+        self._bounds_chan: Broadcast[ComponentCurrentLimit] = Broadcast("BoundsSetter")
+        self._bounds_rx = self._bounds_chan.new_receiver()
+        self._bounds_tx = self._bounds_chan.new_sender()
+
+    async def set(self, component_id: int, max_amps: float) -> None:
+        """Send the given current limit to the microgrid for the given component id.
+
+        Args:
+            component_id: ID of EV Charger to set the current bounds to.
+            max_amps: Current bound value to set for the EV Charger.
+        """
+        await self._bounds_tx.send(ComponentCurrentLimit(component_id, max_amps))
+
+    async def stop(self) -> None:
+        """Stop the BoundsSetter."""
+        await self._bounds_chan.close()
+        await cancel_and_await(self._task)
+
+    async def _run(self) -> None:
+        """Wait for new bounds and forward them to the microgrid API.
+
+        Also, periodically resend the last set bounds to the microgrid API, if no new
+        bounds have been set.
+
+        Raises:
+            RuntimeError: If no meters are found in the component graph.
+            ValueError: If the meter channel is closed.
+        """
+        api_client = connection_manager.get().api_client
+        graph = connection_manager.get().component_graph
+        meters = graph.components(component_category={ComponentCategory.METER})
+        if not meters:
+            err = "No meters found in the component graph."
+            logger.error(err)
+            raise RuntimeError(err)
+
+        meter_data = (
+            await api_client.meter_data(next(iter(meters)).component_id)
+        ).into_peekable()
+        latest_bound: Dict[int, ComponentCurrentLimit] = {}
+
+        select = Select(
+            bound_chan=self._bounds_rx,
+            timer=Timer(self._repeat_interval.total_seconds()),
+        )
+        while await select.ready():
+            meter = meter_data.peek()
+            if meter is None:
+                raise ValueError("Meter channel closed.")
+
+            if msg := select.bound_chan:
+                bound: ComponentCurrentLimit = msg.inner
+                if (
+                    bound.component_id in latest_bound
+                    and latest_bound[bound.component_id] == bound
+                ):
+                    continue
+                latest_bound[bound.component_id] = bound
+                min_voltage = min(meter.voltage_per_phase)
+                logging.info("sending new bounds: %s", bound)
+                await api_client.set_bounds(
+                    bound.component_id,
+                    0,
+                    bound.max_amps * min_voltage * self._NUM_PHASES,
+                )
+            elif msg := select.timer:
+                for bound in latest_bound.values():
+                    min_voltage = min(meter.voltage_per_phase)
+                    logging.debug("resending bounds: %s", bound)
+                    await api_client.set_bounds(
+                        bound.component_id,
+                        0,
+                        bound.max_amps * min_voltage * self._NUM_PHASES,
+                    )


### PR DESCRIPTION
This method would send the given current bound for the given EV Charger component ID,  to the Microgrid API.

It would also repeat the last bound to the microgrid, every configured interval,  so that our requests don't expire.


Bounds are used to limit the max current drawn by an EV, although the exact value will be determined by the EV.


Based on #266 