### PR TITLE
Refactor power distributor's `Result`s

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -8,6 +8,10 @@
 
 * Update BatteryStatus to mark battery with unknown capacity as not working (#263)
 * The channels dependency was updated to v0.14.0 (#292)
+* Some properties for `PowerDistributingActor` results were renamed to be more consistent between `Success` and `PartialFailure`:
+  * The `Success.used_batteries` property was renamed to `succeeded_batteries`.
+  * The `PartialFailure.success_batteries` property was renamed to `succeeded_batteries`.
+  * The `succeed_power` property was renamed to `succeeded_power` for both `Success` and `PartialFailure`.
 
 ## New Features
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -26,6 +26,7 @@
       )
       grid_power = microgrid.logical_meter().grid_power()
   ```
+* The `Result` class (and subclasses) for the `PowerDistributingActor` are now dataclasses, so logging them will produce a more detailed output.
 
 ## Bug Fixes
 

--- a/src/frequenz/sdk/actor/power_distributing/power_distributing.py
+++ b/src/frequenz/sdk/actor/power_distributing/power_distributing.py
@@ -271,12 +271,12 @@ class PowerDistributingActor:
                     request.batteries
                 )
             except KeyError as err:
-                await user.channel.send(Error(request, str(err)))
+                await user.channel.send(Error(request=request, msg=str(err)))
                 continue
 
             if len(pairs_data) == 0:
                 error_msg = f"No data for the given batteries {str(request.batteries)}"
-                await user.channel.send(Error(request, str(error_msg)))
+                await user.channel.send(Error(request=request, msg=str(error_msg)))
                 continue
 
             try:
@@ -285,7 +285,7 @@ class PowerDistributingActor:
                 )
             except ValueError as err:
                 error_msg = f"Couldn't distribute power, error: {str(err)}"
-                await user.channel.send(Error(request, str(error_msg)))
+                await user.channel.send(Error(request=request, msg=str(error_msg)))
                 continue
 
             distributed_power_value = request.power - distribution.remaining_power
@@ -380,17 +380,17 @@ class PowerDistributingActor:
                     f"No battery {battery}, available batteries: "
                     f"{list(self._battery_receivers.keys())}"
                 )
-                return Error(request, msg)
+                return Error(request=request, msg=msg)
 
         if not request.adjust_power:
             if request.power < 0:
                 bound = self._get_lower_bound(request.batteries)
                 if request.power < bound:
-                    return OutOfBound(request, bound)
+                    return OutOfBound(request=request, bound=bound)
             else:
                 bound = self._get_upper_bound(request.batteries)
                 if request.power > bound:
-                    return OutOfBound(request, bound)
+                    return OutOfBound(request=request, bound=bound)
 
         return None
 
@@ -420,7 +420,7 @@ class PowerDistributingActor:
             # Generators seems to be the fastest
             if prev_request.batteries == batteries:
                 task = asyncio.create_task(
-                    prev_user.channel.send(Ignored(prev_request))
+                    prev_user.channel.send(Ignored(request=prev_request))
                 )
                 to_ignore.append(task)
             # Use generators as generators seems to be the fastest.
@@ -490,7 +490,7 @@ class PowerDistributingActor:
                     "Consider increasing size of the queue."
                 )
                 _logger.error(msg)
-                await user.channel.send(Error(request, str(msg)))
+                await user.channel.send(Error(request=request, msg=str(msg)))
             else:
                 self._request_queue.put_nowait((request, user))
                 await asyncio.gather(*tasks)

--- a/src/frequenz/sdk/actor/power_distributing/power_distributing.py
+++ b/src/frequenz/sdk/actor/power_distributing/power_distributing.py
@@ -309,8 +309,8 @@ class PowerDistributingActor:
                 succeed_batteries = set(battery_distribution.keys()) - failed_batteries
                 response = PartialFailure(
                     request=request,
-                    succeed_power=distributed_power_value,
-                    succeed_batteries=succeed_batteries,
+                    succeeded_power=distributed_power_value,
+                    succeeded_batteries=succeed_batteries,
                     failed_power=failed_power,
                     failed_batteries=failed_batteries,
                     excess_power=distribution.remaining_power,
@@ -319,8 +319,8 @@ class PowerDistributingActor:
                 succeed_batteries = set(battery_distribution.keys())
                 response = Success(
                     request=request,
-                    succeed_power=distributed_power_value,
-                    used_batteries=succeed_batteries,
+                    succeeded_power=distributed_power_value,
+                    succeeded_batteries=succeed_batteries,
                     excess_power=distribution.remaining_power,
                 )
 

--- a/src/frequenz/sdk/actor/power_distributing/request.py
+++ b/src/frequenz/sdk/actor/power_distributing/request.py
@@ -12,10 +12,10 @@ class Request:
     """Request to set power to the `PowerDistributingActor`."""
 
     power: int
-    """The amount of power to be set."""
+    """The requested power in watts."""
 
     batteries: set[int]
-    """The set of batteries to use when requesting the power to be set."""
+    """The component ids of the batteries to be used for this request."""
 
     request_timeout_sec: float = 5.0
     """The maximum amount of time to wait for the request to be fulfilled."""
@@ -24,8 +24,8 @@ class Request:
     """Whether to adjust the power to match the bounds.
 
     If `True`, the power will be adjusted (lowered) to match the bounds, so
-    only the decreased power will be set.
+    only the reduced power will be set.
 
     If `False` and the power is outside the batteries' bounds, the request will
-    fail and replied to with an `OutOfBound` result.
+    fail and be replied to with an `OutOfBound` result.
     """

--- a/src/frequenz/sdk/actor/power_distributing/request.py
+++ b/src/frequenz/sdk/actor/power_distributing/request.py
@@ -2,22 +2,30 @@
 # Copyright © 2022 Frequenz Energy-as-a-Service GmbH
 """Definition of the user request."""
 
-from dataclasses import dataclass
-from typing import Set
+from __future__ import annotations
+
+import dataclasses
 
 
-@dataclass
+@dataclasses.dataclass
 class Request:
-    """Request from the user."""
+    """Request to set power to the `PowerDistributingActor`."""
 
-    # How much power to set
     power: int
-    # In which batteries the power should be set
-    batteries: Set[int]
-    # Timeout for the server to respond on the requests.
+    """The amount of power to be set."""
+
+    batteries: set[int]
+    """The set of batteries to use when requesting the power to be set."""
+
     request_timeout_sec: float = 5.0
-    # If True and requested power value is above upper bound, then the power will be
-    # decreased to match the bounds. Only the decreased power will be set.
-    # If False and the requested power is above upper bound, then request won't
-    # be processed. result.OutOfBound message will be send back to the user.
+    """The maximum amount of time to wait for the request to be fulfilled."""
+
     adjust_power: bool = True
+    """Whether to adjust the power to match the bounds.
+
+    If `True`, the power will be adjusted (lowered) to match the bounds, so
+    only the decreased power will be set.
+
+    If `False` and the power is outside the batteries' bounds, the request will
+    fail and replied to with an `OutOfBound` result.
+    """

--- a/src/frequenz/sdk/actor/power_distributing/result.py
+++ b/src/frequenz/sdk/actor/power_distributing/result.py
@@ -27,8 +27,8 @@ class Success(Result):
     def __init__(
         self,
         request: Request,
-        succeed_power: int,
-        used_batteries: Set[int],
+        succeeded_power: int,
+        succeeded_batteries: Set[int],
         excess_power: int,
     ) -> None:
         """Create class instance.
@@ -42,8 +42,8 @@ class Success(Result):
                 because it was outside available power bounds.
         """
         super().__init__(request)
-        self.succeed_power: int = succeed_power
-        self.used_batteries: Set[int] = used_batteries
+        self.succeed_power: int = succeeded_power
+        self.used_batteries: Set[int] = succeeded_batteries
         self.excess_power: int = excess_power
 
 
@@ -56,8 +56,8 @@ class PartialFailure(Result):
     def __init__(  # pylint: disable=too-many-arguments
         self,
         request: Request,
-        succeed_power: int,
-        succeed_batteries: Set[int],
+        succeeded_power: int,
+        succeeded_batteries: Set[int],
         failed_power: int,
         failed_batteries: Set[int],
         excess_power: int,
@@ -76,8 +76,8 @@ class PartialFailure(Result):
                 because it was outside available power bounds.
         """
         super().__init__(request)
-        self.succeed_power: int = succeed_power
-        self.succeed_batteries: Set[int] = succeed_batteries
+        self.succeed_power: int = succeeded_power
+        self.succeed_batteries: Set[int] = succeeded_batteries
         self.failed_power: int = failed_power
         self.failed_batteries: Set[int] = failed_batteries
         self.excess_power: int = excess_power

--- a/src/frequenz/sdk/actor/power_distributing/result.py
+++ b/src/frequenz/sdk/actor/power_distributing/result.py
@@ -55,7 +55,7 @@ class _BaseSuccessMixin:
 
 @dataclasses.dataclass
 class Success(_BaseSuccessMixin, Result):  # Order matters here. See above.
-    """Result returned when setting the power succeed for all batteries."""
+    """Result returned when setting the power succeeded for all batteries."""
 
 
 @dataclasses.dataclass

--- a/tests/actor/test_power_distributing.py
+++ b/tests/actor/test_power_distributing.py
@@ -179,7 +179,7 @@ class TestPowerDistributingActor:
 
         result: Result = done.pop().result()
         assert isinstance(result, Success)
-        assert result.succeed_power == 1000
+        assert result.succeeded_power == 1000
         assert result.excess_power == 200
         assert result.request == request
 
@@ -238,8 +238,8 @@ class TestPowerDistributingActor:
 
         result: Result = done.pop().result()
         assert isinstance(result, Success)
-        assert result.used_batteries == {206}
-        assert result.succeed_power == 500
+        assert result.succeeded_batteries == {206}
+        assert result.succeeded_power == 500
         assert result.excess_power == 700
         assert result.request == request
 
@@ -291,8 +291,8 @@ class TestPowerDistributingActor:
 
         result: Result = done.pop().result()
         assert isinstance(result, Success)
-        assert result.used_batteries == {206}
-        assert result.succeed_power == 500
+        assert result.succeeded_batteries == {206}
+        assert result.succeeded_power == 500
         assert result.excess_power == 700
         assert result.request == request
 
@@ -360,8 +360,8 @@ class TestPowerDistributingActor:
 
         result: Result = done.pop().result()
         assert isinstance(result, Success)
-        assert result.used_batteries == {206}
-        assert result.succeed_power == 1000
+        assert result.succeeded_batteries == {206}
+        assert result.succeeded_power == 1000
         assert result.excess_power == 200
         assert result.request == request
 
@@ -695,7 +695,7 @@ class TestPowerDistributingActor:
 
         result = done.pop().result()
         assert isinstance(result, Success)
-        assert result.succeed_power == 1000
+        assert result.succeeded_power == 1000
         assert result.excess_power == 0
         assert result.request == request
 
@@ -739,5 +739,5 @@ class TestPowerDistributingActor:
         result = done.pop().result()
         assert isinstance(result, Success)
         assert result.excess_power == 700
-        assert result.succeed_power == 500
+        assert result.succeeded_power == 500
         assert result.request == request


### PR DESCRIPTION
We make `Result` and its subclasses dataclasses so they have a proper `__str__()` method that shows the details.

We also make some property renaming to make it more consistent and improve documentation.

Fixes #275.