### PR TITLE
Fix ring buffer benchmarks

### DIFF
--- a/benchmarks/timeseries/ringbuffer_memusage.py
+++ b/benchmarks/timeseries/ringbuffer_memusage.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import argparse
 import tracemalloc
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import numpy as np
 
@@ -71,7 +71,12 @@ def main(ringbuffer_len: int, iterations: int, gap_size: int) -> None:
 
     for i in range(0, ringbuffer_len * iterations, gap_size + 1):
         ringbuffer.update(
-            Sample(datetime.fromtimestamp(200 + i * FIVE_MINUTES.total_seconds()), i)
+            Sample(
+                datetime.fromtimestamp(
+                    200 + i * FIVE_MINUTES.total_seconds(), tz=timezone.utc
+                ),
+                i,
+            )
         )
 
     # Snapshot memory allocations after ringbuffer update

--- a/benchmarks/timeseries/serializable_ringbuffer.py
+++ b/benchmarks/timeseries/serializable_ringbuffer.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import fnmatch
 import os
 import time
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Any
 
 import numpy as np
@@ -68,7 +68,12 @@ def main() -> None:
 
     for i in range(0, SIZE, 10000):
         ringbuffer.update(
-            Sample(datetime.fromtimestamp(200 + i * FIVE_MINUTES.total_seconds()), i)
+            Sample(
+                datetime.fromtimestamp(
+                    200 + i * FIVE_MINUTES.total_seconds(), tz=timezone.utc
+                ),
+                i,
+            )
         )
 
     print(


### PR DESCRIPTION
The `OrderedRingBuffer` class was previously updated to use datetime aware objects. Thus, the new ring buffer benchmarks needs to be updated to fix type errors as arithmetic operation cannot be performed using both naive and aware datetimes.