### PR TITLE
Make the resampler use timedelta for periods

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -19,6 +19,7 @@
   to better distinguish it from the sampling period parameter in the resampler.
 * The serialization feature for the ringbuffer was made more flexible. The `dump` and `load` methods can now work directly with a ringbuffer instance.
 * The `ResamplerConfig` now takes the resampling period as a `timedelta`. The configuration was renamed from `resampling_period_s` to `resampling_period` accordingly.
+* The `SourceProperties` of the resampler now uses a `timedelta` for the input sampling period. The attribute was renamed from `sampling_period_s` to `sampling_period` accordingly.
 
 ## New Features
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -18,6 +18,7 @@
   Notice that the parameter `sampling_period` has been renamed to `input_sampling_period`
   to better distinguish it from the sampling period parameter in the resampler.
 * The serialization feature for the ringbuffer was made more flexible. The `dump` and `load` methods can now work directly with a ringbuffer instance.
+* The `ResamplerConfig` now takes the resampling period as a `timedelta`. The configuration was renamed from `resampling_period_s` to `resampling_period` accordingly.
 
 ## New Features
 

--- a/benchmarks/power_distribution/power_distributor.py
+++ b/benchmarks/power_distribution/power_distributor.py
@@ -8,6 +8,7 @@ import csv
 import random
 import timeit
 from dataclasses import dataclass
+from datetime import timedelta
 from typing import Any, Coroutine, Dict, List, Set  # pylint: disable=unused-import
 
 from frequenz.channels import Bidirectional, Broadcast
@@ -154,7 +155,9 @@ async def run() -> None:
     """Create microgrid api and run tests."""
     # pylint: disable=protected-access
 
-    await microgrid.initialize(HOST, PORT, ResamplerConfig(resampling_period_s=1.0))
+    await microgrid.initialize(
+        HOST, PORT, ResamplerConfig(resampling_period=timedelta(seconds=1.0))
+    )
 
     all_batteries: Set[Component] = connection_manager.get().component_graph.components(
         component_category={ComponentCategory.BATTERY}

--- a/benchmarks/timeseries/resampling.py
+++ b/benchmarks/timeseries/resampling.py
@@ -29,7 +29,7 @@ def _benchmark_resampling_helper(resamples: int, samples: int) -> None:
     helper = _ResamplingHelper(
         "benchmark",
         ResamplerConfig(
-            resampling_period_s=1.0,
+            resampling_period=timedelta(seconds=1.0),
             max_data_age_in_periods=3.0,
             resampling_function=nop,
             initial_buffer_len=samples * 3,

--- a/examples/battery_pool.py
+++ b/examples/battery_pool.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from datetime import timedelta
 from typing import Any, Dict
 
 from frequenz.channels import Receiver
@@ -25,7 +26,9 @@ async def main() -> None:
         level=logging.DEBUG, format="%(asctime)s %(name)s %(levelname)s:%(message)s"
     )
     await microgrid.initialize(
-        host=HOST, port=PORT, resampler_config=ResamplerConfig(resampling_period_s=1.0)
+        host=HOST,
+        port=PORT,
+        resampler_config=ResamplerConfig(resampling_period=timedelta(seconds=1.0)),
     )
 
     battery_pool = microgrid.battery_pool()

--- a/examples/battery_status.py
+++ b/examples/battery_status.py
@@ -9,6 +9,7 @@ this feature.
 
 import asyncio
 import logging
+from datetime import timedelta
 
 from frequenz.channels import Broadcast
 
@@ -31,7 +32,9 @@ async def main() -> None:
     logging.basicConfig(
         level=logging.DEBUG, format="%(asctime)s %(name)s %(levelname)s:%(message)s"
     )
-    await microgrid.initialize(HOST, PORT, ResamplerConfig(resampling_period_s=1.0))
+    await microgrid.initialize(
+        HOST, PORT, ResamplerConfig(resampling_period=timedelta(seconds=1.0))
+    )
     batteries = {
         bat.component_id
         for bat in connection_manager.get().component_graph.components(

--- a/examples/power_distribution.py
+++ b/examples/power_distribution.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from queue import Queue
 from typing import List, Optional, Set
 
@@ -159,7 +159,9 @@ async def run() -> None:
     logging.basicConfig(
         level=logging.DEBUG, format="%(asctime)s %(name)s %(levelname)s:%(message)s"
     )
-    await microgrid.initialize(HOST, PORT, ResamplerConfig(resampling_period_s=1.0))
+    await microgrid.initialize(
+        HOST, PORT, ResamplerConfig(resampling_period=timedelta(seconds=1.0))
+    )
 
     channel_registry = ChannelRegistry(name="Microgrid Channel Registry")
 
@@ -180,7 +182,7 @@ async def run() -> None:
         channel_registry=channel_registry,
         data_sourcing_request_sender=data_source_request_channel.new_sender(),
         resampling_request_receiver=resampling_actor_request_channel.new_receiver(),
-        config=ResamplerConfig(resampling_period_s=1.0),
+        config=ResamplerConfig(resampling_period=timedelta(seconds=1.0)),
     )
 
     logical_meter = LogicalMeter(

--- a/examples/resampling.py
+++ b/examples/resampling.py
@@ -4,7 +4,7 @@
 """Frequenz Python SDK resampling example."""
 
 import asyncio
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 from frequenz.channels import Broadcast
 from frequenz.channels.util import Merge
@@ -43,7 +43,9 @@ async def _print_sample(sample: Sample) -> None:
 
 async def run() -> None:  # pylint: disable=too-many-locals
     """Run main functions that initializes and creates everything."""
-    await microgrid.initialize(HOST, PORT, ResamplerConfig(resampling_period_s=0.2))
+    await microgrid.initialize(
+        HOST, PORT, ResamplerConfig(resampling_period=timedelta(seconds=0.2))
+    )
 
     channel_registry = ChannelRegistry(name="data-registry")
 
@@ -66,7 +68,7 @@ async def run() -> None:  # pylint: disable=too-many-locals
         channel_registry=channel_registry,
         data_sourcing_request_sender=data_source_request_sender,
         resampling_request_receiver=resampling_request_receiver,
-        config=ResamplerConfig(resampling_period_s=1),
+        config=ResamplerConfig(resampling_period=timedelta(seconds=1)),
     )
 
     components = await connection_manager.get().api_client.components()
@@ -105,7 +107,9 @@ async def run() -> None:  # pylint: disable=too-many-locals
     # Create a channel to calculate an average for all the data
     average_chan = Broadcast[Sample]("average")
 
-    second_stage_resampler = Resampler(ResamplerConfig(resampling_period_s=3.0))
+    second_stage_resampler = Resampler(
+        ResamplerConfig(resampling_period=timedelta(seconds=3.0))
+    )
     second_stage_resampler.add_timeseries(
         "avg", average_chan.new_receiver(), _print_sample
     )

--- a/src/frequenz/sdk/microgrid/_data_pipeline.py
+++ b/src/frequenz/sdk/microgrid/_data_pipeline.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 import typing
 from collections import abc
 from dataclasses import dataclass
-from datetime import timedelta
 
 from frequenz.channels import Bidirectional, Broadcast, Sender
 
@@ -175,9 +174,7 @@ class _DataPipeline:
                 batteries_status_receiver=self._battery_status_channel.new_receiver(
                     maxsize=1
                 ),
-                min_update_interval=timedelta(
-                    seconds=self._resampler_config.resampling_period_s
-                ),
+                min_update_interval=self._resampler_config.resampling_period,
                 batteries_id=battery_ids,
             )
 

--- a/src/frequenz/sdk/timeseries/_moving_window.py
+++ b/src/frequenz/sdk/timeseries/_moving_window.py
@@ -142,13 +142,12 @@ class MovingWindow:
         self._resampler_task: asyncio.Task[None] | None = None
 
         if resampler_config:
-            resampling_period = timedelta(seconds=resampler_config.resampling_period_s)
             assert (
-                resampling_period <= size
+                resampler_config.resampling_period <= size
             ), "The resampling period should be equal to or lower than the window size."
 
             self._resampler = Resampler(resampler_config)
-            sampling = resampling_period
+            sampling = resampler_config.resampling_period
 
         # Sampling period might not fit perfectly into the window size.
         num_samples = math.ceil(size.total_seconds() / sampling.total_seconds())

--- a/src/frequenz/sdk/timeseries/_resampling.py
+++ b/src/frequenz/sdk/timeseries/_resampling.py
@@ -428,30 +428,6 @@ class Resampler:
             return False
         return True
 
-    async def _wait_for_next_resampling_period(self) -> None:
-        """Wait for next resampling period.
-
-        If resampling period already started, then return without sleeping.
-        That would allow us to catch up with resampling.
-        Print warning if function woke up to late.
-        """
-        now = datetime.now(tz=timezone.utc)
-        if self._window_end > now:
-            sleep_for = self._window_end - now
-            await asyncio.sleep(sleep_for.total_seconds())
-
-        timer_error_s = (now - self._window_end).total_seconds()
-        if timer_error_s > (self._config.resampling_period_s / 10.0):
-            _logger.warning(
-                "The resampling task woke up too late. Resampling should have started "
-                "at %s, but it started at %s (%s seconds difference; resampling "
-                "period is %s seconds)",
-                self._window_end,
-                now,
-                timer_error_s,
-                self._config.resampling_period_s,
-            )
-
     async def resample(self, *, one_shot: bool = False) -> None:
         """Start resampling all known timeseries.
 
@@ -492,6 +468,30 @@ class Resampler:
                 raise ResamplingError(exceptions)
             if one_shot:
                 break
+
+    async def _wait_for_next_resampling_period(self) -> None:
+        """Wait for next resampling period.
+
+        If resampling period already started, then return without sleeping.
+        That would allow us to catch up with resampling.
+        Print warning if function woke up to late.
+        """
+        now = datetime.now(tz=timezone.utc)
+        if self._window_end > now:
+            sleep_for = self._window_end - now
+            await asyncio.sleep(sleep_for.total_seconds())
+
+        timer_error_s = (now - self._window_end).total_seconds()
+        if timer_error_s > (self._config.resampling_period_s / 10.0):
+            _logger.warning(
+                "The resampling task woke up too late. Resampling should have started "
+                "at %s, but it started at %s (%s seconds difference; resampling "
+                "period is %s seconds)",
+                self._window_end,
+                now,
+                timer_error_s,
+                self._config.resampling_period_s,
+            )
 
 
 class _ResamplingHelper:

--- a/src/frequenz/sdk/timeseries/_resampling.py
+++ b/src/frequenz/sdk/timeseries/_resampling.py
@@ -76,10 +76,10 @@ ResamplingFunction = Callable[
 
 A resampling function produces a new sample based on a list of pre-existing
 samples. It can do "upsampling" when there data rate of the `input_samples`
-period is smaller than the `resampling_period_s`, or "downsampling" if it is
+period is smaller than the `resampling_period`, or "downsampling" if it is
 bigger.
 
-In general a resampling window is the same as the `resampling_period_s`, and
+In general a resampling window is the same as the `resampling_period`, and
 this function might receive input samples from multiple windows in the past to
 enable extrapolation, but no samples from the future (so the timestamp of the
 new sample that is going to be produced will always be bigger than the biggest
@@ -123,18 +123,18 @@ def average(
 class ResamplerConfig:
     """Resampler configuration."""
 
-    resampling_period_s: float
-    """The resampling period in seconds.
+    resampling_period: timedelta
+    """The resampling period.
 
     This is the time it passes between resampled data should be calculated.
 
-    It must be a positive number.
+    It must be a positive time span.
     """
 
     max_data_age_in_periods: float = 3.0
     """The maximum age a sample can have to be considered *relevant* for resampling.
 
-    Expressed in number of periods, where period is the `resampling_period_s`
+    Expressed in number of periods, where period is the `resampling_period`
     if we are downsampling (resampling period bigger than the input period) or
     the input sampling period if we are upsampling (input period bigger than
     the resampling period).
@@ -142,12 +142,12 @@ class ResamplerConfig:
     It must be bigger than 1.0.
 
     Example:
-        If `resampling_period_s` is 3, the input sampling period is
+        If `resampling_period` is 3 seconds, the input sampling period is
         1 and `max_data_age_in_periods` is 2, then data older than 3*2
         = 6 seconds will be discarded when creating a new sample and never
         passed to the resampling function.
 
-        If `resampling_period_s` is 3, the input sampling period is
+        If `resampling_period` is 3 seconds, the input sampling period is
         5 and `max_data_age_in_periods` is 2, then data older than 5*2
         = 10 seconds will be discarded when creating a new sample and never
         passed to the resampling function.
@@ -197,9 +197,9 @@ class ResamplerConfig:
         Raises:
             ValueError: If any value is out of range.
         """
-        if self.resampling_period_s < 0.0:
+        if self.resampling_period.total_seconds() < 0.0:
             raise ValueError(
-                f"resampling_period_s ({self.resampling_period_s}) must be positive"
+                f"resampling_period ({self.resampling_period}) must be positive"
             )
         if self.max_data_age_in_periods < 1.0:
             raise ValueError(
@@ -348,8 +348,8 @@ class Resampler:
         self._resamplers: dict[Source, _StreamingHelper] = {}
         """A mapping between sources and the streaming helper handling that source."""
 
-        self._window_end: datetime = datetime.now(timezone.utc) + timedelta(
-            seconds=self._config.resampling_period_s
+        self._window_end: datetime = (
+            datetime.now(timezone.utc) + self._config.resampling_period
         )
         """The time in which the current window ends.
 
@@ -449,9 +449,7 @@ class Resampler:
                 return_exceptions=True,
             )
 
-            self._window_end = self._window_end + timedelta(
-                seconds=self._config.resampling_period_s
-            )
+            self._window_end = self._window_end + self._config.resampling_period
             exceptions = {
                 source: results[i]
                 for i, source in enumerate(self._resamplers)
@@ -476,16 +474,21 @@ class Resampler:
             sleep_for = self._window_end - now
             await asyncio.sleep(sleep_for.total_seconds())
 
-        timer_error_s = (now - self._window_end).total_seconds()
-        if timer_error_s > (self._config.resampling_period_s / 10.0):
+        timer_error = now - self._window_end
+        # We use a tolerance of 10% of the resampling period
+        tolerance = timedelta(
+            seconds=self._config.resampling_period.total_seconds() / 10.0
+        )
+        if timer_error > tolerance:
             _logger.warning(
-                "The resampling task woke up too late. Resampling should have started "
-                "at %s, but it started at %s (%s seconds difference; resampling "
-                "period is %s seconds)",
+                "The resampling task woke up too late. Resampling should have "
+                "started at %s, but it started at %s (tolerance: %s, "
+                "difference: %s; resampling period: %s)",
                 self._window_end,
                 now,
-                timer_error_s,
-                self._config.resampling_period_s,
+                tolerance,
+                timer_error,
+                self._config.resampling_period,
             )
 
 
@@ -493,8 +496,8 @@ class _ResamplingHelper:
     """Keeps track of *relevant* samples to pass them to the resampling function.
 
     Samples are stored in an internal ring buffer. All collected samples that
-    are newer than `max(resampling_period_s, input_period_s)
-    * max_data_age_in_periods` seconds are considered *relevant* and are passed
+    are newer than `max(resampling_period, input_period_s)
+    * max_data_age_in_periods` are considered *relevant* and are passed
     to the provided `resampling_function` when calling the `resample()` method.
     All older samples are discarded.
     """
@@ -552,7 +555,7 @@ class _ResamplingHelper:
             props.sampling_period_s is not None
             or props.sampling_start is None
             or props.received_samples
-            < config.resampling_period_s * config.max_data_age_in_periods
+            < config.resampling_period.total_seconds() * config.max_data_age_in_periods
             or len(self._buffer) < self._buffer.maxlen
             # There might be a race between the first sample being received and
             # this function being called
@@ -589,14 +592,14 @@ class _ResamplingHelper:
         # If we are upsampling, one sample could be enough for back-filling, but
         # we store max_data_age_in_periods for input periods, so resampling
         # functions can do more complex inter/extrapolation if they need to.
-        if input_sampling_period_s > config.resampling_period_s:
+        if input_sampling_period_s > config.resampling_period.total_seconds():
             new_buffer_len = input_sampling_period_s * config.max_data_age_in_periods
         # If we are upsampling, we want a buffer that can hold
-        # max_data_age_in_periods * resampling_period_s seconds of data, and we
+        # max_data_age_in_periods * resampling_period of data, and we
         # one sample every input_sampling_period_s.
         else:
             new_buffer_len = (
-                config.resampling_period_s
+                config.resampling_period.total_seconds()
                 / input_sampling_period_s
                 * config.max_data_age_in_periods
             )
@@ -652,9 +655,9 @@ class _ResamplingHelper:
         # To see which samples are relevant we need to consider if we are down
         # or upsampling.
         period = (
-            max(conf.resampling_period_s, props.sampling_period_s)
+            max(conf.resampling_period.total_seconds(), props.sampling_period_s)
             if props.sampling_period_s is not None
-            else conf.resampling_period_s
+            else conf.resampling_period.total_seconds()
         )
         minimum_relevant_timestamp = timestamp - timedelta(
             seconds=period * conf.max_data_age_in_periods

--- a/src/frequenz/sdk/timeseries/_resampling.py
+++ b/src/frequenz/sdk/timeseries/_resampling.py
@@ -15,8 +15,6 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from typing import AsyncIterator, Callable, Coroutine, Optional, Sequence
 
-from frequenz.channels.util import Timer
-
 from .._internal.asyncio import cancel_and_await
 from . import Sample
 
@@ -349,9 +347,6 @@ class Resampler:
 
         self._resamplers: dict[Source, _StreamingHelper] = {}
         """A mapping between sources and the streaming helper handling that source."""
-
-        self._timer: Timer = Timer(config.resampling_period_s)
-        """The timer to trigger the next resampling."""
 
         self._window_end: datetime = datetime.now(timezone.utc) + timedelta(
             seconds=self._config.resampling_period_s

--- a/tests/actor/test_resampling.py
+++ b/tests/actor/test_resampling.py
@@ -4,7 +4,7 @@
 """Frequenz Python SDK resampling example."""
 import asyncio
 import dataclasses
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Iterator
 
 import async_solipsism
@@ -126,7 +126,7 @@ async def test_single_request(
         data_sourcing_request_sender=data_source_req_chan.new_sender(),
         resampling_request_receiver=resampling_req_chan.new_receiver(),
         config=ResamplerConfig(
-            resampling_period_s=0.2,
+            resampling_period=timedelta(seconds=0.2),
             max_data_age_in_periods=2,
         ),
     )
@@ -172,7 +172,7 @@ async def test_duplicate_request(
         data_sourcing_request_sender=data_source_req_chan.new_sender(),
         resampling_request_receiver=resampling_req_chan.new_receiver(),
         config=ResamplerConfig(
-            resampling_period_s=0.2,
+            resampling_period=timedelta(seconds=0.2),
             max_data_age_in_periods=2,
         ),
     )

--- a/tests/timeseries/_battery_pool/test_battery_pool.py
+++ b/tests/timeseries/_battery_pool/test_battery_pool.py
@@ -8,7 +8,7 @@ import asyncio
 import dataclasses
 import logging
 from dataclasses import dataclass, is_dataclass, replace
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Any, AsyncIterator, Generic, Iterator, TypeVar
 
 import async_solipsism
@@ -134,7 +134,9 @@ async def setup_all_batteries(mocker: MockerFixture) -> AsyncIterator[SetupArgs]
     min_update_interval: float = 0.2
     # pylint: disable=protected-access
     microgrid._data_pipeline._DATA_PIPELINE = None
-    microgrid._data_pipeline.initialize(ResamplerConfig(min_update_interval))
+    microgrid._data_pipeline.initialize(
+        ResamplerConfig(resampling_period=timedelta(seconds=min_update_interval))
+    )
     streamer = MockComponentDataStreamer(mock_microgrid)
 
     # We don't use status channel from the sdk interface to limit
@@ -184,7 +186,9 @@ async def setup_batteries_pool(mocker: MockerFixture) -> AsyncIterator[SetupArgs
     min_update_interval: float = 0.2
     # pylint: disable=protected-access
     microgrid._data_pipeline._DATA_PIPELINE = None
-    microgrid._data_pipeline.initialize(ResamplerConfig(min_update_interval))
+    microgrid._data_pipeline.initialize(
+        ResamplerConfig(resampling_period=timedelta(seconds=min_update_interval))
+    )
 
     # We don't use status channel from the sdk interface to limit
     # the scope of this tests. This tests should cover BatteryPool only.

--- a/tests/timeseries/mock_microgrid.py
+++ b/tests/timeseries/mock_microgrid.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import asyncio
 import typing
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Callable, Set
 
 from pytest_mock import MockerFixture
@@ -119,7 +119,7 @@ class MockMicrogrid:  # pylint: disable=too-many-instance-attributes
 
         # pylint: disable=protected-access
         _data_pipeline._DATA_PIPELINE = _data_pipeline._DataPipeline(
-            ResamplerConfig(resampling_period_s=self._sample_rate_s)
+            ResamplerConfig(resampling_period=timedelta(seconds=self._sample_rate_s))
         )
         # pylint: enable=protected-access
 

--- a/tests/timeseries/test_moving_window.py
+++ b/tests/timeseries/test_moving_window.py
@@ -113,9 +113,7 @@ async def test_resampling_window(fake_time: time_machine.Coordinates) -> None:
     window_size = timedelta(seconds=16)
     input_sampling = timedelta(seconds=1)
     output_sampling = timedelta(seconds=2)
-    resampler_config = ResamplerConfig(
-        resampling_period_s=output_sampling.total_seconds()
-    )
+    resampler_config = ResamplerConfig(resampling_period=output_sampling)
 
     window = MovingWindow(
         size=window_size,

--- a/tests/timeseries/test_resampling.py
+++ b/tests/timeseries/test_resampling.py
@@ -407,7 +407,7 @@ async def test_future_samples_not_included(
         a_sequence(sample0s, sample1s), config, source_props  # sample2_1s is not here
     )
     assert source_props == SourceProperties(
-        sampling_start=timestamp, received_samples=3, sampling_period_s=None
+        sampling_start=timestamp, received_samples=3, sampling_period=None
     )
     assert _get_buffer_len(resampler, source_receiver) == config.initial_buffer_len
     sink_mock.reset_mock()
@@ -489,7 +489,7 @@ async def test_resampling_with_one_window(
         a_sequence(sample1s), config, source_props
     )
     assert source_props == SourceProperties(
-        sampling_start=timestamp, received_samples=2, sampling_period_s=None
+        sampling_start=timestamp, received_samples=2, sampling_period=None
     )
     assert _get_buffer_len(resampler, source_recvr) == config.initial_buffer_len
     sink_mock.reset_mock()
@@ -518,7 +518,9 @@ async def test_resampling_with_one_window(
     # By now we have a full buffer (5 samples and a buffer of length 4), which
     # we received in 4 seconds, so we have an input period of 0.8s.
     assert source_props == SourceProperties(
-        sampling_start=timestamp, received_samples=5, sampling_period_s=0.8
+        sampling_start=timestamp,
+        received_samples=5,
+        sampling_period=timedelta(seconds=0.8),
     )
     # The buffer should be able to hold 2 seconds of data, and data is coming
     # every 0.8 seconds, so we should be able to store 3 samples.
@@ -536,7 +538,9 @@ async def test_resampling_with_one_window(
         current_iteration=3,
     )
     assert source_props == SourceProperties(
-        sampling_start=timestamp, received_samples=5, sampling_period_s=0.8
+        sampling_start=timestamp,
+        received_samples=5,
+        sampling_period=timedelta(seconds=0.8),
     )
     assert _get_buffer_len(resampler, source_recvr) == 3
 
@@ -598,7 +602,7 @@ async def test_resampling_with_one_and_a_half_windows(  # pylint: disable=too-ma
         a_sequence(sample0s, sample1s), config, source_props
     )
     assert source_props == SourceProperties(
-        sampling_start=timestamp, received_samples=2, sampling_period_s=None
+        sampling_start=timestamp, received_samples=2, sampling_period=None
     )
     assert _get_buffer_len(resampler, source_recvr) == config.initial_buffer_len
     sink_mock.reset_mock()
@@ -626,7 +630,7 @@ async def test_resampling_with_one_and_a_half_windows(  # pylint: disable=too-ma
         a_sequence(sample2_5s, sample3s, sample4s), config, source_props
     )
     assert source_props == SourceProperties(
-        sampling_start=timestamp, received_samples=5, sampling_period_s=None
+        sampling_start=timestamp, received_samples=5, sampling_period=None
     )
     assert _get_buffer_len(resampler, source_recvr) == config.initial_buffer_len
     sink_mock.reset_mock()
@@ -654,7 +658,9 @@ async def test_resampling_with_one_and_a_half_windows(  # pylint: disable=too-ma
     # By now we have a full buffer (7 samples and a buffer of length 6), which
     # we received in 4 seconds, so we have an input period of 6/7s.
     assert source_props == SourceProperties(
-        sampling_start=timestamp, received_samples=7, sampling_period_s=6 / 7
+        sampling_start=timestamp,
+        received_samples=7,
+        sampling_period=timedelta(seconds=6 / 7),
     )
     # The buffer should be able to hold 2 * 1.5 (3) seconds of data, and data
     # is coming every 6/7 seconds (~0.857s), so we should be able to store
@@ -693,7 +699,9 @@ async def test_resampling_with_one_and_a_half_windows(  # pylint: disable=too-ma
         current_iteration=5,
     )
     assert source_props == SourceProperties(
-        sampling_start=timestamp, received_samples=7, sampling_period_s=6 / 7
+        sampling_start=timestamp,
+        received_samples=7,
+        sampling_period=timedelta(seconds=6 / 7),
     )
     assert _get_buffer_len(resampler, source_recvr) == 4
 
@@ -755,7 +763,7 @@ async def test_resampling_with_two_windows(  # pylint: disable=too-many-statemen
         a_sequence(sample0s, sample1s), config, source_props
     )
     assert source_props == SourceProperties(
-        sampling_start=timestamp, received_samples=2, sampling_period_s=None
+        sampling_start=timestamp, received_samples=2, sampling_period=None
     )
     assert _get_buffer_len(resampler, source_recvr) == config.initial_buffer_len
     sink_mock.reset_mock()
@@ -783,7 +791,7 @@ async def test_resampling_with_two_windows(  # pylint: disable=too-many-statemen
         a_sequence(sample1s, sample2_5s, sample3s, sample4s), config, source_props
     )
     assert source_props == SourceProperties(
-        sampling_start=timestamp, received_samples=5, sampling_period_s=None
+        sampling_start=timestamp, received_samples=5, sampling_period=None
     )
     assert _get_buffer_len(resampler, source_recvr) == config.initial_buffer_len
     sink_mock.reset_mock()
@@ -811,7 +819,7 @@ async def test_resampling_with_two_windows(  # pylint: disable=too-many-statemen
         source_props,
     )
     assert source_props == SourceProperties(
-        sampling_start=timestamp, received_samples=7, sampling_period_s=None
+        sampling_start=timestamp, received_samples=7, sampling_period=None
     )
     assert _get_buffer_len(resampler, source_recvr) == config.initial_buffer_len
     sink_mock.reset_mock()
@@ -833,7 +841,7 @@ async def test_resampling_with_two_windows(  # pylint: disable=too-many-statemen
         a_sequence(sample5s, sample6s), config, source_props
     )
     assert source_props == SourceProperties(
-        sampling_start=timestamp, received_samples=7, sampling_period_s=None
+        sampling_start=timestamp, received_samples=7, sampling_period=None
     )
     assert _get_buffer_len(resampler, source_recvr) == config.initial_buffer_len
     sink_mock.reset_mock()
@@ -849,7 +857,7 @@ async def test_resampling_with_two_windows(  # pylint: disable=too-many-statemen
         current_iteration=5,
     )
     assert source_props == SourceProperties(
-        sampling_start=timestamp, received_samples=7, sampling_period_s=None
+        sampling_start=timestamp, received_samples=7, sampling_period=None
     )
     assert _get_buffer_len(resampler, source_recvr) == config.initial_buffer_len
 

--- a/tests/timeseries/test_resampling.py
+++ b/tests/timeseries/test_resampling.py
@@ -93,7 +93,7 @@ async def test_resampler_config_len_ok(
 ) -> None:
     """Test checks on the resampling buffer."""
     config = ResamplerConfig(
-        resampling_period_s=1.0,
+        resampling_period=timedelta(seconds=1.0),
         initial_buffer_len=init_len,
     )
     assert config.initial_buffer_len == init_len
@@ -110,7 +110,7 @@ async def test_resampler_config_len_warn(
 ) -> None:
     """Test checks on the resampling buffer."""
     config = ResamplerConfig(
-        resampling_period_s=1.0,
+        resampling_period=timedelta(seconds=1.0),
         initial_buffer_len=init_len,
     )
     assert config.initial_buffer_len == init_len
@@ -133,7 +133,7 @@ async def test_resampler_config_len_error(init_len: int) -> None:
     """Test checks on the resampling buffer."""
     with pytest.raises(ValueError):
         _ = ResamplerConfig(
-            resampling_period_s=1.0,
+            resampling_period=timedelta(seconds=1.0),
             initial_buffer_len=init_len,
         )
 
@@ -144,7 +144,7 @@ async def test_helper_buffer_too_big(
 ) -> None:
     """Test checks on the resampling buffer."""
     config = ResamplerConfig(
-        resampling_period_s=DEFAULT_BUFFER_LEN_MAX + 1,
+        resampling_period=timedelta(seconds=DEFAULT_BUFFER_LEN_MAX + 1),
         max_data_age_in_periods=1,
     )
     helper = _ResamplingHelper("test", config)
@@ -181,7 +181,7 @@ async def test_resampling_window_size_is_constant(
         spec=ResamplingFunction, return_value=expected_resampled_value
     )
     config = ResamplerConfig(
-        resampling_period_s=resampling_period_s,
+        resampling_period=timedelta(seconds=resampling_period_s),
         max_data_age_in_periods=1.0,
         resampling_function=resampling_fun_mock,
         initial_buffer_len=4,
@@ -265,7 +265,7 @@ async def test_timer_errors_are_logged(
         spec=ResamplingFunction, return_value=expected_resampled_value
     )
     config = ResamplerConfig(
-        resampling_period_s=resampling_period_s,
+        resampling_period=timedelta(seconds=resampling_period_s),
         max_data_age_in_periods=2.0,
         resampling_function=resampling_fun_mock,
         initial_buffer_len=4,
@@ -342,9 +342,9 @@ async def test_timer_errors_are_logged(
         "frequenz.sdk.timeseries._resampling",
         logging.WARNING,
         "The resampling task woke up too late. Resampling should have started at "
-        "1970-01-01 00:00:04+00:00, but it started at "
-        "1970-01-01 00:00:04.399800+00:00 (0.3998 seconds difference; resampling "
-        "period is 2 seconds)",
+        "1970-01-01 00:00:04+00:00, but it started at 1970-01-01 "
+        "00:00:04.399800+00:00 (tolerance: 0:00:00.200000, difference: "
+        "0:00:00.399800; resampling period: 0:00:02)",
     ) in _filter_logs(caplog.record_tuples, logger_level=logging.WARNING)
     sink_mock.reset_mock()
     resampling_fun_mock.reset_mock()
@@ -363,7 +363,7 @@ async def test_future_samples_not_included(
         spec=ResamplingFunction, return_value=expected_resampled_value
     )
     config = ResamplerConfig(
-        resampling_period_s=resampling_period_s,
+        resampling_period=timedelta(seconds=resampling_period_s),
         max_data_age_in_periods=2.0,
         resampling_function=resampling_fun_mock,
         initial_buffer_len=4,
@@ -448,7 +448,7 @@ async def test_resampling_with_one_window(
         spec=ResamplingFunction, return_value=expected_resampled_value
     )
     config = ResamplerConfig(
-        resampling_period_s=resampling_period_s,
+        resampling_period=timedelta(seconds=resampling_period_s),
         max_data_age_in_periods=1.0,
         resampling_function=resampling_fun_mock,
         initial_buffer_len=4,
@@ -557,7 +557,7 @@ async def test_resampling_with_one_and_a_half_windows(  # pylint: disable=too-ma
         spec=ResamplingFunction, return_value=expected_resampled_value
     )
     config = ResamplerConfig(
-        resampling_period_s=resampling_period_s,
+        resampling_period=timedelta(seconds=resampling_period_s),
         max_data_age_in_periods=1.5,
         resampling_function=resampling_fun_mock,
         initial_buffer_len=7,
@@ -714,7 +714,7 @@ async def test_resampling_with_two_windows(  # pylint: disable=too-many-statemen
         spec=ResamplingFunction, return_value=expected_resampled_value
     )
     config = ResamplerConfig(
-        resampling_period_s=resampling_period_s,
+        resampling_period=timedelta(seconds=resampling_period_s),
         max_data_age_in_periods=2.0,
         resampling_function=resampling_fun_mock,
         initial_buffer_len=16,
@@ -867,7 +867,7 @@ async def test_receiving_stopped_resampling_error(
         spec=ResamplingFunction, return_value=expected_resampled_value
     )
     config = ResamplerConfig(
-        resampling_period_s=resampling_period_s,
+        resampling_period=timedelta(seconds=resampling_period_s),
         max_data_age_in_periods=2.0,
         resampling_function=resampling_fun_mock,
     )
@@ -928,7 +928,7 @@ async def test_receiving_resampling_error(fake_time: time_machine.Coordinates) -
     )
     resampler = Resampler(
         ResamplerConfig(
-            resampling_period_s=resampling_period_s,
+            resampling_period=timedelta(seconds=resampling_period_s),
             max_data_age_in_periods=2.0,
             resampling_function=resampling_fun_mock,
         )


### PR DESCRIPTION
As a step towards [using proper units], now the resampler uses `timedelta` for specifying periods. It also includes a couple of cleanup commits.

- Move private method to the end of the class
- Remove unused timer
- Make the resampling period a `timedelta`
- Make source properties' sampling period a `timedelta`

[using proper units]: https://github.com/frequenz-floss/frequenz-sdk-python/discussions/6