### PR TITLE
Add an option to align resampling windows

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -58,6 +58,10 @@
 
   * The `SourceProperties` of the resampler now uses a `timedelta` for the input sampling period. The attribute was renamed from `sampling_period_s` to `sampling_period` accordingly.
 
+  * The periods are now aligned to the `UNIX_EPOCH` by default.
+
+    To use the old behaviour (aligning to the time the resampler was created), pass `align_to=None` to the `ResamplerConfig`.
+
 ## New Features
 
 * The core data-pipeline actors are now created automatically (#270).
@@ -75,6 +79,10 @@
   ```
 
 * The `Result` class (and subclasses) for the `PowerDistributingActor` are now `dataclass`es, so logging them will produce a more detailed output.
+
+* The `Resampler` can now can align the resampling period to an arbitrary `datetime`.
+
+  This can be configured via the new `align_to` option in the `ResamplerConfig`. By default the resampling period is aligned to the `UNIX_EPOCH`.
 
 ## Bug Fixes
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -12,12 +12,10 @@
   battery_power_receiver = microgrid.battery_pool().power.new_receiver()
   ```
 
-+ Formulas composition has changed (#327) -
-  - receivers from formulas are no longer composable.
-  - formula composition is now done by composing FormulaEngine instances.
-  - Automatic formulas from the logical meter and *pools, are now
-    properties, and return `FormulaEngine` instances, which can be
-    composed further, or can provide a receiver to fetch values.
+* Formulas composition has changed (#327)
+  * Receivers from formulas are no longer composable.
+  * Formula composition is now done by composing FormulaEngine instances.
+  * Automatic formulas from the logical meter and \*pools, are now properties, and return `FormulaEngine` instances, which can be composed further, or can provide a receiver to fetch values.
 
   ``` python
   grid_power_receiver = microgrid.logical_meter().grid_power.new_receiver()
@@ -30,15 +28,15 @@
   inverter_power_receiver = self._inverter_power.new_receiver()
   ```
 
-* Update BatteryStatus to mark battery with unknown capacity as not working (#263)
+* Update `BatteryStatus` to mark battery with unknown capacity as not working (#263)
 * The channels dependency was updated to v0.14.0 (#292)
 * Some properties for `PowerDistributingActor` results were renamed to be more consistent between `Success` and `PartialFailure`:
   * The `Success.used_batteries` property was renamed to `succeeded_batteries`.
   * The `PartialFailure.success_batteries` property was renamed to `succeeded_batteries`.
   * The `succeed_power` property was renamed to `succeeded_power` for both `Success` and `PartialFailure`.
-* Update MovingWindow to accept size parameter as timedelta instead of int (#269).
+* Update `MovingWindow` to accept the `size` parameter as `timedelta` instead of `int` (#269).
   This change allows users to define the time span of the moving window more intuitively, representing the duration over which samples will be stored.
-* Add a resampler in the MovingWindow to control the granularity of the samples to be stored in the underlying buffer (#269).
+* Add a resampler in the `MovingWindow` to control the granularity of the samples to be stored in the underlying buffer (#269).
   Notice that the parameter `sampling_period` has been renamed to `input_sampling_period`
   to better distinguish it from the sampling period parameter in the resampler.
 * The serialization feature for the ringbuffer was made more flexible. The `dump` and `load` methods can now work directly with a ringbuffer instance.
@@ -47,9 +45,11 @@
 
 ## New Features
 
-* Automatic creation of core data-pipeline actors, to eliminate a lot
-  of boiler plate code.  This makes it much simpler to deploy apps
-  (#270).  For example:
+* The core data-pipeline actors are now created automatically (#270).
+
+  This eliminates a lot of boiler plate code and makes it much simpler to deploy apps.
+
+  For example:
 
   ``` python
   async def run():
@@ -59,9 +59,9 @@
       grid_power = microgrid.logical_meter().grid_power()
   ```
 
-* The `Result` class (and subclasses) for the `PowerDistributingActor` are now dataclasses, so logging them will produce a more detailed output.
+* The `Result` class (and subclasses) for the `PowerDistributingActor` are now `dataclass`es, so logging them will produce a more detailed output.
 
 ## Bug Fixes
 
-* Change PowerDistributor to use all batteries if none is working (#258)
-* Update the ordered ring buffer to fix the len() function so that it returns a value equal to or greater than zero, as expected (#274)
+* Change `PowerDistributor` to use all batteries when none are working (#258)
+* Update the ordered ring buffer to fix the `len()` function so that it returns a value equal to or greater than zero, as expected (#274)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -38,18 +38,25 @@
   * The `PartialFailure.success_batteries` property was renamed to `succeeded_batteries`.
   * The `succeed_power` property was renamed to `succeeded_power` for both `Success` and `PartialFailure`.
 
-* Update `MovingWindow` to accept the `size` parameter as `timedelta` instead of `int` (#269).
-  This change allows users to define the time span of the moving window more intuitively, representing the duration over which samples will be stored.
-
-* Add a resampler in the `MovingWindow` to control the granularity of the samples to be stored in the underlying buffer (#269).
-  Notice that the parameter `sampling_period` has been renamed to `input_sampling_period`
-  to better distinguish it from the sampling period parameter in the resampler.
-
 * The serialization feature for the ringbuffer was made more flexible. The `dump` and `load` methods can now work directly with a ringbuffer instance.
 
-* The `ResamplerConfig` now takes the resampling period as a `timedelta`. The configuration was renamed from `resampling_period_s` to `resampling_period` accordingly.
+* `MovingWindow`
 
-* The `SourceProperties` of the resampler now uses a `timedelta` for the input sampling period. The attribute was renamed from `sampling_period_s` to `sampling_period` accordingly.
+  * Accept the `size` parameter as `timedelta` instead of `int` (#269).
+
+    This change allows users to define the time span of the moving window more intuitively, representing the duration over which samples will be stored.
+
+  * The input data will be resampled if a `resampler_config` is passed (#269).
+
+    This allows controlling the granularity of the samples to be stored in the underlying buffer.
+
+    Note that the parameter `sampling_period` has been renamed to `input_sampling_period` to better distinguish it from the sampling period parameter in the `resampler_config`.
+
+* `Resampler`
+
+  * The `ResamplerConfig` now takes the resampling period as a `timedelta`. The configuration was renamed from `resampling_period_s` to `resampling_period` accordingly.
+
+  * The `SourceProperties` of the resampler now uses a `timedelta` for the input sampling period. The attribute was renamed from `sampling_period_s` to `sampling_period` accordingly.
 
 ## New Features
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -29,18 +29,26 @@
   ```
 
 * Update `BatteryStatus` to mark battery with unknown capacity as not working (#263)
+
 * The channels dependency was updated to v0.14.0 (#292)
+
 * Some properties for `PowerDistributingActor` results were renamed to be more consistent between `Success` and `PartialFailure`:
+
   * The `Success.used_batteries` property was renamed to `succeeded_batteries`.
   * The `PartialFailure.success_batteries` property was renamed to `succeeded_batteries`.
   * The `succeed_power` property was renamed to `succeeded_power` for both `Success` and `PartialFailure`.
+
 * Update `MovingWindow` to accept the `size` parameter as `timedelta` instead of `int` (#269).
   This change allows users to define the time span of the moving window more intuitively, representing the duration over which samples will be stored.
+
 * Add a resampler in the `MovingWindow` to control the granularity of the samples to be stored in the underlying buffer (#269).
   Notice that the parameter `sampling_period` has been renamed to `input_sampling_period`
   to better distinguish it from the sampling period parameter in the resampler.
+
 * The serialization feature for the ringbuffer was made more flexible. The `dump` and `load` methods can now work directly with a ringbuffer instance.
+
 * The `ResamplerConfig` now takes the resampling period as a `timedelta`. The configuration was renamed from `resampling_period_s` to `resampling_period` accordingly.
+
 * The `SourceProperties` of the resampler now uses a `timedelta` for the input sampling period. The attribute was renamed from `sampling_period_s` to `sampling_period` accordingly.
 
 ## New Features
@@ -64,4 +72,5 @@
 ## Bug Fixes
 
 * Change `PowerDistributor` to use all batteries when none are working (#258)
+
 * Update the ordered ring buffer to fix the `len()` function so that it returns a value equal to or greater than zero, as expected (#274)

--- a/src/frequenz/sdk/timeseries/__init__.py
+++ b/src/frequenz/sdk/timeseries/__init__.py
@@ -6,8 +6,35 @@ Handling of timeseries streams.
 
 A timeseries is a stream (normally an async iterator) of
 [`Sample`][frequenz.sdk.timeseries.Sample]s.
+
+# Periodicity and alignment
+
+All the data produced by this package is always periodic and aligned to the
+`UNIX_EPOCH` (by default).
+
+Classes normally take a (re)sampling period as and argument and, optionally, an
+`align_to` argument.
+
+This means timestamps are always separated exaclty by a period, and that this
+timestamp falls always at multiples of the period, starting at the `align_to`.
+
+This ensures that the data is predictable and consistent among restarts.
+
+Example:
+    If we have a period of 10 seconds, and are aligning to the UNIX
+    epoch. Assuming the following timeline starts in 1970-01-01 00:00:00
+    UTC and our current `now` is 1970-01-01 00:00:32 UTC, then the next
+    timestamp will be at 1970-01-01 00:00:40 UTC:
+
+    ```
+    align_to = 1970-01-01 00:00:00         next event = 1970-01-01 00:00:40
+    |                                       |
+    |---------|---------|---------|-|-------|---------|---------|---------|
+    0        10        20        30 |      40        50        60        70
+                                   now = 1970-01-01 00:00:32
+    ```
 """
 
-from ._base_types import Sample, Sample3Phase
+from ._base_types import UNIX_EPOCH, Sample, Sample3Phase
 
-__all__ = ["Sample", "Sample3Phase"]
+__all__ = ["Sample", "Sample3Phase", "UNIX_EPOCH"]

--- a/src/frequenz/sdk/timeseries/_base_types.py
+++ b/src/frequenz/sdk/timeseries/_base_types.py
@@ -7,8 +7,11 @@ from __future__ import annotations
 
 import functools
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Callable, Iterator, Optional, overload
+
+UNIX_EPOCH = datetime.fromtimestamp(0.0, tz=timezone.utc)
+"""The UNIX epoch (in UTC)."""
 
 
 # Ordering by timestamp is a bit arbitrary, and it is not always what might be

--- a/tests/timeseries/mock_microgrid.py
+++ b/tests/timeseries/mock_microgrid.py
@@ -119,7 +119,14 @@ class MockMicrogrid:  # pylint: disable=too-many-instance-attributes
 
         # pylint: disable=protected-access
         _data_pipeline._DATA_PIPELINE = _data_pipeline._DataPipeline(
-            ResamplerConfig(resampling_period=timedelta(seconds=self._sample_rate_s))
+            ResamplerConfig(
+                resampling_period=timedelta(seconds=self._sample_rate_s),
+                # Align to the time the resampler is created to avoid flakiness
+                # in the tests, it seems test using the mock microgrid assume
+                # that the resampling window is aligned to the start of the
+                # test.
+                align_to=None,
+            )
         )
         # pylint: enable=protected-access
 


### PR DESCRIPTION
The `ResamplerConfig` now has a new option `align_to` to align the resampling windows to some arbitrary time. This means that the timestamps of the produced samples will be a multiple of the resampling period beginning at the `align_to` time.

By default `align_to` is the Unix epoch, and if it is `None` it will have the current behaviour of aligning timestamps to the time when the resampler is started.

Fixes #328.