### PR TITLE
Make the `MovingWindow` public and remove public mentions to the `RingBuffer`

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -40,6 +40,8 @@
 
 * `MovingWindow`
 
+  * The class is now publicly available in the `frequenz.sdk.timeseries` package.
+
   * Accept the `size` parameter as `timedelta` instead of `int` (#269).
 
     This change allows users to define the time span of the moving window more intuitively, representing the duration over which samples will be stored.
@@ -53,6 +55,8 @@
   * Rename the constructor argument `window_alignment` to `align_to` and change the default to `UNIX_EPOCH`. This is to make it more consistent with the `ResamplerConfig`.
 
 * `Resampler`
+
+  * The `ResamplerConfig` class is now publicly available in the `frequenz.sdk.timeseries` package.
 
   * The `ResamplerConfig` now takes the resampling period as a `timedelta`. The configuration was renamed from `resampling_period_s` to `resampling_period` accordingly.
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -38,8 +38,6 @@
   * The `PartialFailure.success_batteries` property was renamed to `succeeded_batteries`.
   * The `succeed_power` property was renamed to `succeeded_power` for both `Success` and `PartialFailure`.
 
-* The serialization feature for the ringbuffer was made more flexible. The `dump` and `load` methods can now work directly with a ringbuffer instance.
-
 * `MovingWindow`
 
   * Accept the `size` parameter as `timedelta` instead of `int` (#269).
@@ -90,4 +88,4 @@
 
 * Change `PowerDistributor` to use all batteries when none are working (#258)
 
-* Update the ordered ring buffer to fix the `len()` function so that it returns a value equal to or greater than zero, as expected (#274)
+* Update the ordered ring buffer used by the `MovingWindow` to fix the `len()` function so that it returns a value equal to or greater than zero, as expected (#274)

--- a/src/frequenz/sdk/timeseries/__init__.py
+++ b/src/frequenz/sdk/timeseries/__init__.py
@@ -36,5 +36,13 @@ Example:
 """
 
 from ._base_types import UNIX_EPOCH, Sample, Sample3Phase
+from ._moving_window import MovingWindow
+from ._resampling import ResamplerConfig
 
-__all__ = ["Sample", "Sample3Phase", "UNIX_EPOCH"]
+__all__ = [
+    "MovingWindow",
+    "ResamplerConfig",
+    "Sample",
+    "Sample3Phase",
+    "UNIX_EPOCH",
+]

--- a/src/frequenz/sdk/timeseries/_moving_window.py
+++ b/src/frequenz/sdk/timeseries/_moving_window.py
@@ -17,8 +17,7 @@ from frequenz.channels import Broadcast, Receiver, Sender
 from numpy.typing import ArrayLike
 
 from .._internal.asyncio import cancel_and_await
-from . import Sample
-from ._base_types import UNIX_EPOCH
+from ._base_types import UNIX_EPOCH, Sample
 from ._resampling import Resampler, ResamplerConfig
 from ._ringbuffer import OrderedRingBuffer
 

--- a/src/frequenz/sdk/timeseries/_moving_window.py
+++ b/src/frequenz/sdk/timeseries/_moving_window.py
@@ -36,7 +36,7 @@ class MovingWindow:
     Note that a numpy ndarray is returned and thus users can use
     numpys operations directly on a window.
 
-    The window uses an ringbuffer for storage and the first element is aligned to
+    The window uses a ring buffer for storage and the first element is aligned to
     a fixed defined point in time. Since the moving nature of the window, the
     date of the first and the last element are constantly changing and therefore
     the point in time that defines the alignment can be outside of the time window.
@@ -45,10 +45,7 @@ class MovingWindow:
 
     If for example the `align_to` parameter is set to
     `datetime(1, 1, 1, tzinfo=timezone.utc)` and the window size is bigger than
-    one day then the first element will always be aligned to the midnight.
-    For further information see also the
-    [`OrderedRingBuffer`][frequenz.sdk.timeseries._ringbuffer.OrderedRingBuffer]
-    documentation.
+    one day then the first element will always be aligned to midnight.
 
     Resampling might be required to reduce the number of samples to store, and
     it can be set by specifying the resampler config parameter so that the user
@@ -113,8 +110,8 @@ class MovingWindow:
         """
         Initialize the MovingWindow.
 
-        This method creates the underlying ringbuffer and starts a
-        new task that updates the ringbuffer with new incoming samples.
+        This method creates the underlying ring buffer and starts a
+        new task that updates the ring buffer with new incoming samples.
         The task stops running only if the channel receiver is closed.
 
         Args:
@@ -168,7 +165,7 @@ class MovingWindow:
         )
 
     async def _run_impl(self) -> None:
-        """Awaits samples from the receiver and updates the underlying ringbuffer.
+        """Awaits samples from the receiver and updates the underlying ring buffer.
 
         Raises:
             asyncio.CancelledError: if the MovingWindow task is cancelled.

--- a/src/frequenz/sdk/timeseries/_resampling.py
+++ b/src/frequenz/sdk/timeseries/_resampling.py
@@ -16,8 +16,7 @@ from datetime import datetime, timedelta, timezone
 from typing import AsyncIterator, Callable, Coroutine, Optional, Sequence
 
 from .._internal.asyncio import cancel_and_await
-from . import Sample
-from ._base_types import UNIX_EPOCH
+from ._base_types import UNIX_EPOCH, Sample
 
 _logger = logging.getLogger(__name__)
 

--- a/src/frequenz/sdk/timeseries/_ringbuffer/buffer.py
+++ b/src/frequenz/sdk/timeseries/_ringbuffer/buffer.py
@@ -14,8 +14,7 @@ from typing import Generic, List, SupportsFloat, SupportsIndex, TypeVar, overloa
 import numpy as np
 import numpy.typing as npt
 
-from .. import Sample
-from .._base_types import UNIX_EPOCH
+from .._base_types import UNIX_EPOCH, Sample
 
 FloatArray = TypeVar("FloatArray", List[float], npt.NDArray[np.float64])
 


### PR DESCRIPTION
The ring buffer is not part of the public interface yet, so it shouldn't be shown in the release notes of the user facing documentation.

The `MovingWindow` is now exported in the `frequenz.sdk.timeseries` package. The `ResamplerConfig` class is also now made public via the same package, as it is part of the `MovingWindow`'s public interface.
