### PR TITLE
Mock Resampler in formula tests

### DIFF
--- a/src/frequenz/sdk/timeseries/_formula_engine/_formula_engine_pool.py
+++ b/src/frequenz/sdk/timeseries/_formula_engine/_formula_engine_pool.py
@@ -110,3 +110,8 @@ class FormulaEnginePool:
         ).generate()
         self._engines[channel_key] = engine
         return engine
+
+    async def stop(self) -> None:
+        """Stop all formula engines in the pool."""
+        for engine in self._engines.values():
+            await engine._stop()  # pylint: disable=protected-access

--- a/src/frequenz/sdk/timeseries/logical_meter/_logical_meter.py
+++ b/src/frequenz/sdk/timeseries/logical_meter/_logical_meter.py
@@ -402,3 +402,7 @@ class LogicalMeter:
         )
         assert isinstance(engine, FormulaEngine)
         return engine
+
+    async def stop(self) -> None:
+        """Stop all formula engines."""
+        await self._formula_pool.stop()

--- a/tests/timeseries/_formula_engine/utils.py
+++ b/tests/timeseries/_formula_engine/utils.py
@@ -5,15 +5,13 @@
 
 from __future__ import annotations
 
-from datetime import datetime
 from math import isclose
-from typing import overload
 
 from frequenz.channels import Receiver
 
 from frequenz.sdk.microgrid import _data_pipeline
 from frequenz.sdk.microgrid.component import ComponentMetricId
-from frequenz.sdk.timeseries import Sample, Sample3Phase
+from frequenz.sdk.timeseries import Sample
 from frequenz.sdk.timeseries._formula_engine import ResampledFormulaBuilder
 
 
@@ -48,47 +46,3 @@ def equal_float_lists(list1: list[float], list2: list[float]) -> bool:
         and len(list1) == len(list2)
         and all(isclose(v1, v2) for v1, v2 in zip(list1, list2))
     )
-
-
-@overload
-async def synchronize_receivers(
-    receivers: list[Receiver[Sample]],
-) -> None:
-    ...
-
-
-@overload
-async def synchronize_receivers(
-    receivers: list[Receiver[Sample3Phase]],
-) -> None:
-    ...
-
-
-async def synchronize_receivers(
-    receivers: list[Receiver[Sample]] | list[Receiver[Sample3Phase]],
-) -> None:
-    """Check if given receivers are all returning the same timestamp.
-
-    If not, try to synchronize them.
-    """
-    by_ts: dict[datetime, list[Receiver[Sample] | Receiver[Sample3Phase]]] = {}
-    for recv in receivers:
-        while True:
-            sample = await recv.receive()
-            assert sample is not None
-            if isinstance(sample, Sample) and sample.value is None:
-                continue
-            if isinstance(sample, Sample3Phase) and sample.value_p1 is None:
-                continue
-            by_ts.setdefault(sample.timestamp, []).append(recv)
-            break
-    latest_ts = max(by_ts)
-
-    for sample_ts, recvs in by_ts.items():
-        if sample_ts == latest_ts:
-            continue
-        while sample_ts < latest_ts:
-            for recv in recvs:
-                val = await recv.receive()
-                assert val is not None
-                sample_ts = val.timestamp

--- a/tests/timeseries/mock_datapipeline.py
+++ b/tests/timeseries/mock_datapipeline.py
@@ -1,0 +1,191 @@
+# License: MIT
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
+
+"""Mock data_pipeline."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime
+
+from frequenz.channels import Broadcast, Receiver, Sender
+from pytest_mock import MockerFixture
+
+from frequenz.sdk.actor import ComponentMetricRequest, ResamplerConfig
+from frequenz.sdk.microgrid._data_pipeline import _DataPipeline
+from frequenz.sdk.microgrid.component import ComponentMetricId
+from frequenz.sdk.timeseries import Sample
+from frequenz.sdk.timeseries._formula_engine._formula_generators._formula_generator import (
+    NON_EXISTING_COMPONENT_ID,
+)
+
+# pylint: disable=too-many-instance-attributes
+
+
+class MockDataPipeline:
+    """Mock data_pipeline."""
+
+    def __init__(  # pylint: disable=too-many-arguments
+        self,
+        mocker: MockerFixture,
+        resampler_config: ResamplerConfig,
+        bat_inverter_ids: list[int],
+        pv_inverter_ids: list[int],
+        evc_ids: list[int],
+        chp_ids: list[int],
+        meter_ids: list[int],
+        namespaces: int,
+    ) -> None:
+        """Create a `MockDataPipeline` instance."""
+        self._data_pipeline = _DataPipeline(resampler_config)
+
+        self._channel_registry = self._data_pipeline._channel_registry
+        self._resampler_request_channel = Broadcast[ComponentMetricRequest](
+            "resampler-request"
+        )
+        self._basic_receivers: dict[str, list[Receiver[Sample]]] = {}
+
+        def power_senders(
+            comp_ids: list[int],
+        ) -> list[Sender[Sample]]:
+            senders: list[Sender[Sample]] = []
+            for comp_id in comp_ids:
+                name = f"{comp_id}:{ComponentMetricId.ACTIVE_POWER}"
+                senders.append(self._channel_registry.new_sender(name))
+                self._basic_receivers[name] = [
+                    self._channel_registry.new_receiver(name) for _ in range(namespaces)
+                ]
+            return senders
+
+        self._bat_inverter_power_senders = power_senders(bat_inverter_ids)
+        self._pv_inverter_power_senders = power_senders(pv_inverter_ids)
+        self._ev_power_senders = power_senders(evc_ids)
+        self._chp_power_senders = power_senders(chp_ids)
+        self._meter_power_senders = power_senders(meter_ids)
+        self._non_existing_component_sender = power_senders(
+            [NON_EXISTING_COMPONENT_ID]
+        )[0]
+
+        def current_senders(ids: list[int]) -> list[list[Sender[Sample]]]:
+            senders: list[list[Sender[Sample]]] = []
+            for comp_id in ids:
+                p1_name = f"{comp_id}:{ComponentMetricId.CURRENT_PHASE_1}"
+                p2_name = f"{comp_id}:{ComponentMetricId.CURRENT_PHASE_2}"
+                p3_name = f"{comp_id}:{ComponentMetricId.CURRENT_PHASE_3}"
+
+                senders.append(
+                    [
+                        self._channel_registry.new_sender(p1_name),
+                        self._channel_registry.new_sender(p2_name),
+                        self._channel_registry.new_sender(p3_name),
+                    ]
+                )
+                self._basic_receivers[p1_name] = [
+                    self._channel_registry.new_receiver(p1_name)
+                    for _ in range(namespaces)
+                ]
+                self._basic_receivers[p2_name] = [
+                    self._channel_registry.new_receiver(p2_name)
+                    for _ in range(namespaces)
+                ]
+                self._basic_receivers[p3_name] = [
+                    self._channel_registry.new_receiver(p3_name)
+                    for _ in range(namespaces)
+                ]
+            return senders
+
+        self._bat_inverter_current_senders = current_senders(bat_inverter_ids)
+        self._pv_inverter_current_senders = current_senders(pv_inverter_ids)
+        self._ev_current_senders = current_senders(evc_ids)
+        self._chp_current_senders = current_senders(chp_ids)
+        self._meter_current_senders = current_senders(meter_ids)
+
+        self._next_ts = datetime.now()
+
+        mocker.patch(
+            "frequenz.sdk.microgrid._data_pipeline._DataPipeline"
+            "._resampling_request_sender",
+            self._resampling_request_sender,
+        )
+        mocker.patch(
+            "frequenz.sdk.microgrid._data_pipeline._DATA_PIPELINE", self._data_pipeline
+        )
+
+        self._forward_tasks: dict[str, asyncio.Task[None]] = {}
+        asyncio.create_task(self._handle_resampling_requests())
+
+    def _resampling_request_sender(self) -> Sender[ComponentMetricRequest]:
+        return self._resampler_request_channel.new_sender()
+
+    async def _channel_forward_messages(
+        self, receiver: Receiver[Sample], sender: Sender[Sample]
+    ) -> None:
+        async for sample in receiver:
+            await sender.send(sample)
+
+    async def _handle_resampling_requests(self) -> None:
+        async for request in self._resampler_request_channel.new_receiver():
+            if request.get_channel_name() in self._forward_tasks:
+                continue
+            basic_recv_name = f"{request.component_id}:{request.metric_id}"
+            recv = self._basic_receivers[basic_recv_name].pop()
+            assert recv is not None
+            self._forward_tasks[request.get_channel_name()] = asyncio.create_task(
+                self._channel_forward_messages(
+                    recv,
+                    self._channel_registry.new_sender(request.get_channel_name()),
+                )
+            )
+
+    async def send_meter_power(self, values: list[float | None]) -> None:
+        """Send the given values as resampler output for meter power."""
+        assert len(values) == len(self._meter_power_senders)
+        for chan, value in zip(self._meter_power_senders, values):
+            sample = Sample(self._next_ts, value)
+            await chan.send(sample)
+
+    async def send_evc_power(self, values: list[float | None]) -> None:
+        """Send the given values as resampler output for EV Charger power."""
+        assert len(values) == len(self._ev_power_senders)
+        for chan, value in zip(self._ev_power_senders, values):
+            sample = Sample(self._next_ts, value)
+            await chan.send(sample)
+
+    async def send_bat_inverter_power(self, values: list[float | None]) -> None:
+        """Send the given values as resampler output for battery inverter power."""
+        assert len(values) == len(self._bat_inverter_power_senders)
+        for chan, value in zip(self._bat_inverter_power_senders, values):
+            sample = Sample(self._next_ts, value)
+            await chan.send(sample)
+
+    async def send_non_existing_component_value(self) -> None:
+        """Send a value for a non existing component."""
+        sample = Sample(self._next_ts, None)
+        await self._non_existing_component_sender.send(sample)
+
+    async def send_evc_current(self, values: list[list[float | None]]) -> None:
+        """Send the given values as resampler output for EV Charger current."""
+        assert len(values) == len(self._ev_current_senders)
+        for chan, evc_values in zip(self._ev_current_senders, values):
+            assert len(evc_values) == 3  # 3 values for phases
+            for phase, value in enumerate(evc_values):
+                sample = Sample(self._next_ts, value)
+                await chan[phase].send(sample)
+
+    async def send_bat_inverter_current(self, values: list[list[float | None]]) -> None:
+        """Send the given values as resampler output for battery inverter current."""
+        assert len(values) == len(self._bat_inverter_current_senders)
+        for chan, bat_values in zip(self._bat_inverter_current_senders, values):
+            assert len(bat_values) == 3  # 3 values for phases
+            for phase, value in enumerate(bat_values):
+                sample = Sample(self._next_ts, value)
+                await chan[phase].send(sample)
+
+    async def send_meter_current(self, values: list[list[float | None]]) -> None:
+        """Send the given values as resampler output for meter current."""
+        assert len(values) == len(self._meter_current_senders)
+        for chan, meter_values in zip(self._meter_current_senders, values):
+            assert len(meter_values) == 3  # 3 values for phases
+            for phase, value in enumerate(meter_values):
+                sample = Sample(self._next_ts, value)
+                await chan[phase].send(sample)

--- a/tests/timeseries/test_ev_charger_pool.py
+++ b/tests/timeseries/test_ev_charger_pool.py
@@ -6,19 +6,14 @@
 from __future__ import annotations
 
 import asyncio
-from datetime import datetime, timezone
-from typing import Any
 
-from frequenz.channels import Broadcast, Receiver, Sender
 from pytest_mock import MockerFixture
 
 from frequenz.sdk import microgrid
 from frequenz.sdk.microgrid.component import (
-    ComponentMetricId,
     EVChargerCableState,
     EVChargerComponentState,
 )
-from frequenz.sdk.timeseries import Sample
 from frequenz.sdk.timeseries.ev_charger_pool._state_tracker import (
     EVChargerState,
     StateTracker,
@@ -32,9 +27,11 @@ class TestEVChargerPool:
     async def test_state_updates(self, mocker: MockerFixture) -> None:
         """Test ev charger state updates are visible."""
 
-        mockgrid = MockMicrogrid(grid_side_meter=False, sample_rate_s=0.01)
+        mockgrid = MockMicrogrid(
+            grid_side_meter=False, api_client_streaming=True, sample_rate_s=0.01
+        )
         mockgrid.add_ev_chargers(5)
-        await mockgrid.start(mocker)
+        mockgrid.start_mock_client(lambda client: client.initialize(mocker))
 
         state_tracker = StateTracker(set(mockgrid.evc_ids))
 
@@ -81,47 +78,19 @@ class TestEVChargerPool:
         """Test the ev power formula."""
         mockgrid = MockMicrogrid(grid_side_meter=False)
         mockgrid.add_ev_chargers(3)
-        await mockgrid.start(mocker)
-
-        channels: dict[int, Broadcast[Sample]] = {
-            meter_id: Broadcast(f"#{meter_id}")
-            for meter_id in [*mockgrid.meter_ids, *mockgrid.evc_ids]
-        }
-        senders: list[Sender[Sample]] = [
-            channels[component_id].new_sender() for component_id in mockgrid.evc_ids
-        ]
-
-        async def send_resampled_data(
-            now: datetime,
-            meter_data: list[float | None],
-        ) -> None:
-            """Send resampled data to the channels."""
-            for sender, value in zip(senders, meter_data):
-                await sender.send(Sample(now, value))
-
-        def mock_resampled_receiver(
-            _1: Any, component_id: int, _2: ComponentMetricId
-        ) -> Receiver[Sample]:
-            return channels[component_id].new_receiver()
-
-        mocker.patch(
-            "frequenz.sdk.timeseries._formula_engine._resampled_formula_builder"
-            ".ResampledFormulaBuilder._get_resampled_receiver",
-            mock_resampled_receiver,
-        )
+        await mockgrid.start_mock_datapipeline(mocker)
 
         ev_pool = microgrid.ev_charger_pool()
         power_receiver = ev_pool.power.new_receiver()
         production_receiver = ev_pool.production_power.new_receiver()
         consumption_receiver = ev_pool.consumption_power.new_receiver()
 
-        now = datetime.now(tz=timezone.utc)
-        await send_resampled_data(now, [2.0, 4.0, 10.0])
+        await mockgrid.mock_data.send_evc_power([2.0, 4.0, 10.0])
         assert (await power_receiver.receive()).value == 16.0
         assert (await production_receiver.receive()).value == 0.0
         assert (await consumption_receiver.receive()).value == 16.0
 
-        await send_resampled_data(now, [2.0, 4.0, -10.0])
+        await mockgrid.mock_data.send_evc_power([2.0, 4.0, -10.0])
         assert (await power_receiver.receive()).value == -4.0
         assert (await production_receiver.receive()).value == 4.0
         assert (await consumption_receiver.receive()).value == 0.0
@@ -130,48 +99,22 @@ class TestEVChargerPool:
 
     async def test_ev_component_data(self, mocker: MockerFixture) -> None:
         """Test the component_data method of EVChargerPool."""
-        mockgrid = MockMicrogrid(grid_side_meter=False)
+        mockgrid = MockMicrogrid(grid_side_meter=False, api_client_streaming=True)
         mockgrid.add_ev_chargers(1)
-        await mockgrid.start(mocker)
+
+        # The component_data method is a bit special because it uses both raw data
+        # coming from the MicrogridClient to get the component state, and resampler data
+        # to get the 3-phase current values.  So we need both `start_mock_client` and
+        # `start_mock_datapipeline`.
+        mockgrid.start_mock_client(lambda client: client.initialize(mocker))
+        await mockgrid.start_mock_datapipeline(mocker)
+
         evc_id = mockgrid.evc_ids[0]
-
         ev_pool = microgrid.ev_charger_pool()
-
-        resampled_p1_channel = Broadcast[Sample]("resampled-current-phase-1")
-        resampled_p2_channel = Broadcast[Sample]("resampled-current-phase-2")
-        resampled_p3_channel = Broadcast[Sample]("resampled-current-phase-3")
-
-        async def send_resampled_current(
-            phase_1: float | None, phase_2: float | None, phase_3: float | None
-        ) -> None:
-            sender_p1 = resampled_p1_channel.new_sender()
-            sender_p2 = resampled_p2_channel.new_sender()
-            sender_p3 = resampled_p3_channel.new_sender()
-
-            now = datetime.now()
-            asyncio.gather(
-                sender_p1.send(Sample(now, phase_1)),
-                sender_p2.send(Sample(now, phase_2)),
-                sender_p3.send(Sample(now, phase_3)),
-            )
-
-        async def mock_current_streams(
-            _1: Any, _2: int
-        ) -> tuple[Receiver[Sample], Receiver[Sample], Receiver[Sample]]:
-            return (
-                resampled_p1_channel.new_receiver(),
-                resampled_p2_channel.new_receiver(),
-                resampled_p3_channel.new_receiver(),
-            )
-
-        mocker.patch(
-            "frequenz.sdk.timeseries.ev_charger_pool.EVChargerPool._get_current_streams",
-            mock_current_streams,
-        )
 
         recv = ev_pool.component_data(evc_id)
 
-        await send_resampled_current(2, 3, 5)
+        await mockgrid.mock_data.send_evc_current([[2, 3, 5]])
         await asyncio.sleep(0.02)
         status = await recv.receive()
         assert (
@@ -181,7 +124,7 @@ class TestEVChargerPool:
         ) == (2, 3, 5)
         assert status.state == EVChargerState.MISSING
 
-        await send_resampled_current(2, 3, None)
+        await mockgrid.mock_data.send_evc_current([[2, 3, None]])
         await asyncio.sleep(0.02)
         status = await recv.receive()
         assert (
@@ -191,7 +134,7 @@ class TestEVChargerPool:
         ) == (2, 3, None)
         assert status.state == EVChargerState.IDLE
 
-        await send_resampled_current(None, None, None)
+        await mockgrid.mock_data.send_evc_current([[None, None, None]])
         await asyncio.sleep(0.02)
         status = await recv.receive()
         assert (
@@ -201,7 +144,7 @@ class TestEVChargerPool:
         ) == (None, None, None)
         assert status.state == EVChargerState.MISSING
 
-        await send_resampled_current(None, None, None)
+        await mockgrid.mock_data.send_evc_current([[None, None, None]])
         mockgrid.evc_cable_states[evc_id] = EVChargerCableState.EV_PLUGGED
         await asyncio.sleep(0.02)
         status = await recv.receive()
@@ -212,7 +155,7 @@ class TestEVChargerPool:
         ) == (None, None, None)
         assert status.state == EVChargerState.MISSING
 
-        await send_resampled_current(4, None, None)
+        await mockgrid.mock_data.send_evc_current([[4, None, None]])
         await asyncio.sleep(0.02)
         status = await recv.receive()
         assert (

--- a/tests/timeseries/test_logical_meter.py
+++ b/tests/timeseries/test_logical_meter.py
@@ -5,21 +5,12 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
-from typing import Any
-
-from frequenz.channels import Broadcast, Receiver, Sender
 from pytest_mock import MockerFixture
 
 from frequenz.sdk import microgrid
 from frequenz.sdk.microgrid.component import ComponentMetricId
-from frequenz.sdk.timeseries import Sample
 
-from ._formula_engine.utils import (
-    equal_float_lists,
-    get_resampled_stream,
-    synchronize_receivers,
-)
+from ._formula_engine.utils import equal_float_lists, get_resampled_stream
 from .mock_microgrid import MockMicrogrid
 
 # pylint: disable=too-many-locals
@@ -33,7 +24,7 @@ class TestLogicalMeter:
         mockgrid = MockMicrogrid(grid_side_meter=True)
         mockgrid.add_batteries(2)
         mockgrid.add_solar_inverters(1)
-        await mockgrid.start(mocker)
+        await mockgrid.start_mock_datapipeline(mocker)
         logical_meter = microgrid.logical_meter()
 
         grid_power_recv = logical_meter.grid_power.new_receiver()
@@ -44,12 +35,12 @@ class TestLogicalMeter:
             ComponentMetricId.ACTIVE_POWER,
         )
 
-        await synchronize_receivers([grid_power_recv, main_meter_recv])
         results = []
         main_meter_data = []
-        for _ in range(10):
+        for count in range(10):
+            await mockgrid.mock_data.send_meter_power([20.0 + count, 12.0, -13.0, -5.0])
             val = await main_meter_recv.receive()
-            assert val is not None and val.value is not None and val.value > 0.0
+            assert val is not None and val.value is not None and val.value != 0.0
             main_meter_data.append(val.value)
 
             val = await grid_power_recv.receive()
@@ -66,7 +57,7 @@ class TestLogicalMeter:
         mockgrid = MockMicrogrid(grid_side_meter=False)
         mockgrid.add_batteries(2)
         mockgrid.add_solar_inverters(1)
-        await mockgrid.start(mocker)
+        await mockgrid.start_mock_datapipeline(mocker)
         logical_meter = microgrid.logical_meter()
 
         grid_power_recv = logical_meter.grid_power.new_receiver()
@@ -80,15 +71,14 @@ class TestLogicalMeter:
             for meter_id in mockgrid.meter_ids
         ]
 
-        await synchronize_receivers([grid_power_recv, *meter_receivers])
-
         results = []
         meter_sums = []
-        for _ in range(10):
+        for count in range(10):
+            await mockgrid.mock_data.send_meter_power([20.0 + count, 12.0, -13.0, -5.0])
             meter_sum = 0.0
             for recv in meter_receivers:
                 val = await recv.receive()
-                assert val is not None and val.value is not None and val.value > 0.0
+                assert val is not None and val.value is not None and val.value != 0.0
                 meter_sum += val.value
 
             val = await grid_power_recv.receive()
@@ -109,46 +99,19 @@ class TestLogicalMeter:
         mockgrid = MockMicrogrid(grid_side_meter=False)
         mockgrid.add_batteries(2)
         mockgrid.add_solar_inverters(1)
-        await mockgrid.start(mocker)
-
-        channels: dict[int, Broadcast[Sample]] = {
-            meter_id: Broadcast(f"#{meter_id}") for meter_id in mockgrid.meter_ids
-        }
-        senders: list[Sender[Sample]] = [
-            channels[meter_id].new_sender() for meter_id in mockgrid.meter_ids
-        ]
-
-        async def send_resampled_data(
-            now: datetime,
-            meter_data: tuple[float | None, float | None, float | None, float | None],
-        ) -> None:
-            """Send resampled data to the channels."""
-            for sender, value in zip(senders, meter_data):
-                await sender.send(Sample(now, value))
-
-        def mock_resampled_receiver(
-            _1: Any, component_id: int, _2: ComponentMetricId
-        ) -> Receiver[Sample]:
-            return channels[component_id].new_receiver()
-
-        mocker.patch(
-            "frequenz.sdk.timeseries._formula_engine._resampled_formula_builder"
-            ".ResampledFormulaBuilder._get_resampled_receiver",
-            mock_resampled_receiver,
-        )
+        await mockgrid.start_mock_datapipeline(mocker)
 
         logical_meter = microgrid.logical_meter()
         grid_recv = logical_meter.grid_power.new_receiver()
         grid_production_recv = logical_meter.grid_production_power.new_receiver()
         grid_consumption_recv = logical_meter.grid_consumption_power.new_receiver()
 
-        now = datetime.now()
-        await send_resampled_data(now, (1.0, 2.0, 3.0, 4.0))
+        await mockgrid.mock_data.send_meter_power([1.0, 2.0, 3.0, 4.0])
         assert (await grid_recv.receive()).value == 10.0
         assert (await grid_production_recv.receive()).value == 0.0
         assert (await grid_consumption_recv.receive()).value == 10.0
 
-        await send_resampled_data(now, (1.0, 2.0, -3.0, -4.0))
+        await mockgrid.mock_data.send_meter_power([1.0, 2.0, -3.0, -4.0])
         assert (await grid_recv.receive()).value == -4.0
         assert (await grid_production_recv.receive()).value == 4.0
         assert (await grid_consumption_recv.receive()).value == 0.0
@@ -158,35 +121,7 @@ class TestLogicalMeter:
         mockgrid = MockMicrogrid(grid_side_meter=False)
         mockgrid.add_chps(1)
         mockgrid.add_batteries(2)
-        await mockgrid.start(mocker)
-
-        assert len(mockgrid.meter_ids) == 4
-
-        channels: dict[int, Broadcast[Sample]] = {
-            meter_id: Broadcast(f"#{meter_id}") for meter_id in [*mockgrid.meter_ids]
-        }
-        senders: list[Sender[Sample]] = [
-            channels[component_id].new_sender() for component_id in mockgrid.meter_ids
-        ]
-
-        async def send_resampled_data(
-            now: datetime,
-            meter_data: list[float | None],
-        ) -> None:
-            """Send resampled data to the channels."""
-            for sender, value in zip(senders, meter_data):
-                await sender.send(Sample(now, value))
-
-        def mock_resampled_receiver(
-            _1: Any, component_id: int, _2: ComponentMetricId
-        ) -> Receiver[Sample]:
-            return channels[component_id].new_receiver()
-
-        mocker.patch(
-            "frequenz.sdk.timeseries._formula_engine._resampled_formula_builder"
-            ".ResampledFormulaBuilder._get_resampled_receiver",
-            mock_resampled_receiver,
-        )
+        await mockgrid.start_mock_datapipeline(mocker)
 
         logical_meter = microgrid.logical_meter()
         chp_power_receiver = logical_meter.chp_power.new_receiver()
@@ -197,13 +132,12 @@ class TestLogicalMeter:
             logical_meter.chp_consumption_power.new_receiver()
         )
 
-        now = datetime.now(tz=timezone.utc)
-        await send_resampled_data(now, [1.0, 2.0, 3.0, 4.0])
+        await mockgrid.mock_data.send_meter_power([1.0, 2.0, 3.0, 4.0])
         assert (await chp_power_receiver.receive()).value == 2.0
         assert (await chp_production_power_receiver.receive()).value == 0.0
         assert (await chp_consumption_power_receiver.receive()).value == 2.0
 
-        await send_resampled_data(now, [-4.0, -12.0, None, 10.2])
+        await mockgrid.mock_data.send_meter_power([-4.0, -12.0, None, 10.2])
         assert (await chp_power_receiver.receive()).value == -12.0
         assert (await chp_production_power_receiver.receive()).value == 12.0
         assert (await chp_consumption_power_receiver.receive()).value == 0.0
@@ -212,36 +146,7 @@ class TestLogicalMeter:
         """Test the pv power formula."""
         mockgrid = MockMicrogrid(grid_side_meter=False)
         mockgrid.add_solar_inverters(2)
-        await mockgrid.start(mocker)
-
-        assert len(mockgrid.pv_inverter_ids) == 2
-
-        channels: dict[int, Broadcast[Sample]] = {
-            inv_id: Broadcast(f"#{inv_id}") for inv_id in [*mockgrid.pv_inverter_ids]
-        }
-        senders: list[Sender[Sample]] = [
-            channels[component_id].new_sender()
-            for component_id in mockgrid.pv_inverter_ids
-        ]
-
-        async def send_resampled_data(
-            now: datetime,
-            meter_data: list[float | None],
-        ) -> None:
-            """Send resampled data to the channels."""
-            for sender, value in zip(senders, meter_data):
-                await sender.send(Sample(now, value))
-
-        def mock_resampled_receiver(
-            _1: Any, component_id: int, _2: ComponentMetricId
-        ) -> Receiver[Sample]:
-            return channels[component_id].new_receiver()
-
-        mocker.patch(
-            "frequenz.sdk.timeseries._formula_engine._resampled_formula_builder"
-            ".ResampledFormulaBuilder._get_resampled_receiver",
-            mock_resampled_receiver,
-        )
+        await mockgrid.start_mock_datapipeline(mocker)
 
         logical_meter = microgrid.logical_meter()
         pv_power_receiver = logical_meter.pv_power.new_receiver()
@@ -250,8 +155,7 @@ class TestLogicalMeter:
             logical_meter.pv_consumption_power.new_receiver()
         )
 
-        now = datetime.now(tz=timezone.utc)
-        await send_resampled_data(now, [-1.0, -2.0])
+        await mockgrid.mock_data.send_meter_power([10.0, -1.0, -2.0])
         assert (await pv_power_receiver.receive()).value == -3.0
         assert (await pv_production_power_receiver.receive()).value == 3.0
         assert (await pv_consumption_power_receiver.receive()).value == 0.0
@@ -261,41 +165,12 @@ class TestLogicalMeter:
         mockgrid = MockMicrogrid(grid_side_meter=True)
         mockgrid.add_batteries(2)
         mockgrid.add_solar_inverters(2)
-        await mockgrid.start(mocker)
-
-        assert len(mockgrid.meter_ids) == 5
-
-        channels: dict[int, Broadcast[Sample]] = {
-            meter_id: Broadcast(f"#{meter_id}") for meter_id in [*mockgrid.meter_ids]
-        }
-        senders: list[Sender[Sample]] = [
-            channels[component_id].new_sender() for component_id in mockgrid.meter_ids
-        ]
-
-        async def send_resampled_data(
-            now: datetime,
-            meter_data: list[float | None],
-        ) -> None:
-            """Send resampled data to the channels."""
-            for sender, value in zip(senders, meter_data):
-                await sender.send(Sample(now, value))
-
-        def mock_resampled_receiver(
-            _1: Any, component_id: int, _2: ComponentMetricId
-        ) -> Receiver[Sample]:
-            return channels[component_id].new_receiver()
-
-        mocker.patch(
-            "frequenz.sdk.timeseries._formula_engine._resampled_formula_builder"
-            ".ResampledFormulaBuilder._get_resampled_receiver",
-            mock_resampled_receiver,
-        )
+        await mockgrid.start_mock_datapipeline(mocker)
 
         logical_meter = microgrid.logical_meter()
         consumer_power_receiver = logical_meter.consumer_power.new_receiver()
 
-        now = datetime.now(tz=timezone.utc)
-        await send_resampled_data(now, [20.0, 2.0, 3.0, 4.0, 5.0])
+        await mockgrid.mock_data.send_meter_power([20.0, 2.0, 3.0, 4.0, 5.0])
         assert (await consumer_power_receiver.receive()).value == 6.0
 
     async def test_consumer_power_no_grid_meter(self, mocker: MockerFixture) -> None:
@@ -303,39 +178,10 @@ class TestLogicalMeter:
         mockgrid = MockMicrogrid(grid_side_meter=False)
         mockgrid.add_batteries(2)
         mockgrid.add_solar_inverters(2)
-        await mockgrid.start(mocker)
-
-        assert len(mockgrid.meter_ids) == 5
-
-        channels: dict[int, Broadcast[Sample]] = {
-            meter_id: Broadcast(f"#{meter_id}") for meter_id in [*mockgrid.meter_ids]
-        }
-        senders: list[Sender[Sample]] = [
-            channels[component_id].new_sender() for component_id in mockgrid.meter_ids
-        ]
-
-        async def send_resampled_data(
-            now: datetime,
-            meter_data: list[float | None],
-        ) -> None:
-            """Send resampled data to the channels."""
-            for sender, value in zip(senders, meter_data):
-                await sender.send(Sample(now, value))
-
-        def mock_resampled_receiver(
-            _1: Any, component_id: int, _2: ComponentMetricId
-        ) -> Receiver[Sample]:
-            return channels[component_id].new_receiver()
-
-        mocker.patch(
-            "frequenz.sdk.timeseries._formula_engine._resampled_formula_builder"
-            ".ResampledFormulaBuilder._get_resampled_receiver",
-            mock_resampled_receiver,
-        )
+        await mockgrid.start_mock_datapipeline(mocker)
 
         logical_meter = microgrid.logical_meter()
         consumer_power_receiver = logical_meter.consumer_power.new_receiver()
 
-        now = datetime.now(tz=timezone.utc)
-        await send_resampled_data(now, [20.0, 2.0, 3.0, 4.0, 5.0])
+        await mockgrid.mock_data.send_meter_power([20.0, 2.0, 3.0, 4.0, 5.0])
         assert (await consumer_power_receiver.receive()).value == 20.0


### PR DESCRIPTION
This allows most of the formula tests to be reliable.

Only the test for the `EVChargerPool.component_data` method still depends on a lower level mock, and it needs it because it combines resampled data with component state values.  If it is flaky, we'll have to add multi stage testing - with a fast test first, and a slower one if that fails, etc.