### PR TITLE
Implement machine learning model handler

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 requires-python = ">= 3.11, < 4"
 dependencies = [
   "frequenz-api-microgrid >= 0.11.0, < 0.12.0",
-  "frequenz-channels >= 0.14.0, < 0.15.0",
+  "frequenz-channels >= 0.15.0, < 0.16.0",
   "google-api-python-client >= 2.71, < 3",
   "grpcio >= 1.54.2, < 2",
   "grpcio-tools >= 1.54.2, < 2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,6 +129,10 @@ src_paths = ["src", "examples", "tests"]
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 required_plugins = ["pytest-asyncio", "pytest-mock"]
+markers = [
+  "integration: integration tests (deselect with '-m \"not integration\"')",
+]
+
 
 [[tool.mypy.overrides]]
 module = [

--- a/src/frequenz/sdk/actor/power_distributing/_battery_status.py
+++ b/src/frequenz/sdk/actor/power_distributing/_battery_status.py
@@ -197,10 +197,12 @@ class BatteryStatusTracker:
             raise RuntimeError(f"Can't find inverter adjacent to battery: {battery_id}")
 
         self._battery: _ComponentStreamStatus = _ComponentStreamStatus(
-            battery_id, data_recv_timer=Timer(max_data_age_sec)
+            battery_id,
+            data_recv_timer=Timer.periodic(timedelta(seconds=max_data_age_sec)),
         )
         self._inverter: _ComponentStreamStatus = _ComponentStreamStatus(
-            inverter_id, data_recv_timer=Timer(max_data_age_sec)
+            inverter_id,
+            data_recv_timer=Timer.periodic(timedelta(seconds=max_data_age_sec)),
         )
 
         # Select needs receivers that can be get in async way only.

--- a/src/frequenz/sdk/model/__init__.py
+++ b/src/frequenz/sdk/model/__init__.py
@@ -1,0 +1,21 @@
+# License: MIT
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
+
+"""Model interface."""
+
+from ._manager import (
+    EnumeratedModelRepository,
+    ModelManager,
+    ModelRepository,
+    SingleModelRepository,
+    WeekdayModelRepository,
+)
+
+# Explicitly declare the public API.
+__all__ = [
+    "EnumeratedModelRepository",
+    "ModelManager",
+    "ModelRepository",
+    "SingleModelRepository",
+    "WeekdayModelRepository",
+]

--- a/src/frequenz/sdk/model/_manager.py
+++ b/src/frequenz/sdk/model/_manager.py
@@ -1,0 +1,318 @@
+# License: MIT
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
+
+"""Load, update, monitor and retrieve machine learning models."""
+
+import abc
+import asyncio
+import logging
+import os
+import pickle
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Generic, TypeVar
+
+from frequenz.channels.util import FileWatcher
+
+from frequenz.sdk._internal._asyncio import cancel_and_await
+
+_logger = logging.getLogger(__name__)
+
+T = TypeVar("T")
+"""The model type."""
+
+
+class ModelRepository(abc.ABC):
+    """Provide an interface for building the model repository configuration.
+
+    The ModelRepository is meant to be subclassed to provide specific
+    implementations based on the type of models being managed.
+    """
+
+    @abc.abstractmethod
+    def _get_allowed_keys(self) -> list[Any]:
+        """Get the list of allowed keys for the model repository.
+
+        Returns:
+            a list of allowed keys.  # noqa: DAR202
+
+        Raises:
+            NotImplementedError: if the method is not implemented in the subclass.
+        """
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def _build_path(self, key: Any) -> str:
+        """Build the model path for the given key.
+
+        Args:
+            key: the key for which to build the model path.
+
+        Returns:
+            the model path.  # noqa: DAR202
+
+        Raises:
+            NotImplementedError: if the method is not implemented in the subclass.
+        """
+        raise NotImplementedError
+
+    def get_models_config(self) -> dict[Any, str]:
+        """Get the models configuration.
+
+        Returns:
+            the model keys to model paths mapping.
+        """
+        allowed_keys = self._get_allowed_keys()
+        assert allowed_keys, "Allowed keys must be set."
+        return {key: self._build_path(key) for key in allowed_keys}
+
+
+@dataclass
+class SingleModelRepository(ModelRepository):
+    """Repository to manage a single model."""
+
+    model_path: str
+    """The path to a single model file."""
+
+    def _get_allowed_keys(self) -> list[Any]:
+        """Get the allowed keys for the single model repository.
+
+        Returns:
+            the allowed single key.
+        """
+        return ["Single"]
+
+    def _build_path(self, key: Any) -> str:
+        """Build the model path for the given key.
+
+        Args:
+            key: the key for which to build the model path.
+
+        Returns:
+            the model path.
+        """
+        return self.model_path
+
+
+@dataclass
+class WeekdayModelRepository(ModelRepository):
+    """Repository to manage weekday-based models."""
+
+    directory: str
+    """The base directory where the weekday-based models are stored."""
+
+    file_name: str
+    """The name of the file containing the model."""
+
+    def _get_allowed_keys(self) -> list[Any]:
+        """Get the allowed keys for the weekday-based models repository.
+
+        Returns:
+            the allowed keys for the weekday-based models repository.
+        """
+        return ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
+
+    def _build_path(self, key: str) -> str:
+        """Build the model path for the given key.
+
+        The model path is constructed by combining the directory, key and
+        file name as follow: directory/key/file_name.
+
+        Args:
+            key: the key for which to build the model path.
+
+        Returns:
+            The model path.
+
+        Raises:
+            AssertionError: if the directory or file name is not set.
+        """
+        assert self.directory, "Directory must be set."
+        assert self.file_name, "File name must be set."
+        return f"{self.directory}/{key}/{self.file_name}"
+
+
+@dataclass
+class EnumeratedModelRepository(ModelRepository):
+    """Repository to manage interval-based models."""
+
+    directory: str
+    """The base directory where the interval-based models are stored."""
+
+    file_name: str
+    """The name of the file containing the model."""
+
+    num_models: int
+    """The number of interval-based models to load and manage."""
+
+    def _get_allowed_keys(self) -> list[Any]:
+        """Get the allowed keys for the interval-based models repository.
+
+        Returns:
+            the allowed keys for the interval-based models repository.
+        """
+        return list(range(self.num_models))
+
+    def _build_path(self, key: str) -> str:
+        """Build the model path for the given key.
+
+        The model path is constructed by combining the directory, key and
+        file name as follow: directory/key/file_name.
+
+        Args:
+            key: the key for which to build the model path.
+
+        Returns:
+            the model path.
+
+        Raises:
+            AssertionError: if the directory or file name is not set.
+        """
+        assert self.directory, "Directory must be set."
+        assert self.file_name, "File name must be set."
+        return f"{self.directory}/{key}/{self.file_name}"
+
+
+@dataclass
+class _Model(Generic[T]):
+    """Represent a machine learning model."""
+
+    data: T
+    """The machine learning model."""
+
+    path: str
+    """The path to the model file."""
+
+
+class ModelManager(Generic[T]):
+    """Manage machine learning models.
+
+    The model manager acts as a central hub for retrieving models, reloading
+    models, and monitoring model paths for changes.
+    """
+
+    def __init__(self, model_repository: ModelRepository) -> None:
+        """Initialize the model manager.
+
+        Args:
+            model_repository: a model repository that defines the mapping
+                between model keys and paths.
+        """
+        self._models: dict[Any, _Model[T]] = {}
+
+        models_config = model_repository.get_models_config()
+        for key, model_path in models_config.items():
+            self._models[key] = _Model(data=self._load(model_path), path=model_path)
+
+        self._monitoring_task: asyncio.Task[None] = asyncio.create_task(
+            self._start_model_monitor()
+        )
+
+    def __getitem__(self, key: Any) -> T:
+        """Get a specific loaded model using the subscript operator.
+
+        Args:
+            key: the key to identify the model.
+
+        Returns:
+            the model instance corresponding to the key.
+        """
+        return self.get_model(key)
+
+    def get_model(self, key: Any = None) -> T:
+        """Get a specific loaded model.
+
+        Args:
+            key: the key to identify the model.
+
+        Raises:
+            KeyError: if the key is invalid or it is not provided for
+                multi-model retrieval.
+
+        Returns:
+            the model instance corresponding to the key.
+        """
+        if key is None:
+            if len(self._models) != 1:
+                raise KeyError("No key provided for multi-model retrieval")
+            key = list(self._models.keys())[0]
+
+        if key not in self._models:
+            raise KeyError("Invalid key")
+
+        return self._models[key].data
+
+    def get_paths(self) -> list[Path | str]:
+        """Get the paths of all loaded models.
+
+        Returns:
+            the paths of all loaded models.
+        """
+        return [model.path for model in self._models.values()]
+
+    def reload_model(self, model_path: str) -> None:
+        """Reload a model from the given path.
+
+        Args:
+            model_path: the path to the model file.
+
+        Raises:
+            ValueError: if the model with the specified path is not found.
+        """
+        if model_path not in self.get_paths():
+            raise ValueError(f"No model found with path: {model_path}")
+
+        for model in self._models.values():
+            if model.path == model_path:
+                model.data = self._load(model_path)
+
+    async def join(self) -> None:
+        """Await the monitoring task, and return when the task completes."""
+        if self._monitoring_task and not self._monitoring_task.done():
+            await self._monitoring_task
+
+    async def _start_model_monitor(self) -> None:
+        """Start monitoring the model paths for changes."""
+        # model_paths = self._model_loader.get_paths()
+        model_paths = self.get_paths()
+        file_watcher = FileWatcher(paths=model_paths)
+
+        _logger.info("Monitoring the paths of the models for changes: %s", model_paths)
+
+        async for event in file_watcher:
+            # The model could be deleted and created again.
+            if event.type in (
+                FileWatcher.EventType.CREATE,
+                FileWatcher.EventType.MODIFY,
+            ):
+                _logger.info(
+                    "Model file %s has been modified. Reloading model...",
+                    str(event.path),
+                )
+                self.reload_model(str(event.path))
+
+        _logger.debug("ModelManager stopped.")
+
+    async def _stop_model_monitor(self) -> None:
+        """Stop monitoring the model paths for changes."""
+        if self._monitoring_task:
+            await cancel_and_await(self._monitoring_task)
+
+    def _load(self, model_path: str) -> T:
+        """Load the model file.
+
+        Args:
+            model_path: the path of the model to be loaded.
+
+        Raises:
+            FileNotFoundError: if the model path does not exist.
+
+        Returns:
+            the model instance.
+        """
+        if not os.path.exists(model_path):
+            raise FileNotFoundError(f"The model path {model_path} does not exist.")
+
+        with open(model_path, "rb") as file:
+            model: T = pickle.load(file)
+            return model

--- a/src/frequenz/sdk/timeseries/ev_charger_pool/_set_current_bounds.py
+++ b/src/frequenz/sdk/timeseries/ev_charger_pool/_set_current_bounds.py
@@ -97,7 +97,7 @@ class BoundsSetter:
 
         select = Select(
             bound_chan=self._bounds_rx,
-            timer=Timer(self._repeat_interval.total_seconds()),
+            timer=Timer.periodic(self._repeat_interval),
         )
         while await select.ready():
             meter = meter_data.peek()

--- a/tests/model/__init__.py
+++ b/tests/model/__init__.py
@@ -1,0 +1,4 @@
+# License: MIT
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
+
+"""Tests for the model package."""

--- a/tests/model/test_integration.py
+++ b/tests/model/test_integration.py
@@ -1,0 +1,79 @@
+# License: MIT
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
+
+"""Integration tests for machine learning model manager."""
+
+import asyncio
+import os
+import pathlib
+import pickle
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+from frequenz.sdk.model import ModelManager, ModelRepository
+
+
+@pytest.mark.integration
+async def test_weekend_model(tmp_path: pathlib.Path) -> None:
+    """Test model with custom day periods are updated on model files changes.
+
+    Args:
+        tmp_path: a temporary directory created by pytest to load models from
+            and to monitor them.
+    """
+    weekend = ["sat", "sun"]
+
+    @dataclass
+    class WeekendModelRepository(ModelRepository):
+        """Repository to manage a custom weekend-based models."""
+
+        directory: str
+        file_name: str
+
+        def _get_allowed_keys(self) -> list[Any]:
+            return weekend
+
+        def _build_path(self, key: str) -> str:
+            assert key in self._get_allowed_keys(), f"Key {key} is not allowed."
+            return f"{self.directory}/{key}/{self.file_name}"
+
+    weekend_models: dict[str, str] = {day: f"{day} Model" for day in weekend}
+
+    for day in weekend:
+        model_path = f"{str(tmp_path)}/{day}/model.pkl"
+        os.makedirs(os.path.dirname(model_path), exist_ok=True)
+        with open(model_path, "wb") as file:
+            pickle.dump(weekend_models[day], file)
+
+    model_repository = WeekendModelRepository(
+        directory=str(tmp_path), file_name="model.pkl"
+    )
+    model_manager: ModelManager[str] = ModelManager(model_repository=model_repository)
+
+    sat_model = model_manager.get_model("sat")
+    assert sat_model == weekend_models["sat"]
+
+    sun_model = model_manager.get_model("sun")
+    assert sun_model == weekend_models["sun"]
+
+    await asyncio.sleep(0.1)  # Allow the monitoring task to start
+
+    # Update the content of the mock files
+    updated_models: dict[str, str] = {day: f"{day} Model UPDATED" for day in weekend}
+
+    for day in weekend:
+        model_path = f"{str(tmp_path)}/{day}/model.pkl"
+        with open(model_path, "wb") as file:
+            pickle.dump(updated_models[day], file)
+
+    await asyncio.sleep(0.1)  # Allow the monitoring task to process the updated models
+
+    sat_model = model_manager["sat"]
+    assert sat_model == updated_models["sat"]
+
+    sun_model = model_manager["sun"]
+    assert sun_model == updated_models["sun"]
+
+    await model_manager._stop_model_monitor()  # pylint: disable=protected-access

--- a/tests/model/test_model_manager.py
+++ b/tests/model/test_model_manager.py
@@ -1,0 +1,282 @@
+# License: MIT
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
+
+"""Tests for machine learning model manager."""
+
+import bisect
+import calendar
+import pickle
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+from unittest.mock import mock_open, patch
+
+import pytest
+
+from frequenz.sdk.model import (
+    EnumeratedModelRepository,
+    ModelManager,
+    ModelRepository,
+    SingleModelRepository,
+    WeekdayModelRepository,
+)
+
+
+@dataclass
+class MockModel:
+    """Mock model for unit testing purposes."""
+
+    data: int | str
+
+    def predict(self) -> int | str:
+        """Make a prediction based on the model data."""
+        return self.data
+
+
+async def test_single_model() -> None:
+    """Test single model."""
+    test_model = MockModel("Single Model")
+    pickled_model = pickle.dumps(test_model)
+    mock_file = mock_open(read_data=pickled_model)
+
+    with patch("builtins.open", side_effect=mock_file), patch(
+        "os.path.exists", return_value=True
+    ):
+        model_repository = SingleModelRepository(
+            model_path="models/consumption/single/model.pkl"
+        )
+        model_manager: ModelManager[MockModel] = ModelManager(
+            model_repository=model_repository
+        )
+
+        model = model_manager.get_model()
+
+        assert isinstance(model, MockModel)
+        assert model.data == test_model.data
+
+        with pytest.raises(KeyError):
+            model = model_manager.get_model(-1)
+            model = model_manager.get_model(0)
+            model = model_manager.get_model(1)
+            model = model_manager.get_model("single")
+            model = model_manager.get_model("Single")
+            model = model_manager[0]
+            model = model_manager[""]
+
+    await model_manager._stop_model_monitor()  # pylint: disable=protected-access
+
+
+async def test_weekday_models_name() -> None:
+    """Test weekday-based models using weekday names as keys."""
+    day_name_models: dict[str, MockModel] = {
+        day: MockModel(f"{day} Model") for day in calendar.day_abbr
+    }
+
+    pickled_models = [pickle.dumps(model) for model in day_name_models.values()]
+    mock_files = [
+        mock_open(read_data=pickled_model)() for pickled_model in pickled_models
+    ]
+
+    with patch("builtins.open", side_effect=mock_files), patch(
+        "os.path.exists", return_value=True
+    ):
+        model_repository = WeekdayModelRepository(
+            directory="models/consumption/day", file_name="model.pkl"
+        )
+        model_manager: ModelManager[MockModel] = ModelManager(
+            model_repository=model_repository
+        )
+
+        monday_model = model_manager.get_model("Mon")
+        assert monday_model.data == day_name_models["Mon"].data
+
+        wednesday_model = model_manager["Wed"]
+        assert wednesday_model.data == day_name_models["Wed"].data
+
+        friday_model = model_manager["Fri"]
+        assert friday_model.data == day_name_models["Fri"].data
+
+        sunday_model = model_manager.get_model("Sun")
+        assert sunday_model.data == day_name_models["Sun"].data
+
+        with pytest.raises(KeyError):
+            model_manager.get_model()
+            model_manager.get_model(10)
+            model_manager.get_model("TUE")
+            model_manager.get_model("sunday")
+            model_manager.get_model("Thursday")
+            model_manager.get_model(0)
+
+    await model_manager._stop_model_monitor()  # pylint: disable=protected-access
+
+
+async def test_weekday_models_number() -> None:
+    """Test weekday-based models using the weekday numbers as keys."""
+
+    @dataclass
+    class WeekdayCustomModelRepository(ModelRepository):
+        """Repository to manage a custom weekday-based models."""
+
+        directory: str
+        file_name: str
+
+        def _get_allowed_keys(self) -> list[Any]:
+            return [num for num, _ in enumerate(calendar.day_name)]
+
+        def _build_path(self, key: str) -> str:
+            return f"{self.directory}/{key}/{self.file_name}"
+
+    day_num_models: dict[int, MockModel] = {
+        num: MockModel(f"{day} Model") for num, day in enumerate(calendar.day_name)
+    }
+
+    pickled_models = [pickle.dumps(model) for model in day_num_models.values()]
+    mock_files = [
+        mock_open(read_data=pickled_model)() for pickled_model in pickled_models
+    ]
+
+    with patch("builtins.open", side_effect=mock_files), patch(
+        "os.path.exists", return_value=True
+    ):
+        model_repository = WeekdayCustomModelRepository(
+            directory="models/consumption/day", file_name="model.pkl"
+        )
+        model_manager: ModelManager[MockModel] = ModelManager(
+            model_repository=model_repository
+        )
+
+        monday_model = model_manager.get_model(0)
+        assert monday_model.data == day_num_models[0].data
+        timestamp = datetime(2023, 6, 12, tzinfo=timezone.utc)
+        assert model_manager.get_model(timestamp.weekday()) == monday_model
+
+        timestamp = datetime(2023, 6, 11, tzinfo=timezone.utc)
+        sunday_model = model_manager[timestamp.weekday()]
+        assert sunday_model.data == day_num_models[6].data
+
+        with pytest.raises(KeyError):
+            model_manager.get_model()
+            model_manager.get_model(10)
+            model_manager.get_model("Monday")
+
+    await model_manager._stop_model_monitor()  # pylint: disable=protected-access
+
+
+async def test_enumerated_models() -> None:  # pylint: disable=too-many-locals
+    """Test 15m ahead current time interval-based models using the interval numbers as keys."""
+
+    def timestamp_to_interval_num(
+        timestamp: datetime, interval_to_num: dict[str, int]
+    ) -> int:
+        interval_key = f"{timestamp.hour:02d}{timestamp.minute:02d}"
+        position = bisect.bisect(sorted(interval_to_num.keys()), interval_key)
+        return sorted(interval_to_num.values())[position - 1]
+
+    interval_num_models: dict[int, MockModel] = {}
+    interval_to_num: dict[str, int] = {}
+
+    interval_min = 15
+    num_intervals_in_day = 24 * 60 // interval_min
+
+    for index in range(0, num_intervals_in_day):
+        ahead_min = index * interval_min + interval_min
+        key = f"{(ahead_min // 60) % 24:02d}{ahead_min % 60:02d}"
+        interval_num_models[index] = MockModel(key)
+        interval_to_num[key] = index
+
+    pickled_models = [pickle.dumps(model) for model in interval_num_models.values()]
+    mock_files = [
+        mock_open(read_data=pickled_model)() for pickled_model in pickled_models
+    ]
+
+    with patch("builtins.open", side_effect=mock_files), patch(
+        "os.path.exists", return_value=True
+    ):
+        model_repository = EnumeratedModelRepository(
+            directory="models/production/interval",
+            file_name="model.pkl",
+            num_models=num_intervals_in_day,
+        )
+        model_manager: ModelManager[MockModel] = ModelManager(
+            model_repository=model_repository
+        )
+
+        first_model = model_manager.get_model(0)
+        assert first_model.data == interval_num_models[0].data
+        assert first_model.data == "0015"
+        timestamp = datetime(2023, 6, 12, 00, 10, tzinfo=timezone.utc)
+        interval_num = timestamp_to_interval_num(timestamp, interval_to_num)
+        assert model_manager.get_model(interval_num) == first_model
+
+        mid_model = model_manager.get_model(47)
+        assert mid_model.data == interval_num_models[47].data
+        assert mid_model.data == "1200"
+        timestamp = datetime(2023, 6, 12, 11, 48, tzinfo=timezone.utc)
+        interval_num = timestamp_to_interval_num(timestamp, interval_to_num)
+        assert model_manager.get_model(interval_num) == mid_model
+
+        last_model = model_manager.get_model(95)
+        assert last_model.data == interval_num_models[95].data
+        assert last_model.data == "0000"
+        timestamp = datetime(2023, 6, 12, 23, 45, tzinfo=timezone.utc)
+        interval_num = timestamp_to_interval_num(timestamp, interval_to_num)
+        assert model_manager.get_model(interval_num) == last_model
+
+    await model_manager._stop_model_monitor()  # pylint: disable=protected-access
+
+
+async def test_interval_models_name() -> None:
+    """Test 15m interval-based models using the interval names as keys."""
+
+    def format_key() -> list[str]:
+        return [
+            f"{hour:02d}{minute:02d}"
+            for hour in range(0, 24)
+            for minute in range(0, 60, 15)
+        ]
+
+    interval_name_models: dict[str, MockModel] = {
+        key: MockModel(f"{key} Model") for key in format_key()
+    }
+
+    @dataclass
+    class IntervalCustomModelRepository(ModelRepository):
+        """Repository to manage a custom interval-based models."""
+
+        directory: str
+        file_name: str
+
+        def _get_allowed_keys(self) -> list[Any]:
+            return format_key()
+
+        def _build_path(self, key: str) -> str:
+            return f"{self.directory}/{key}/{self.file_name}"
+
+    pickled_models = [pickle.dumps(model) for model in interval_name_models.values()]
+    mock_files = [
+        mock_open(read_data=pickled_model)() for pickled_model in pickled_models
+    ]
+
+    with patch("builtins.open", side_effect=mock_files), patch(
+        "os.path.exists", return_value=True
+    ):
+        model_repository = IntervalCustomModelRepository(
+            directory="models/consumption/interval", file_name="model.pkl"
+        )
+        model_manager: ModelManager[MockModel] = ModelManager(
+            model_repository=model_repository
+        )
+
+        midnight_model = model_manager.get_model("0000")
+        assert midnight_model.data == interval_name_models["0000"].data
+
+        midday_model = model_manager["1200"]
+        assert midday_model.data == interval_name_models["1200"].data
+
+        sunrise_model = model_manager["0615"]
+        assert sunrise_model.data == interval_name_models["0615"].data
+
+        sunset_model = model_manager.get_model("2045")
+        assert sunset_model.data == interval_name_models["2045"].data
+
+    await model_manager._stop_model_monitor()  # pylint: disable=protected-access


### PR DESCRIPTION
The model handlers interface has been implemented to handle the loading, updating, monitoring, and retrieval of machine learning models. Three common types of model handlers have been included: single model handler, day model handler, and interval model handler. The single model handler is responsible for managing a single model, the day model handler handles a model per day, and the interval model handler manages models based on specific intervals.

The directories/paths structure for storing/loading models considering the use-cases in the [discussion](https://github.com/frequenz-floss/frequenz-sdk-python/discussions/325) is as follows:

```
models/
    {consumption,production}/
        single/
            (prefix)_model_(suffix).pkl
        day/
            [mon,tue,wed,thu,fri,sat,sun]/
                (prefix)_model_(suffix).pkl
        interval/
            [0000,0015,0030,0045,0100,..,2345]/
                (prefix)_model_(suffix).pkl
```

Fixes: https://github.com/frequenz-floss/frequenz-sdk-python/discussions/325