### PR TITLE
ci: Fix building of tags

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,8 @@ on:
   merge_group:
   pull_request:
   push:
+    tags:
+      - '*'
     branches-ignore:
       # Ignore pushes to merge queues.
       # We only want to test the merge commit (`merge_group` event), the hashes
@@ -193,7 +195,7 @@ jobs:
   create-github-release:
     needs: ["publish-docs"]
     # Create a release only on tags creation
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     permissions:
       # We need write permissions on contents to create GitHub releases and on
       # discussions to create the release announcement in the discussion forums


### PR DESCRIPTION
Tags were not built because `branches-ignore` was added so only branches were built.

We also specify that only tags starting with `v` should produce a GitHub release (and pypi upload), just in case some tag is added that is not really a new version.