### PR TITLE
Fix ring buffer len

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,7 +6,7 @@
 
 ## Upgrading
 
-<!-- Here goes notes on how to upgrade from previous versions, including deprecations and what they should be replaced with --> 
+<!-- Here goes notes on how to upgrade from previous versions, including deprecations and what they should be replaced with -->
 
 ## New Features
 
@@ -16,4 +16,8 @@
 
 ## Bug Fixes
 
-<!-- Here goes notable bug fixes that are worth a special mention or explanation -->
+- Two bugs in the ring buffer which is used by the `MovingWindow` class were fixed:
+  - `len(buffer)` was not considering potentially existing gaps (areas without elements) in the buffer.
+  - A off-by-one error in the gap calculation logic was fixed that recorded a
+    gap when there was none if an element with a future timestamp was added that
+    would create a gap of exactly 1.

--- a/src/frequenz/sdk/timeseries/_ringbuffer/buffer.py
+++ b/src/frequenz/sdk/timeseries/_ringbuffer/buffer.py
@@ -82,7 +82,7 @@ class OrderedRingBuffer(Generic[FloatArray]):
         self._gaps: list[Gap] = []
         self._datetime_newest: datetime = self._DATETIME_MIN
         self._datetime_oldest: datetime = self._DATETIME_MAX
-        self._time_range: timedelta = (len(self._buffer) - 1) * sampling_period
+        self._full_time_range: timedelta = len(self._buffer) * self._sampling_period
 
     @property
     def sampling_period(self) -> timedelta:
@@ -145,7 +145,9 @@ class OrderedRingBuffer(Generic[FloatArray]):
         # Update timestamps
         prev_newest = self._datetime_newest
         self._datetime_newest = max(self._datetime_newest, timestamp)
-        self._datetime_oldest = self._datetime_newest - self._time_range
+        self._datetime_oldest = self._datetime_newest - (
+            self._full_time_range - self._sampling_period
+        )
 
         # Update data
         value: float = np.nan if sample.value is None else sample.value.base_value
@@ -293,7 +295,7 @@ class OrderedRingBuffer(Generic[FloatArray]):
 
         if not new_missing:
             # Replace all gaps with one if we went far into then future
-            if self._datetime_newest - newest >= self._time_range:
+            if self._datetime_newest - newest >= self._full_time_range:
                 self._gaps = [
                     Gap(start=self._datetime_oldest, end=self._datetime_newest)
                 ]

--- a/tests/timeseries/test_ringbuffer.py
+++ b/tests/timeseries/test_ringbuffer.py
@@ -195,14 +195,14 @@ def test_timestamp_ringbuffer_missing_parameter(
 @pytest.mark.parametrize(
     "buffer",
     [
-        OrderedRingBuffer([0.0] * 24 * int(ONE_MINUTE.total_seconds()), ONE_MINUTE),
+        OrderedRingBuffer([0.0] * 10 * int(ONE_MINUTE.total_seconds()), ONE_MINUTE),
         OrderedRingBuffer(
-            np.empty(shape=(24 * int(ONE_MINUTE.total_seconds()),), dtype=np.float64),
+            np.empty(shape=(12 * int(ONE_MINUTE.total_seconds()),), dtype=np.float64),
             ONE_MINUTE,
         ),
-        OrderedRingBuffer([0.0] * 24 * int(FIVE_MINUTES.total_seconds()), FIVE_MINUTES),
+        OrderedRingBuffer([0.0] * 5 * int(FIVE_MINUTES.total_seconds()), FIVE_MINUTES),
         OrderedRingBuffer(
-            np.empty(shape=(24 * int(FIVE_MINUTES.total_seconds())), dtype=np.float64),
+            np.empty(shape=(5 * int(FIVE_MINUTES.total_seconds())), dtype=np.float64),
             FIVE_MINUTES,
         ),
     ],

--- a/tests/timeseries/test_ringbuffer.py
+++ b/tests/timeseries/test_ringbuffer.py
@@ -289,6 +289,21 @@ def test_len_ringbuffer_samples_fit_buffer_size() -> None:
         assert len(buffer) == len(test_samples)
 
 
+def test_len_with_gaps() -> None:
+    """Test the length when there are gaps in the buffer."""
+    buffer = OrderedRingBuffer(
+        np.empty(shape=10, dtype=float),
+        sampling_period=timedelta(seconds=1),
+        align_to=datetime(1, 1, 1, tzinfo=timezone.utc),
+    )
+
+    for i in range(10):
+        buffer.update(
+            Sample(datetime(2, 2, 2, 0, 0, i, tzinfo=timezone.utc), Quantity(float(i)))
+        )
+        assert len(buffer) == i + 1
+
+
 def test_len_ringbuffer_samples_overwrite_buffer() -> None:
     """Test the length of ordered ring buffer.
 

--- a/tests/timeseries/test_ringbuffer.py
+++ b/tests/timeseries/test_ringbuffer.py
@@ -335,3 +335,22 @@ def test_ringbuffer_empty_buffer() -> None:
             sampling_period=timedelta(seconds=1),
             align_to=datetime(1, 1, 1),
         )
+
+
+def test_off_by_one_gap_logic_bug() -> None:
+    """Test off by one bug in the gap calculation."""
+    buffer = OrderedRingBuffer(
+        np.empty(shape=2, dtype=float),
+        sampling_period=timedelta(seconds=1),
+        align_to=datetime(1, 1, 1, tzinfo=timezone.utc),
+    )
+
+    base_time = datetime(2023, 1, 1, tzinfo=timezone.utc)
+
+    times = [base_time, base_time + timedelta(seconds=1)]
+
+    buffer.update(Sample(times[0], Quantity(1.0)))
+    buffer.update(Sample(times[1], Quantity(2.0)))
+
+    assert buffer.is_missing(times[0]) is False
+    assert buffer.is_missing(times[1]) is False

--- a/tests/timeseries/test_ringbuffer_serialization.py
+++ b/tests/timeseries/test_ringbuffer_serialization.py
@@ -61,8 +61,6 @@ def load_dump_test(dumped: rb.OrderedRingBuffer[Any], path: str) -> None:
     # pylint: disable=protected-access
     assert dumped._gaps == loaded._gaps
     # pylint: disable=protected-access
-    assert dumped._time_range == loaded._time_range
-    # pylint: disable=protected-access
     assert dumped._sampling_period == loaded._sampling_period
     # pylint: disable=protected-access
     assert dumped._time_index_alignment == loaded._time_index_alignment


### PR DESCRIPTION
- RingBuffer: Fix off-by-one error in gap calculation
- RingBuffer: Rename variables and add comments for more clarity
- RingBuffer: Decrease test samples to speedup a long test
- RingBuffer: Fix gaps being ignored in __len__()

fixes #442
