### PR TITLE
Expose only usable SoC and Capacity through the BatteryPool

### DIFF
--- a/src/frequenz/sdk/timeseries/battery_pool/__init__.py
+++ b/src/frequenz/sdk/timeseries/battery_pool/__init__.py
@@ -3,13 +3,11 @@
 
 """Manage a pool of batteries."""
 
-from ._result_types import Bound, CapacityMetrics, PowerMetrics, SoCMetrics
+from ._result_types import Bound, PowerMetrics
 from .battery_pool import BatteryPool
 
 __all__ = [
     "BatteryPool",
     "PowerMetrics",
-    "SoCMetrics",
-    "CapacityMetrics",
     "Bound",
 ]

--- a/src/frequenz/sdk/timeseries/battery_pool/_metric_calculator.py
+++ b/src/frequenz/sdk/timeseries/battery_pool/_metric_calculator.py
@@ -206,9 +206,7 @@ class CapacityCalculator(MetricCalculator[CapacityMetrics]):
             High level metric calculated from the given metrics.
             Return None if there are no component metrics.
         """
-        result = CapacityMetrics(
-            timestamp=_MIN_TIMESTAMP, total_capacity=0, bound=Bound(lower=0, upper=0)
-        )
+        result = CapacityMetrics(timestamp=_MIN_TIMESTAMP, total_capacity=0)
 
         for battery_id in working_batteries:
             if battery_id not in metrics_data:
@@ -223,11 +221,9 @@ class CapacityCalculator(MetricCalculator[CapacityMetrics]):
             # All metrics are related so if any is missing then we skip the component.
             if capacity is None or soc_lower_bound is None or soc_upper_bound is None:
                 continue
-
+            usable_capacity = capacity * (soc_upper_bound - soc_lower_bound) / 100
             result.timestamp = max(result.timestamp, metrics.timestamp)
-            result.total_capacity += capacity
-            result.bound.upper += capacity * soc_upper_bound
-            result.bound.lower += capacity * soc_lower_bound
+            result.total_capacity += usable_capacity
 
         return None if result.timestamp == _MIN_TIMESTAMP else result
 

--- a/src/frequenz/sdk/timeseries/battery_pool/_result_types.py
+++ b/src/frequenz/sdk/timeseries/battery_pool/_result_types.py
@@ -59,33 +59,25 @@ class SoCMetrics:
     """Timestamp of the metrics."""
 
     average_soc: float
-    """Average soc.
+    """Average SoC of working batteries in the pool, weighted by usable capacity.
+
+    The values are normalized to the 0-100% range.
 
     Average soc is calculated with the formula:
     ```python
     working_batteries: Set[BatteryData] # working batteries from the battery pool
 
-    used_capacity = sum(battery.capacity * battery.soc for battery in working_batteries)
-    total_capacity = sum(battery.capacity for battery in working_batteries)
+    battery.soc_scaled = max(
+        0,
+        (soc - soc_lower_bound) / (soc_upper_bound - soc_lower_bound) * 100,
+    )
+    used_capacity = sum(
+        battery.usable_capacity * battery.soc_scaled
+        for battery in working_batteries
+    )
+    total_capacity = sum(battery.usable_capacity for battery in working_batteries)
     average_soc = used_capacity/total_capacity
     ```
-    """
-
-    bound: Bound
-    """SoC bounds weighted by capacity.
-
-    Bounds are calculated with the formula:
-    capacity_lower_bound = sum(
-        battery.capacity * battery.soc_lower_bound for battery in working_batteries)
-
-    capacity_upper_bound = sum(
-        battery.capacity * battery.soc_upper_bound for battery in working_batteries)
-
-    total_capacity = sum(battery.capacity for battery in working_batteries)
-
-    bound.lower = capacity_lower_bound/total_capacity
-    bound.upper = capacity_upper_bound/total_capacity
-
     """
 
 

--- a/src/frequenz/sdk/timeseries/battery_pool/_result_types.py
+++ b/src/frequenz/sdk/timeseries/battery_pool/_result_types.py
@@ -35,19 +35,6 @@ class CapacityMetrics:
     total_capacity = sum(battery.capacity for battery in working_batteries)
     ```
     """
-    bound: Bound
-    """Capacity bounds.
-
-    Bounds are calculated with the formula:
-    ```python
-    working_batteries: Set[BatteryData] # working batteries from the battery
-    bound.lower = sum(
-        battery.capacity * battery.soc_lower_bound for battery in working_batteries)
-
-    bound.upper = sum(
-        battery.capacity * battery.soc_upper_bound for battery in working_batteries)
-    ```
-    """
 
 
 @dataclass

--- a/src/frequenz/sdk/timeseries/battery_pool/_result_types.py
+++ b/src/frequenz/sdk/timeseries/battery_pool/_result_types.py
@@ -19,56 +19,6 @@ class Bound:
 
 
 @dataclass
-class CapacityMetrics:
-    """Capacity metrics."""
-
-    # compare = False tells the dataclass to not use name for comparison methods
-    timestamp: datetime = field(compare=False)
-    """Timestamp of the metrics,"""
-
-    total_capacity: float
-    """Total batteries capacity.
-
-    Calculated with the formula:
-    ```python
-    working_batteries: Set[BatteryData] # working batteries from the battery pool
-    total_capacity = sum(battery.capacity for battery in working_batteries)
-    ```
-    """
-
-
-@dataclass
-class SoCMetrics:
-    """Soc metrics."""
-
-    # compare = False tells the dataclass to not use name for comparison methods
-    timestamp: datetime = field(compare=False)
-    """Timestamp of the metrics."""
-
-    average_soc: float
-    """Average SoC of working batteries in the pool, weighted by usable capacity.
-
-    The values are normalized to the 0-100% range.
-
-    Average soc is calculated with the formula:
-    ```python
-    working_batteries: Set[BatteryData] # working batteries from the battery pool
-
-    battery.soc_scaled = max(
-        0,
-        (soc - soc_lower_bound) / (soc_upper_bound - soc_lower_bound) * 100,
-    )
-    used_capacity = sum(
-        battery.usable_capacity * battery.soc_scaled
-        for battery in working_batteries
-    )
-    total_capacity = sum(battery.usable_capacity for battery in working_batteries)
-    average_soc = used_capacity/total_capacity
-    ```
-    """
-
-
-@dataclass
 class PowerMetrics:
     """Power bounds metrics."""
 

--- a/src/frequenz/sdk/timeseries/battery_pool/battery_pool.py
+++ b/src/frequenz/sdk/timeseries/battery_pool/battery_pool.py
@@ -27,10 +27,10 @@ from .._formula_engine._formula_generators import (
     FormulaGeneratorConfig,
     FormulaType,
 )
-from .._quantities import Power
+from .._quantities import Energy, Power
 from ._methods import MetricAggregator, SendOnUpdate
 from ._metric_calculator import CapacityCalculator, PowerBoundsCalculator, SoCCalculator
-from ._result_types import CapacityMetrics, PowerMetrics
+from ._result_types import PowerMetrics
 
 
 class BatteryPool:
@@ -357,7 +357,7 @@ class BatteryPool:
         return self._active_methods[method_name]
 
     @property
-    def capacity(self) -> MetricAggregator[CapacityMetrics]:
+    def capacity(self) -> MetricAggregator[Sample[Energy]]:
         """Get receiver to receive new capacity metrics when they change.
 
         Capacity formulas are described in the receiver return type.  None will be send

--- a/src/frequenz/sdk/timeseries/battery_pool/battery_pool.py
+++ b/src/frequenz/sdk/timeseries/battery_pool/battery_pool.py
@@ -330,10 +330,11 @@ class BatteryPool:
 
     @property
     def soc(self) -> MetricAggregator[SoCMetrics]:
-        """Get receiver to receive new soc metrics when they change.
+        """Fetch the normalized average weighted-by-capacity SoC values for the pool.
 
-        Soc formulas are described in the receiver return type.  None will be send if
-        there is no component to calculate metric.
+        The formulas for calculating this metric are described
+        [here][frequenz.sdk.timeseries.battery_pool.SoCMetrics].  `None` values will be
+        sent if there are no components to calculate the metric with.
 
         A receiver from the MetricAggregator can be obtained by calling the
         `new_receiver` method.

--- a/src/frequenz/sdk/timeseries/battery_pool/battery_pool.py
+++ b/src/frequenz/sdk/timeseries/battery_pool/battery_pool.py
@@ -20,6 +20,7 @@ from ...actor.power_distributing._battery_pool_status import BatteryStatus
 from ...actor.power_distributing.result import Result
 from ...microgrid import connection_manager
 from ...microgrid.component import ComponentCategory
+from ...timeseries import Quantity, Sample
 from .._formula_engine import FormulaEngine, FormulaEnginePool
 from .._formula_engine._formula_generators import (
     BatteryPowerFormula,
@@ -29,7 +30,7 @@ from .._formula_engine._formula_generators import (
 from .._quantities import Power
 from ._methods import MetricAggregator, SendOnUpdate
 from ._metric_calculator import CapacityCalculator, PowerBoundsCalculator, SoCCalculator
-from ._result_types import CapacityMetrics, PowerMetrics, SoCMetrics
+from ._result_types import CapacityMetrics, PowerMetrics
 
 
 class BatteryPool:
@@ -329,7 +330,7 @@ class BatteryPool:
         return engine
 
     @property
-    def soc(self) -> MetricAggregator[SoCMetrics]:
+    def soc(self) -> MetricAggregator[Sample[Quantity]]:
         """Fetch the normalized average weighted-by-capacity SoC values for the pool.
 
         The formulas for calculating this metric are described

--- a/tests/timeseries/_battery_pool/test_battery_pool.py
+++ b/tests/timeseries/_battery_pool/test_battery_pool.py
@@ -24,14 +24,8 @@ from frequenz.sdk._internal._constants import (
 from frequenz.sdk.actor import ResamplerConfig
 from frequenz.sdk.actor.power_distributing import BatteryStatus
 from frequenz.sdk.microgrid.component import ComponentCategory
-from frequenz.sdk.timeseries import Quantity, Sample
-from frequenz.sdk.timeseries._quantities import Power
-from frequenz.sdk.timeseries.battery_pool import (
-    BatteryPool,
-    Bound,
-    CapacityMetrics,
-    PowerMetrics,
-)
+from frequenz.sdk.timeseries import Energy, Power, Quantity, Sample
+from frequenz.sdk.timeseries.battery_pool import BatteryPool, Bound, PowerMetrics
 from frequenz.sdk.timeseries.battery_pool._metric_calculator import (
     battery_inverter_mapping,
 )
@@ -508,93 +502,115 @@ async def run_capacity_test(setup_args: SetupArgs) -> None:
         capacity_receiver.receive(), timeout=WAIT_FOR_COMPONENT_DATA_SEC + 0.2
     )
     now = datetime.now(tz=timezone.utc)
-    expected = CapacityMetrics(
+    expected = Sample[Energy](
         timestamp=now,
-        total_capacity=50.0,  # 50% of 50 kWh + 50% of 50 kWh = 25 + 25 = 50 kWh
+        value=Energy.from_watt_hours(
+            50.0
+        ),  # 50% of 50 kWh + 50% of 50 kWh = 25 + 25 = 50 kWh
     )
     compare_messages(msg, expected, WAIT_FOR_COMPONENT_DATA_SEC + 0.2)
 
     batteries_in_pool = list(battery_pool.battery_ids)
-    scenarios: list[Scenario[CapacityMetrics]] = [
+    scenarios: list[Scenario[Sample[Energy]]] = [
         Scenario(
             batteries_in_pool[0],
             {"capacity": 90.0},
-            CapacityMetrics(
+            Sample(
                 now,
-                70.0,  # 50% of 90 kWh + 50% of 50 kWh = 45 + 25 = 70 kWh
+                Energy.from_watt_hours(
+                    70.0
+                ),  # 50% of 90 kWh + 50% of 50 kWh = 45 + 25 = 70 kWh
             ),
         ),
         Scenario(
             batteries_in_pool[1],
             {"soc_lower_bound": 0.0, "soc_upper_bound": 90.0},
-            CapacityMetrics(
+            Sample(
                 now,
-                90.0,  # 50% of 90 kWh + 90% of 50 kWh = 45 + 45 = 90 kWh
+                Energy.from_watt_hours(
+                    90.0
+                ),  # 50% of 90 kWh + 90% of 50 kWh = 45 + 45 = 90 kWh
             ),
         ),
         Scenario(
             batteries_in_pool[0],
             {"capacity": 0.0, "soc_lower_bound": 0.0},
-            CapacityMetrics(
+            Sample(
                 now,
-                45.0,  # 75% of 0 kWh + 90% of 50 kWh = 0 + 45 = 45 kWh
+                Energy.from_watt_hours(
+                    45.0
+                ),  # 75% of 0 kWh + 90% of 50 kWh = 0 + 45 = 45 kWh
             ),
         ),
         # Test zero division error
         Scenario(
             batteries_in_pool[1],
             {"capacity": 0.0},
-            CapacityMetrics(
+            Sample(
                 now,
-                0.0,  # 75% of 0 kWh + 90% of 0 kWh = 0 + 0 = 0 kWh
+                Energy.from_watt_hours(
+                    0.0
+                ),  # 75% of 0 kWh + 90% of 0 kWh = 0 + 0 = 0 kWh
             ),
         ),
         Scenario(
             batteries_in_pool[1],
             {"capacity": 50.0},
-            CapacityMetrics(
+            Sample(
                 now,
-                45.0,  # 75% of 0 kWh + 90% of 50 kWh = 0 + 45 = 45 kWh
+                Energy.from_watt_hours(
+                    45.0
+                ),  # 75% of 0 kWh + 90% of 50 kWh = 0 + 45 = 45 kWh
             ),
         ),
         Scenario(
             batteries_in_pool[1],
             {"soc_upper_bound": float("NaN")},
-            CapacityMetrics(
+            Sample(
                 now,
-                0.0,  # 75% of 0 kWh + 90% of 0 kWh = 0 + 0 = 0 kWh
+                Energy.from_watt_hours(
+                    0.0
+                ),  # 75% of 0 kWh + 90% of 0 kWh = 0 + 0 = 0 kWh
             ),
         ),
         Scenario(
             batteries_in_pool[0],
             {"capacity": 30.0, "soc_lower_bound": 20.0, "soc_upper_bound": 90.0},
-            CapacityMetrics(
+            Sample(
                 now,
-                21.0,  # 70% of 30 kWh + 90% of 0 kWh = 21 + 0 = 21 kWh
+                Energy.from_watt_hours(
+                    21.0
+                ),  # 70% of 30 kWh + 90% of 0 kWh = 21 + 0 = 21 kWh
             ),
         ),
         Scenario(
             batteries_in_pool[1],
             {"capacity": 200.0, "soc_lower_bound": 20.0, "soc_upper_bound": 90.0},
-            CapacityMetrics(
+            Sample(
                 now,
-                161.0,  # 70% of 30 kWh + 70% of 200 kWh = 21 + 140 = 161 kWh
+                Energy.from_watt_hours(
+                    161.0
+                ),  # 70% of 30 kWh + 70% of 200 kWh = 21 + 140 = 161 kWh
             ),
         ),
         Scenario(
             batteries_in_pool[1],
             {"capacity": float("NaN")},
-            CapacityMetrics(
+            Sample(
                 now,
-                21.0,  # 70% of 30 kWh + 70% of 0 kWh = 21 + 0 = 21 kWh
+                Energy.from_watt_hours(
+                    21.0
+                ),  # 70% of 30 kWh + 70% of 0 kWh = 21 + 0 = 21 kWh
             ),
         ),
         Scenario(
             batteries_in_pool[1],
             {"capacity": 200.0},
-            CapacityMetrics(
+            Sample(
                 now,
-                161.0,  # 70% of 30 kWh + 70% of 200 kWh = 21 + 140 = 161 kWh
+                Energy.from_watt_hours(
+                    161.0
+                ),  # 70% of 30 kWh + 70% of 200 kWh = 21 + 140 = 161 kWh
             ),
         ),
     ]
@@ -608,15 +624,15 @@ async def run_capacity_test(setup_args: SetupArgs) -> None:
         all_batteries=all_batteries,
         batteries_in_pool=batteries_in_pool,
         waiting_time_sec=waiting_time_sec,
-        all_pool_result=CapacityMetrics(now, 161.0),
-        only_first_battery_result=CapacityMetrics(now, 21.0),
+        all_pool_result=Sample(now, Energy.from_watt_hours(161.0)),
+        only_first_battery_result=Sample(now, Energy.from_watt_hours(21.0)),
     )
 
     # One battery stopped sending data.
     await streamer.stop_streaming(batteries_in_pool[1])
     await asyncio.sleep(MAX_BATTERY_DATA_AGE_SEC + 0.2)
     msg = await asyncio.wait_for(capacity_receiver.receive(), timeout=waiting_time_sec)
-    compare_messages(msg, CapacityMetrics(now, 21.0), 0.2)
+    compare_messages(msg, Sample(now, Energy.from_watt_hours(21.0)), 0.2)
 
     # All batteries stopped sending data.
     await streamer.stop_streaming(batteries_in_pool[0])
@@ -628,7 +644,7 @@ async def run_capacity_test(setup_args: SetupArgs) -> None:
     latest_data = streamer.get_current_component_data(batteries_in_pool[0])
     streamer.start_streaming(latest_data, sampling_rate=0.1)
     msg = await asyncio.wait_for(capacity_receiver.receive(), timeout=waiting_time_sec)
-    compare_messages(msg, CapacityMetrics(now, 21.0), 0.2)
+    compare_messages(msg, Sample(now, Energy.from_watt_hours(21.0)), 0.2)
 
 
 async def run_soc_test(setup_args: SetupArgs) -> None:


### PR DESCRIPTION
With this PR,
 - soc values from the battery pool are always normalized to the 0-100% range,  and they are now streamed as `Sample[Quantity]` objects.
 - only the usable capacity is streamed, eliminating the need for capacity bounds,  so they are now streamed as `Sample[Energy]` objects.

Closes #417 