### PR TITLE
Remove unused `JUNCTION` and `LOAD` component categories

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -24,6 +24,8 @@
   capacity: float = soc_sample.value.as_watt_hours()
   ```
 
+- `MicrogridApiClient.set_power` no longer returns a `protobuf.Empty` result, but a `None`.  This won't affect you unless you are using the low level APIs of the SDK.
+
 <!-- Here goes notes on how to upgrade from previous versions, including deprecations and what they should be replaced with -->
 
 ## New Features

--- a/src/frequenz/sdk/actor/power_distributing/power_distributing.py
+++ b/src/frequenz/sdk/actor/power_distributing/power_distributing.py
@@ -25,7 +25,6 @@ from typing import Any, Dict, Iterable, List, Optional, Self, Set, Tuple
 
 import grpc
 from frequenz.channels import Peekable, Receiver, Sender
-from google.protobuf.empty_pb2 import Empty  # pylint: disable=no-name-in-module
 
 from ...actor import ChannelRegistry
 from ...actor._decorator import actor
@@ -674,8 +673,7 @@ class PowerDistributingActor:
 
     def _parse_result(
         self,
-        # type comment to quiet pylint and mypy `unused-import` error
-        tasks,  # type: Dict[int, asyncio.Task[Empty]]
+        tasks: Dict[int, asyncio.Task[None]],
         distribution: Dict[int, float],
         request_timeout_sec: float,
     ) -> Tuple[float, Set[int]]:

--- a/src/frequenz/sdk/microgrid/_graph.py
+++ b/src/frequenz/sdk/microgrid/_graph.py
@@ -502,7 +502,6 @@ class _MicrogridComponentGraph(ComponentGraph):
         self._validate_graph_root()
         self._validate_grid_endpoint()
         self._validate_intermediary_components()
-        self._validate_junctions()
         self._validate_leaf_components()
 
     def is_pv_inverter(self, component: Component) -> bool:
@@ -747,7 +746,6 @@ class _MicrogridComponentGraph(ComponentGraph):
         valid_root_types = {
             ComponentCategory.NONE,
             ComponentCategory.GRID,
-            ComponentCategory.JUNCTION,
         }
 
         valid_roots = list(
@@ -820,24 +818,6 @@ class _MicrogridComponentGraph(ComponentGraph):
             raise InvalidGraphError(
                 "Intermediary components without graph predecessors: "
                 f"{missing_predecessors}"
-            )
-
-    def _validate_junctions(self) -> None:
-        """Check that junctions are configured correctly in the graph.
-
-        Raises:
-            InvalidGraphError: if any junction has no successors (it is allowed
-                for a single junction to be the root of the component graph, in
-                which case it will have no predecessors: this is taken care of
-                by the `_validate_graph_root` check)
-        """
-        junctions = self.components(component_category={ComponentCategory.JUNCTION})
-        no_successors = list(
-            filter(lambda c: self._graph.out_degree(c.component_id) == 0, junctions)
-        )
-        if len(no_successors) > 0:
-            raise InvalidGraphError(
-                f"Junctions missing graph successors: {no_successors}"
             )
 
     def _validate_leaf_components(self) -> None:

--- a/src/frequenz/sdk/microgrid/client/_client.py
+++ b/src/frequenz/sdk/microgrid/client/_client.py
@@ -169,7 +169,7 @@ class MicrogridApiClient(ABC):
         """
 
     @abstractmethod
-    async def set_power(self, component_id: int, power_w: float) -> Empty:
+    async def set_power(self, component_id: int, power_w: float) -> None:
         """Send request to the Microgrid to set power for component.
 
         If power > 0, then component will be charged with this power.
@@ -180,9 +180,6 @@ class MicrogridApiClient(ABC):
         Args:
             component_id: id of the component to set power.
             power_w: power to set for the component.
-
-        Returns:
-            Empty response.
         """
 
     @abstractmethod
@@ -567,7 +564,7 @@ class MicrogridGrpcClient(MicrogridApiClient):
             EVChargerData.from_proto,
         ).new_receiver(maxsize=maxsize)
 
-    async def set_power(self, component_id: int, power_w: float) -> Empty:
+    async def set_power(self, component_id: int, power_w: float) -> None:
         """Send request to the Microgrid to set power for component.
 
         If power > 0, then component will be charged with this power.
@@ -579,9 +576,6 @@ class MicrogridGrpcClient(MicrogridApiClient):
             component_id: id of the component to set power.
             power_w: power to set for the component.
 
-        Returns:
-            Empty response.
-
         Raises:
             AioRpcError: if connection to Microgrid API cannot be established or
                 when the api call exceeded timeout
@@ -590,7 +584,7 @@ class MicrogridGrpcClient(MicrogridApiClient):
             if power_w >= 0:
                 # grpc.aio is missing types and mypy thinks this is not
                 # async iterable, but it is
-                result: Empty = await self.api.Charge(
+                await self.api.Charge(
                     microgrid_pb.PowerLevelParam(
                         component_id=component_id, power_w=math.floor(power_w)
                     ),
@@ -600,7 +594,7 @@ class MicrogridGrpcClient(MicrogridApiClient):
                 # grpc.aio is missing types and mypy thinks this is not
                 # async iterable, but it is
                 power_w *= -1
-                result = await self.api.Discharge(
+                await self.api.Discharge(
                     microgrid_pb.PowerLevelParam(
                         component_id=component_id, power_w=math.floor(power_w)
                     ),
@@ -615,7 +609,6 @@ class MicrogridGrpcClient(MicrogridApiClient):
                 details=msg,
                 debug_error_string=err.debug_error_string(),
             )
-        return result
 
     async def set_bounds(
         self,

--- a/src/frequenz/sdk/microgrid/client/_client.py
+++ b/src/frequenz/sdk/microgrid/client/_client.py
@@ -244,10 +244,7 @@ class MicrogridGrpcClient(MicrogridApiClient):
             )
         components_only = filter(
             lambda c: c.category
-            not in (
-                microgrid_pb.ComponentCategory.COMPONENT_CATEGORY_SENSOR,
-                microgrid_pb.ComponentCategory.COMPONENT_CATEGORY_LOAD,
-            ),
+            is not microgrid_pb.ComponentCategory.COMPONENT_CATEGORY_SENSOR,
             component_list.components,
         )
         result: Iterable[Component] = map(

--- a/src/frequenz/sdk/microgrid/component/_component.py
+++ b/src/frequenz/sdk/microgrid/component/_component.py
@@ -58,12 +58,10 @@ class ComponentCategory(Enum):
 
     NONE = microgrid_pb.ComponentCategory.COMPONENT_CATEGORY_UNSPECIFIED
     GRID = microgrid_pb.ComponentCategory.COMPONENT_CATEGORY_GRID
-    JUNCTION = microgrid_pb.ComponentCategory.COMPONENT_CATEGORY_JUNCTION
     METER = microgrid_pb.ComponentCategory.COMPONENT_CATEGORY_METER
     INVERTER = microgrid_pb.ComponentCategory.COMPONENT_CATEGORY_INVERTER
     BATTERY = microgrid_pb.ComponentCategory.COMPONENT_CATEGORY_BATTERY
     EV_CHARGER = microgrid_pb.ComponentCategory.COMPONENT_CATEGORY_EV_CHARGER
-    LOAD = microgrid_pb.ComponentCategory.COMPONENT_CATEGORY_LOAD
     CHP = microgrid_pb.ComponentCategory.COMPONENT_CATEGORY_CHP
 
     # types not yet supported by the API but which can be inferred

--- a/tests/actor/test_battery_status.py
+++ b/tests/actor/test_battery_status.py
@@ -116,7 +116,6 @@ def component_graph() -> Tuple[Set[Component], Set[Connection]]:
     components = {
         Component(1, ComponentCategory.GRID),
         Component(2, ComponentCategory.METER),
-        Component(3, ComponentCategory.JUNCTION),
         Component(104, ComponentCategory.METER),
         Component(105, ComponentCategory.INVERTER),
         Component(106, ComponentCategory.BATTERY),
@@ -130,14 +129,13 @@ def component_graph() -> Tuple[Set[Component], Set[Connection]]:
 
     connections = {
         Connection(1, 2),
-        Connection(2, 3),
-        Connection(3, 104),
+        Connection(2, 104),
         Connection(104, 105),
         Connection(105, 106),
-        Connection(3, 204),
+        Connection(2, 204),
         Connection(204, 205),
         Connection(205, 206),
-        Connection(3, 304),
+        Connection(2, 304),
         Connection(304, 305),
         Connection(305, 306),
     }

--- a/tests/actor/test_data_sourcing.py
+++ b/tests/actor/test_data_sourcing.py
@@ -31,9 +31,6 @@ class TestDataSourcingActor:
             1, microgrid_pb2.ComponentCategory.COMPONENT_CATEGORY_GRID
         )
         servicer.add_component(
-            3, microgrid_pb2.ComponentCategory.COMPONENT_CATEGORY_JUNCTION
-        )
-        servicer.add_component(
             4, microgrid_pb2.ComponentCategory.COMPONENT_CATEGORY_METER
         )
         servicer.add_component(
@@ -46,9 +43,8 @@ class TestDataSourcingActor:
             9, microgrid_pb2.ComponentCategory.COMPONENT_CATEGORY_BATTERY
         )
 
-        servicer.add_connection(1, 3)
-        servicer.add_connection(3, 4)
-        servicer.add_connection(3, 7)
+        servicer.add_connection(1, 4)
+        servicer.add_connection(1, 7)
         servicer.add_connection(7, 8)
         servicer.add_connection(8, 9)
 

--- a/tests/actor/test_power_distributing.py
+++ b/tests/actor/test_power_distributing.py
@@ -53,7 +53,6 @@ class TestPowerDistributingActor:
         components = {
             Component(1, ComponentCategory.GRID),
             Component(2, ComponentCategory.METER),
-            Component(3, ComponentCategory.JUNCTION),
             Component(104, ComponentCategory.METER),
             Component(105, ComponentCategory.INVERTER),
             Component(106, ComponentCategory.BATTERY),
@@ -67,14 +66,13 @@ class TestPowerDistributingActor:
 
         connections = {
             Connection(1, 2),
-            Connection(2, 3),
-            Connection(3, 104),
+            Connection(2, 104),
             Connection(104, 105),
             Connection(105, 106),
-            Connection(3, 204),
+            Connection(2, 204),
             Connection(204, 205),
             Connection(205, 206),
-            Connection(3, 304),
+            Connection(2, 304),
             Connection(304, 305),
             Connection(305, 306),
         }

--- a/tests/microgrid/test_client.py
+++ b/tests/microgrid/test_client.py
@@ -74,12 +74,9 @@ class TestMicrogridGrpcClient:
                 Component(0, ComponentCategory.METER),
             }
 
-            # sensors/loads are not counted as components by the API client
+            # sensors are not counted as components by the API client
             servicer.add_component(
                 1, microgrid_pb.ComponentCategory.COMPONENT_CATEGORY_SENSOR
-            )
-            servicer.add_component(
-                2, microgrid_pb.ComponentCategory.COMPONENT_CATEGORY_LOAD
             )
             assert set(await microgrid.components()) == {
                 Component(0, ComponentCategory.METER),
@@ -91,7 +88,6 @@ class TestMicrogridGrpcClient:
                 [
                     (9, microgrid_pb.ComponentCategory.COMPONENT_CATEGORY_METER),
                     (99, microgrid_pb.ComponentCategory.COMPONENT_CATEGORY_INVERTER),
-                    (66, microgrid_pb.ComponentCategory.COMPONENT_CATEGORY_LOAD),
                     (666, microgrid_pb.ComponentCategory.COMPONENT_CATEGORY_SENSOR),
                     (999, microgrid_pb.ComponentCategory.COMPONENT_CATEGORY_BATTERY),
                 ]
@@ -104,7 +100,6 @@ class TestMicrogridGrpcClient:
 
             servicer.set_components(
                 [
-                    (66, microgrid_pb.ComponentCategory.COMPONENT_CATEGORY_LOAD),
                     (99, microgrid_pb.ComponentCategory.COMPONENT_CATEGORY_SENSOR),
                     (
                         100,

--- a/tests/microgrid/test_client.py
+++ b/tests/microgrid/test_client.py
@@ -106,7 +106,6 @@ class TestMicrogridGrpcClient:
                         microgrid_pb.ComponentCategory.COMPONENT_CATEGORY_UNSPECIFIED,
                     ),
                     (101, microgrid_pb.ComponentCategory.COMPONENT_CATEGORY_GRID),
-                    (103, microgrid_pb.ComponentCategory.COMPONENT_CATEGORY_JUNCTION),
                     (104, microgrid_pb.ComponentCategory.COMPONENT_CATEGORY_METER),
                     (105, microgrid_pb.ComponentCategory.COMPONENT_CATEGORY_INVERTER),
                     (106, microgrid_pb.ComponentCategory.COMPONENT_CATEGORY_BATTERY),
@@ -117,7 +116,6 @@ class TestMicrogridGrpcClient:
             assert set(await microgrid.components()) == {
                 Component(100, ComponentCategory.NONE),
                 Component(101, ComponentCategory.GRID),
-                Component(103, ComponentCategory.JUNCTION),
                 Component(104, ComponentCategory.METER),
                 Component(105, ComponentCategory.INVERTER, InverterType.NONE),
                 Component(106, ComponentCategory.BATTERY),

--- a/tests/microgrid/test_component.py
+++ b/tests/microgrid/test_component.py
@@ -30,13 +30,6 @@ def test_component_category_from_protobuf() -> None:
 
     assert (
         cp._component_category_from_protobuf(
-            microgrid_pb.ComponentCategory.COMPONENT_CATEGORY_JUNCTION
-        )
-        == cp.ComponentCategory.JUNCTION
-    )
-
-    assert (
-        cp._component_category_from_protobuf(
             microgrid_pb.ComponentCategory.COMPONENT_CATEGORY_METER
         )
         == cp.ComponentCategory.METER
@@ -79,9 +72,6 @@ def test_Component() -> None:
 
     c1 = cp.Component(1, cp.ComponentCategory.GRID)
     assert c1.is_valid()
-
-    c3 = cp.Component(3, cp.ComponentCategory.JUNCTION)
-    assert c3.is_valid()
 
     c4 = cp.Component(4, cp.ComponentCategory.METER)
     assert c4.is_valid()

--- a/tests/microgrid/test_graph.py
+++ b/tests/microgrid/test_graph.py
@@ -804,21 +804,6 @@ class Test_MicrogridComponentGraph:
         ):
             graph.validate()
 
-        # junctions are not set up correctly: a junction has no
-        # successors in the graph
-        graph._graph.clear()
-        graph._graph.add_nodes_from(
-            [
-                (1, asdict(Component(1, ComponentCategory.GRID))),
-                (2, asdict(Component(2, ComponentCategory.JUNCTION))),
-            ]
-        )
-        graph._graph.add_edges_from([(1, 2)])
-        with pytest.raises(
-            gr.InvalidGraphError, match="Junctions missing graph successors"
-        ):
-            graph.validate()
-
         # leaf components are not set up correctly: a battery has
         # a successor in the graph
         graph._graph.clear()
@@ -1128,47 +1113,6 @@ class Test_MicrogridComponentGraph:
         )
         graph._graph.add_edges_from([(1, 2), (2, 3), (3, 4)])
         graph._validate_intermediary_components()
-
-    def test__validate_junctions(self) -> None:
-        graph = gr._MicrogridComponentGraph()
-        assert set(graph.components()) == set()
-        assert list(graph.connections()) == []
-
-        # successors missing for at least one junction
-        graph._graph.clear()
-        graph._graph.add_nodes_from(
-            [(1, asdict(Component(1, ComponentCategory.JUNCTION)))]
-        )
-        with pytest.raises(
-            gr.InvalidGraphError, match="Junctions missing graph successors"
-        ):
-            graph._validate_junctions()
-
-        graph._graph.clear()
-        graph._graph.add_nodes_from(
-            [
-                (1, asdict(Component(1, ComponentCategory.JUNCTION))),
-                (2, asdict(Component(2, ComponentCategory.JUNCTION))),
-            ]
-        )
-        graph._graph.add_edges_from([(1, 2)])
-        with pytest.raises(
-            gr.InvalidGraphError, match="Junctions missing graph successors"
-        ):
-            graph._validate_junctions()
-
-        # all junctions have at least one successor
-        graph._graph.clear()
-        graph._graph.add_nodes_from(
-            [
-                (1, asdict(Component(1, ComponentCategory.JUNCTION))),
-                (2, asdict(Component(2, ComponentCategory.JUNCTION))),
-                (3, asdict(Component(3, ComponentCategory.METER))),
-            ]
-        )
-
-        graph._graph.add_edges_from([(1, 2), (2, 3)])
-        graph._validate_junctions()
 
     def test__validate_leaf_components(self) -> None:
         # to ensure clean testing of the individual method,

--- a/tests/microgrid/test_graph.py
+++ b/tests/microgrid/test_graph.py
@@ -62,7 +62,6 @@ class TestComponentGraph:
         return {
             Component(11, ComponentCategory.GRID),
             Component(21, ComponentCategory.METER),
-            Component(31, ComponentCategory.JUNCTION),
             Component(41, ComponentCategory.METER),
             Component(51, ComponentCategory.INVERTER),
             Component(61, ComponentCategory.BATTERY),
@@ -72,8 +71,7 @@ class TestComponentGraph:
     def sample_input_connections(self) -> Set[Connection]:
         return {
             Connection(11, 21),
-            Connection(21, 31),
-            Connection(31, 41),
+            Connection(21, 41),
             Connection(41, 51),
             Connection(51, 61),
         }
@@ -142,15 +140,13 @@ class TestComponentGraph:
         input_components = {
             101: Component(101, ComponentCategory.GRID),
             102: Component(102, ComponentCategory.METER),
-            103: Component(103, ComponentCategory.JUNCTION),
             104: Component(104, ComponentCategory.METER),
             105: Component(105, ComponentCategory.INVERTER),
             106: Component(106, ComponentCategory.BATTERY),
         }
         input_connections = {
             Connection(101, 102),
-            Connection(102, 103),
-            Connection(103, 104),
+            Connection(102, 104),
             Connection(104, 105),
             Connection(105, 106),
         }
@@ -186,16 +182,14 @@ class TestComponentGraph:
             ({1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, set()),
             ({11}, {Component(11, ComponentCategory.GRID)}),
             ({21}, {Component(21, ComponentCategory.METER)}),
-            ({31}, {Component(31, ComponentCategory.JUNCTION)}),
             ({41}, {Component(41, ComponentCategory.METER)}),
             ({51}, {Component(51, ComponentCategory.INVERTER)}),
             ({61}, {Component(61, ComponentCategory.BATTERY)}),
             (
-                {31, 11, 61},
+                {11, 61},
                 {
                     Component(11, ComponentCategory.GRID),
                     Component(61, ComponentCategory.BATTERY),
-                    Component(31, ComponentCategory.JUNCTION),
                 },
             ),
             (
@@ -560,15 +554,13 @@ class Test_MicrogridComponentGraph:
             components={
                 Component(1, ComponentCategory.GRID),
                 Component(2, ComponentCategory.METER),
-                Component(3, ComponentCategory.JUNCTION),
                 Component(4, ComponentCategory.METER),
                 Component(5, ComponentCategory.INVERTER),
                 Component(6, ComponentCategory.BATTERY),
             },
             connections={
                 Connection(1, 2),
-                Connection(2, 3),
-                Connection(3, 4),
+                Connection(2, 4),
                 Connection(4, 5),
                 Connection(5, 6),
             },
@@ -576,7 +568,6 @@ class Test_MicrogridComponentGraph:
         expected = {
             Component(1, ComponentCategory.GRID),
             Component(2, ComponentCategory.METER),
-            Component(3, ComponentCategory.JUNCTION),
             Component(4, ComponentCategory.METER),
             Component(5, ComponentCategory.INVERTER),
             Component(6, ComponentCategory.BATTERY),
@@ -585,8 +576,7 @@ class Test_MicrogridComponentGraph:
         assert set(graph.components()) == expected
         assert graph.connections() == {
             Connection(1, 2),
-            Connection(2, 3),
-            Connection(3, 4),
+            Connection(2, 4),
             Connection(4, 5),
             Connection(5, 6),
         }
@@ -614,8 +604,7 @@ class Test_MicrogridComponentGraph:
 
         assert graph.connections() == {
             Connection(1, 2),
-            Connection(2, 3),
-            Connection(3, 4),
+            Connection(2, 4),
             Connection(4, 5),
             Connection(5, 6),
         }

--- a/tests/microgrid/test_graph.py
+++ b/tests/microgrid/test_graph.py
@@ -221,11 +221,10 @@ class TestComponentGraph:
         [
             ({ComponentCategory.EV_CHARGER}, set()),
             (
-                {ComponentCategory.JUNCTION, ComponentCategory.EV_CHARGER},
-                {Component(31, ComponentCategory.JUNCTION)},
+                {ComponentCategory.BATTERY, ComponentCategory.EV_CHARGER},
+                {Component(61, ComponentCategory.BATTERY)},
             ),
             ({ComponentCategory.GRID}, {Component(11, ComponentCategory.GRID)}),
-            ({ComponentCategory.JUNCTION}, {Component(31, ComponentCategory.JUNCTION)}),
             (
                 {ComponentCategory.METER},
                 {
@@ -245,16 +244,15 @@ class TestComponentGraph:
             (
                 {
                     ComponentCategory.METER,
-                    ComponentCategory.JUNCTION,
+                    ComponentCategory.BATTERY,
                     ComponentCategory.EV_CHARGER,
                 },
                 {
                     Component(21, ComponentCategory.METER),
-                    Component(31, ComponentCategory.JUNCTION),
+                    Component(61, ComponentCategory.BATTERY),
                     Component(41, ComponentCategory.METER),
                 },
             ),
-            ({ComponentCategory.JUNCTION}, {Component(31, ComponentCategory.JUNCTION)}),
         ],
     )
     def test_filter_graph_components_by_type(
@@ -272,14 +270,12 @@ class TestComponentGraph:
         "ids, types, expected",
         [
             ({11}, {ComponentCategory.GRID}, {Component(11, ComponentCategory.GRID)}),
-            ({11}, {ComponentCategory.JUNCTION}, set()),
             ({31}, {ComponentCategory.GRID}, set()),
             (
-                {31},
-                {ComponentCategory.JUNCTION},
-                {Component(31, ComponentCategory.JUNCTION)},
+                {61},
+                {ComponentCategory.BATTERY},
+                {Component(61, ComponentCategory.BATTERY)},
             ),
-            ({31}, {ComponentCategory.GRID}, set()),
             (
                 {11, 21, 31, 61},
                 {ComponentCategory.METER, ComponentCategory.BATTERY},
@@ -604,7 +600,7 @@ class Test_MicrogridComponentGraph:
                 components={
                     Component(7, ComponentCategory.GRID),
                     Component(8, ComponentCategory.METER),
-                    Component(9, ComponentCategory.JUNCTION),
+                    Component(9, ComponentCategory.INVERTER),
                 },
                 connections={
                     Connection(7, 8),
@@ -637,9 +633,9 @@ class Test_MicrogridComponentGraph:
             graph.refresh_from(
                 components={
                     Component(7, ComponentCategory.GRID),
-                    Component(9, ComponentCategory.JUNCTION),
+                    Component(9, ComponentCategory.METER),
                 },
-                connections={Connection(7, 9)},
+                connections={Connection(9, 7)},
                 correct_errors=pretend_to_correct_errors,
             )
 
@@ -875,7 +871,7 @@ class Test_MicrogridComponentGraph:
         graph._graph.add_nodes_from(
             [
                 (1, asdict(Component(1, ComponentCategory.GRID))),
-                (2, asdict(Component(2, ComponentCategory.JUNCTION))),
+                (2, asdict(Component(2, ComponentCategory.INVERTER))),
                 (3, asdict(Component(3, ComponentCategory.METER))),
             ]
         )
@@ -914,9 +910,9 @@ class Test_MicrogridComponentGraph:
         graph._graph.clear()
         graph._graph.add_nodes_from(
             [
-                (1, asdict(Component(1, ComponentCategory.JUNCTION))),
-                (2, asdict(Component(2, ComponentCategory.JUNCTION))),
-                (3, asdict(Component(3, ComponentCategory.JUNCTION))),
+                (1, asdict(Component(1, ComponentCategory.METER))),
+                (2, asdict(Component(2, ComponentCategory.METER))),
+                (3, asdict(Component(3, ComponentCategory.METER))),
             ]
         )
         graph._graph.add_edges_from([(1, 2), (2, 3), (3, 1)])
@@ -959,7 +955,7 @@ class Test_MicrogridComponentGraph:
         graph._graph.add_nodes_from(
             [
                 (1, asdict(Component(1, ComponentCategory.GRID))),
-                (2, asdict(Component(2, ComponentCategory.JUNCTION))),
+                (2, asdict(Component(2, ComponentCategory.GRID))),
                 (3, asdict(Component(3, ComponentCategory.METER))),
             ]
         )
@@ -985,9 +981,7 @@ class Test_MicrogridComponentGraph:
 
         graph._graph.clear()
 
-        graph._graph.add_nodes_from(
-            [(3, asdict(Component(3, ComponentCategory.JUNCTION)))]
-        )
+        graph._graph.add_nodes_from([(3, asdict(Component(3, ComponentCategory.GRID)))])
         with pytest.raises(
             gr.InvalidGraphError, match="Graph root .*id=3.* has no successors!"
         ):
@@ -1017,7 +1011,7 @@ class Test_MicrogridComponentGraph:
         graph._graph.clear()
         graph._graph.add_nodes_from(
             [
-                (1, asdict(Component(1, ComponentCategory.JUNCTION))),
+                (1, asdict(Component(1, ComponentCategory.GRID))),
                 (2, asdict(Component(2, ComponentCategory.METER))),
             ]
         )

--- a/tests/microgrid/test_microgrid_api.py
+++ b/tests/microgrid/test_microgrid_api.py
@@ -32,7 +32,6 @@ class TestMicrogridApi:
         components = [
             [
                 Component(1, ComponentCategory.GRID),
-                Component(3, ComponentCategory.JUNCTION),
                 Component(4, ComponentCategory.METER),
                 Component(5, ComponentCategory.METER),
                 Component(6, ComponentCategory.PV_ARRAY),
@@ -45,7 +44,6 @@ class TestMicrogridApi:
             ],
             [
                 Component(1, ComponentCategory.GRID),
-                Component(3, ComponentCategory.JUNCTION),
                 Component(4, ComponentCategory.METER),
                 Component(7, ComponentCategory.METER),
                 Component(8, ComponentCategory.INVERTER),
@@ -67,21 +65,19 @@ class TestMicrogridApi:
         """
         connections = [
             [
-                Connection(1, 3),
-                Connection(3, 4),
-                Connection(3, 5),
+                Connection(1, 4),
+                Connection(1, 5),
                 Connection(5, 6),
-                Connection(3, 7),
+                Connection(1, 7),
                 Connection(7, 8),
                 Connection(8, 9),
-                Connection(3, 10),
+                Connection(1, 10),
                 Connection(10, 11),
                 Connection(11, 12),
             ],
             [
-                Connection(1, 3),
-                Connection(3, 4),
-                Connection(3, 7),
+                Connection(1, 4),
+                Connection(1, 7),
                 Connection(7, 8),
                 Connection(8, 9),
             ],

--- a/tests/microgrid/test_mock_api.py
+++ b/tests/microgrid/test_mock_api.py
@@ -192,7 +192,7 @@ def test_MockMicrogridServicer() -> None:
     api_prealloc = mock_api.MockMicrogridServicer(
         components=[
             (7, ComponentCategory.COMPONENT_CATEGORY_GRID),
-            (9, ComponentCategory.COMPONENT_CATEGORY_LOAD),
+            (9, ComponentCategory.COMPONENT_CATEGORY_METER),
         ],
         connections=[(7, 8), (8, 9)],
     )
@@ -200,7 +200,7 @@ def test_MockMicrogridServicer() -> None:
         api_prealloc.ListComponents(ComponentFilter(), service_context_mock).components
     ) == [
         Component(id=7, category=ComponentCategory.COMPONENT_CATEGORY_GRID),
-        Component(id=9, category=ComponentCategory.COMPONENT_CATEGORY_LOAD),
+        Component(id=9, category=ComponentCategory.COMPONENT_CATEGORY_METER),
     ]
     assert list(
         api_prealloc.ListConnections(
@@ -217,7 +217,7 @@ async def test_MockGrpcServer() -> None:
         components=[
             (1, ComponentCategory.COMPONENT_CATEGORY_GRID),
             (2, ComponentCategory.COMPONENT_CATEGORY_METER),
-            (3, ComponentCategory.COMPONENT_CATEGORY_LOAD),
+            (3, ComponentCategory.COMPONENT_CATEGORY_INVERTER),
         ],
         connections=[(1, 2), (2, 3)],
     )
@@ -230,7 +230,7 @@ async def test_MockGrpcServer() -> None:
     assert list(components1.components) == [
         Component(id=1, category=ComponentCategory.COMPONENT_CATEGORY_GRID),
         Component(id=2, category=ComponentCategory.COMPONENT_CATEGORY_METER),
-        Component(id=3, category=ComponentCategory.COMPONENT_CATEGORY_LOAD),
+        Component(id=3, category=ComponentCategory.COMPONENT_CATEGORY_INVERTER),
     ]
 
     connections1 = await client.ListConnections(ConnectionFilter())  # type: ignore
@@ -246,7 +246,7 @@ async def test_MockGrpcServer() -> None:
             (6, ComponentCategory.COMPONENT_CATEGORY_GRID),
             (77, ComponentCategory.COMPONENT_CATEGORY_METER),
             (888, ComponentCategory.COMPONENT_CATEGORY_EV_CHARGER),
-            (9999, ComponentCategory.COMPONENT_CATEGORY_LOAD),
+            (9999, ComponentCategory.COMPONENT_CATEGORY_INVERTER),
         ],
         connections=[(6, 77), (6, 888), (77, 9999)],
     )
@@ -258,7 +258,7 @@ async def test_MockGrpcServer() -> None:
         Component(id=6, category=ComponentCategory.COMPONENT_CATEGORY_GRID),
         Component(id=77, category=ComponentCategory.COMPONENT_CATEGORY_METER),
         Component(id=888, category=ComponentCategory.COMPONENT_CATEGORY_EV_CHARGER),
-        Component(id=9999, category=ComponentCategory.COMPONENT_CATEGORY_LOAD),
+        Component(id=9999, category=ComponentCategory.COMPONENT_CATEGORY_INVERTER),
     ]
 
     connections2 = await client.ListConnections(ConnectionFilter())  # type: ignore

--- a/tests/microgrid/test_timeout.py
+++ b/tests/microgrid/test_timeout.py
@@ -110,7 +110,7 @@ async def test_set_power_timeout(mocker: MockerFixture) -> None:
     power_values = [-100, 100]
     for power_w in power_values:
         with pytest.raises(grpc.aio.AioRpcError) as err_ctx:
-            _ = await client.set_power(component_id=1, power_w=power_w)
+            await client.set_power(component_id=1, power_w=power_w)
         assert err_ctx.value.code() == grpc.StatusCode.DEADLINE_EXCEEDED
 
     assert await server.graceful_shutdown()


### PR DESCRIPTION
These component categories are deprecated, and are no longer used in production, and have been removed from the microgrid API v0.15.1, which we will update to soon.

This PR also fixes a protobuf generated type getting leaked outside the MicrogridClient.
