### PR TITLE
A `Percentage` quantity

### DIFF
--- a/src/frequenz/sdk/timeseries/__init__.py
+++ b/src/frequenz/sdk/timeseries/__init__.py
@@ -38,7 +38,7 @@ Example:
 from ._base_types import UNIX_EPOCH, Sample, Sample3Phase
 from ._moving_window import MovingWindow
 from ._periodic_feature_extractor import PeriodicFeatureExtractor
-from ._quantities import Current, Energy, Power, Quantity, QuantityT, Voltage
+from ._quantities import Current, Energy, Percentage, Power, Quantity, Voltage
 from ._resampling import ResamplerConfig
 
 __all__ = [
@@ -56,4 +56,5 @@ __all__ = [
     "Energy",
     "Power",
     "Voltage",
+    "Percentage",
 ]

--- a/src/frequenz/sdk/timeseries/_quantities.py
+++ b/src/frequenz/sdk/timeseries/_quantities.py
@@ -9,7 +9,9 @@ import math
 from datetime import timedelta
 from typing import Any, NoReturn, Self, TypeVar, overload
 
-QuantityT = TypeVar("QuantityT", "Quantity", "Power", "Current", "Voltage", "Energy")
+QuantityT = TypeVar(
+    "QuantityT", "Quantity", "Power", "Current", "Voltage", "Energy", "Percentage"
+)
 
 
 class Quantity:
@@ -704,3 +706,55 @@ class Energy(
         raise TypeError(
             f"unsupported operand type(s) for /: '{type(self)}' and '{type(other)}'"
         )
+
+
+class Percentage(
+    Quantity,
+    metaclass=_NoDefaultConstructible,
+    exponent_unit_map={0: "%"},
+):
+    """A percentage quantity."""
+
+    @classmethod
+    def from_percent(cls, percent: float) -> Self:
+        """Initialize a new percentage quantity from a percent value.
+
+        Args:
+            percent: The percent value, normally in the 0.0-100.0 range.
+
+        Returns:
+            A new percentage quantity.
+        """
+        percentage = cls.__new__(cls)
+        percentage._base_value = percent
+        return percentage
+
+    @classmethod
+    def from_fraction(cls, fraction: float) -> Self:
+        """Initialize a new percentage quantity from a fraction.
+
+        Args:
+            fraction: The fraction, normally in the 0.0-1.0 range.
+
+        Returns:
+            A new percentage quantity.
+        """
+        percentage = cls.__new__(cls)
+        percentage._base_value = fraction * 100
+        return percentage
+
+    def as_percent(self) -> float:
+        """Return this quantity as a percentage.
+
+        Returns:
+            This quantity as a percentage.
+        """
+        return self._base_value
+
+    def as_fraction(self) -> float:
+        """Return this quantity as a fraction.
+
+        Returns:
+            This quantity as a fraction.
+        """
+        return self._base_value / 100

--- a/src/frequenz/sdk/timeseries/battery_pool/_metric_calculator.py
+++ b/src/frequenz/sdk/timeseries/battery_pool/_metric_calculator.py
@@ -12,7 +12,7 @@ from typing import Generic, Iterable, TypeVar
 
 from ...microgrid import connection_manager
 from ...microgrid.component import ComponentCategory, ComponentMetricId, InverterType
-from ...timeseries import Energy, Quantity, Sample
+from ...timeseries import Energy, Percentage, Sample
 from ._component_metrics import ComponentMetricsData
 from ._result_types import Bound, PowerMetrics
 
@@ -59,7 +59,7 @@ def battery_inverter_mapping(batteries: Iterable[int]) -> dict[int, int]:
 
 # Formula output types class have no common interface
 # Print all possible types here.
-T = TypeVar("T", Sample[Quantity], Sample[Energy], PowerMetrics)
+T = TypeVar("T", Sample[Percentage], Sample[Energy], PowerMetrics)
 
 
 class MetricCalculator(ABC, Generic[T]):
@@ -234,7 +234,7 @@ class CapacityCalculator(MetricCalculator[Sample[Energy]]):
         )
 
 
-class SoCCalculator(MetricCalculator[Sample[Quantity]]):
+class SoCCalculator(MetricCalculator[Sample[Percentage]]):
     """Define how to calculate SoC metrics."""
 
     def __init__(self, batteries: Set[int]) -> None:
@@ -283,7 +283,7 @@ class SoCCalculator(MetricCalculator[Sample[Quantity]]):
         self,
         metrics_data: dict[int, ComponentMetricsData],
         working_batteries: set[int],
-    ) -> Sample[Quantity] | None:
+    ) -> Sample[Percentage] | None:
         """Aggregate the metrics_data and calculate high level metric.
 
         Missing components will be ignored. Formula will be calculated for all
@@ -349,11 +349,11 @@ class SoCCalculator(MetricCalculator[Sample[Quantity]]):
         if total_capacity_x100 == 0:
             return Sample(
                 timestamp=timestamp,
-                value=Quantity(0.0),
+                value=Percentage.from_percent(0.0),
             )
         return Sample(
             timestamp=timestamp,
-            value=Quantity(used_capacity_x100 / total_capacity_x100),
+            value=Percentage.from_percent(used_capacity_x100 / total_capacity_x100),
         )
 
 

--- a/src/frequenz/sdk/timeseries/battery_pool/battery_pool.py
+++ b/src/frequenz/sdk/timeseries/battery_pool/battery_pool.py
@@ -20,14 +20,14 @@ from ...actor.power_distributing._battery_pool_status import BatteryStatus
 from ...actor.power_distributing.result import Result
 from ...microgrid import connection_manager
 from ...microgrid.component import ComponentCategory
-from ...timeseries import Quantity, Sample
+from ...timeseries import Sample
 from .._formula_engine import FormulaEngine, FormulaEnginePool
 from .._formula_engine._formula_generators import (
     BatteryPowerFormula,
     FormulaGeneratorConfig,
     FormulaType,
 )
-from .._quantities import Energy, Power
+from .._quantities import Energy, Percentage, Power
 from ._methods import MetricAggregator, SendOnUpdate
 from ._metric_calculator import CapacityCalculator, PowerBoundsCalculator, SoCCalculator
 from ._result_types import PowerMetrics
@@ -330,7 +330,7 @@ class BatteryPool:
         return engine
 
     @property
-    def soc(self) -> MetricAggregator[Sample[Quantity]]:
+    def soc(self) -> MetricAggregator[Sample[Percentage]]:
         """Fetch the normalized average weighted-by-capacity SoC values for the pool.
 
         The values are normalized to the 0-100% range.

--- a/tests/timeseries/test_quantities.py
+++ b/tests/timeseries/test_quantities.py
@@ -10,6 +10,7 @@ import pytest
 from frequenz.sdk.timeseries._quantities import (
     Current,
     Energy,
+    Percentage,
     Power,
     Quantity,
     Voltage,
@@ -257,3 +258,13 @@ def test_quantity_compositions() -> None:
     assert energy / power == timedelta(hours=6.2)
     assert energy / timedelta(hours=6.2) == power
     assert energy == power * timedelta(hours=6.2)
+
+
+def test_percentage() -> None:
+    """Test the percentage class."""
+    pct = Percentage.from_fraction(0.204)
+    assert f"{pct}" == "20.4 %"
+    pct = Percentage.from_percent(20.4)
+    assert f"{pct}" == "20.4 %"
+    assert pct.as_percent() == 20.4
+    assert pct.as_fraction() == 0.204


### PR DESCRIPTION
Percentage is is a unitless quantity,  but with a symbol,  and with multiple representations (as pct, or as a fractional value),  so it somehow fits as a `Quantity`.  The biggest benefit would allow for better user experience for `BatteryPool.soc`,  for example:

```python
soc_sample = await battery_pool.soc.new_receiver().receive()
soc_pct = soc_sample.value.base_value   ## old
soc_pct = soc_sample.value.as_percent()  ## new