### PR TITLE
Add methods for sending individual mock component data messages in tests

### DIFF
--- a/tests/timeseries/_battery_pool/test_battery_pool.py
+++ b/tests/timeseries/_battery_pool/test_battery_pool.py
@@ -440,7 +440,7 @@ async def test_battery_pool_power(mocker: MockerFixture) -> None:
     """Test `BatteryPool.{,production,consumption}_power` methods."""
     mockgrid = MockMicrogrid(grid_side_meter=True)
     mockgrid.add_batteries(2)
-    await mockgrid.start_mock_datapipeline(mocker)
+    await mockgrid.start(mocker)
 
     battery_pool = microgrid.battery_pool()
     power_receiver = battery_pool.power.new_receiver()

--- a/tests/timeseries/_battery_pool/test_battery_pool.py
+++ b/tests/timeseries/_battery_pool/test_battery_pool.py
@@ -447,17 +447,17 @@ async def test_battery_pool_power(mocker: MockerFixture) -> None:
     consumption_receiver = battery_pool.consumption_power.new_receiver()
     production_receiver = battery_pool.production_power.new_receiver()
 
-    await mockgrid.mock_data.send_bat_inverter_power([2.0, 3.0])
+    await mockgrid.mock_resampler.send_bat_inverter_power([2.0, 3.0])
     assert (await power_receiver.receive()).value == Power.from_watts(5.0)
     assert (await consumption_receiver.receive()).value == Power.from_watts(5.0)
     assert (await production_receiver.receive()).value == Power.from_watts(0.0)
 
-    await mockgrid.mock_data.send_bat_inverter_power([-2.0, -5.0])
+    await mockgrid.mock_resampler.send_bat_inverter_power([-2.0, -5.0])
     assert (await power_receiver.receive()).value == Power.from_watts(-7.0)
     assert (await consumption_receiver.receive()).value == Power.from_watts(0.0)
     assert (await production_receiver.receive()).value == Power.from_watts(7.0)
 
-    await mockgrid.mock_data.send_bat_inverter_power([2.0, -5.0])
+    await mockgrid.mock_resampler.send_bat_inverter_power([2.0, -5.0])
     assert (await power_receiver.receive()).value == Power.from_watts(-3.0)
     assert (await consumption_receiver.receive()).value == Power.from_watts(0.0)
     assert (await production_receiver.receive()).value == Power.from_watts(3.0)

--- a/tests/timeseries/_formula_engine/test_formula_composition.py
+++ b/tests/timeseries/_formula_engine/test_formula_composition.py
@@ -44,8 +44,8 @@ class TestFormulaComposition:
         engine = (logical_meter.pv_power + battery_pool.power).build("inv_power")
         inv_calc_recv = engine.new_receiver()
 
-        await mockgrid.mock_data.send_bat_inverter_power([10.0, 12.0, 14.0])
-        await mockgrid.mock_data.send_meter_power(
+        await mockgrid.mock_resampler.send_bat_inverter_power([10.0, 12.0, 14.0])
+        await mockgrid.mock_resampler.send_meter_power(
             [100.0, 10.0, 12.0, 14.0, -100.0, -200.0]
         )
 
@@ -110,10 +110,10 @@ class TestFormulaComposition:
 
         count = 0
         for _ in range(10):
-            await mockgrid.mock_data.send_bat_inverter_power(
+            await mockgrid.mock_resampler.send_bat_inverter_power(
                 [10.0 + count, 12.0 + count, 14.0 + count]
             )
-            await mockgrid.mock_data.send_non_existing_component_value()
+            await mockgrid.mock_resampler.send_non_existing_component_value()
 
             bat_pow = await battery_power_recv.receive()
             pv_pow = await pv_power_recv.receive()
@@ -148,10 +148,10 @@ class TestFormulaComposition:
 
         count = 0
         for _ in range(10):
-            await mockgrid.mock_data.send_meter_power(
+            await mockgrid.mock_resampler.send_meter_power(
                 [10.0 + count, 12.0 + count, 14.0 + count]
             )
-            await mockgrid.mock_data.send_non_existing_component_value()
+            await mockgrid.mock_resampler.send_non_existing_component_value()
             bat_pow = await battery_power_recv.receive()
             pv_pow = await pv_power_recv.receive()
             inv_pow = await inv_calc_recv.receive()
@@ -190,7 +190,7 @@ class TestFormulaComposition:
         count = 0
 
         for _ in range(10):
-            await mockgrid.mock_data.send_meter_current(
+            await mockgrid.mock_resampler.send_meter_current(
                 [
                     [10.0, 12.0, 14.0],
                     [10.0, 12.0, 14.0],
@@ -198,7 +198,7 @@ class TestFormulaComposition:
                     [10.0, 12.0, 14.0],
                 ]
             )
-            await mockgrid.mock_data.send_evc_current(
+            await mockgrid.mock_resampler.send_evc_current(
                 [[10.0 + count, 12.0 + count, 14.0 + count]]
             )
 

--- a/tests/timeseries/_formula_engine/test_formula_composition.py
+++ b/tests/timeseries/_formula_engine/test_formula_composition.py
@@ -27,7 +27,7 @@ class TestFormulaComposition:
         mockgrid = MockMicrogrid(grid_side_meter=False)
         mockgrid.add_batteries(3)
         mockgrid.add_solar_inverters(2)
-        await mockgrid.start_mock_datapipeline(mocker)
+        await mockgrid.start(mocker)
 
         logical_meter = microgrid.logical_meter()
         battery_pool = microgrid.battery_pool()
@@ -99,7 +99,7 @@ class TestFormulaComposition:
         """Test the composition of formulas with missing PV power data."""
         mockgrid = MockMicrogrid(grid_side_meter=False)
         mockgrid.add_batteries(3)
-        await mockgrid.start_mock_datapipeline(mocker)
+        await mockgrid.start(mocker)
         battery_pool = microgrid.battery_pool()
         logical_meter = microgrid.logical_meter()
 
@@ -137,7 +137,7 @@ class TestFormulaComposition:
         """Test the composition of formulas with missing battery power data."""
         mockgrid = MockMicrogrid(grid_side_meter=False)
         mockgrid.add_solar_inverters(2)
-        await mockgrid.start_mock_datapipeline(mocker)
+        await mockgrid.start(mocker)
         battery_pool = microgrid.battery_pool()
         logical_meter = microgrid.logical_meter()
 
@@ -177,7 +177,7 @@ class TestFormulaComposition:
         )
         mockgrid.add_batteries(3)
         mockgrid.add_ev_chargers(1)
-        await mockgrid.start_mock_datapipeline(mocker)
+        await mockgrid.start(mocker)
         logical_meter = microgrid.logical_meter()
         ev_pool = microgrid.ev_charger_pool()
 

--- a/tests/timeseries/mock_microgrid.py
+++ b/tests/timeseries/mock_microgrid.py
@@ -105,8 +105,8 @@ class MockMicrogrid:  # pylint: disable=too-many-instance-attributes
         self._streaming_tasks: list[asyncio.Task[None]] = []
         self._start_meter_streaming(4)
 
-    async def start_mock_datapipeline(self, mocker: MockerFixture) -> None:
-        """Start the MockDataPipeline."""
+    async def start(self, mocker: MockerFixture) -> None:
+        """Init the mock microgrid client and start the mock resampler."""
         self.init_mock_client(lambda mock_client: mock_client.initialize(mocker))
         self.mock_resampler = MockResampler(
             mocker,

--- a/tests/timeseries/mock_microgrid.py
+++ b/tests/timeseries/mock_microgrid.py
@@ -440,6 +440,9 @@ class MockMicrogrid:  # pylint: disable=too-many-instance-attributes
         if _data_pipeline._DATA_PIPELINE:
             await _data_pipeline._DATA_PIPELINE._stop()
 
+        for coro in self._streaming_coros:
+            coro.close()
+
         for task in self._streaming_tasks:
             await cancel_and_await(task)
         microgrid.connection_manager._CONNECTION_MANAGER = None

--- a/tests/timeseries/mock_microgrid.py
+++ b/tests/timeseries/mock_microgrid.py
@@ -148,24 +148,6 @@ class MockMicrogrid:  # pylint: disable=too-many-instance-attributes
         ]
         return self._microgrid
 
-    async def start(self, mocker: MockerFixture) -> None:
-        """Start the MockServer, and the data source and resampling actors."""
-        self.start_mock_client(lambda mock_client: mock_client.initialize(mocker))
-        await asyncio.sleep(self._sample_rate_s / 2)
-
-        # pylint: disable=protected-access
-        _data_pipeline._DATA_PIPELINE = _data_pipeline._DataPipeline(
-            ResamplerConfig(
-                resampling_period=timedelta(seconds=self._sample_rate_s),
-                # Align to the time the resampler is created to avoid flakiness
-                # in the tests, it seems test using the mock microgrid assume
-                # that the resampling window is aligned to the start of the
-                # test.
-                align_to=None,
-            )
-        )
-        # pylint: enable=protected-access
-
     async def _comp_data_send_task(
         self, comp_id: int, make_comp_data: Callable[[int, datetime], ComponentData]
     ) -> None:

--- a/tests/timeseries/mock_microgrid.py
+++ b/tests/timeseries/mock_microgrid.py
@@ -33,7 +33,7 @@ from ..utils.component_data_wrapper import (
     InverterDataWrapper,
     MeterDataWrapper,
 )
-from .mock_datapipeline import MockDataPipeline
+from .mock_resampler import MockResampler
 
 
 class MockMicrogrid:  # pylint: disable=too-many-instance-attributes
@@ -49,7 +49,7 @@ class MockMicrogrid:  # pylint: disable=too-many-instance-attributes
     battery_id_suffix = 9
 
     _microgrid: MockMicrogridClient
-    mock_data: MockDataPipeline
+    mock_resampler: MockResampler
 
     def __init__(  # pylint: disable=too-many-arguments
         self,
@@ -108,7 +108,7 @@ class MockMicrogrid:  # pylint: disable=too-many-instance-attributes
     async def start_mock_datapipeline(self, mocker: MockerFixture) -> None:
         """Start the MockDataPipeline."""
         self.init_mock_client(lambda mock_client: mock_client.initialize(mocker))
-        self.mock_data = MockDataPipeline(
+        self.mock_resampler = MockResampler(
             mocker,
             ResamplerConfig(timedelta(seconds=self._sample_rate_s)),
             bat_inverter_ids=self.battery_inverter_ids,

--- a/tests/timeseries/mock_microgrid.py
+++ b/tests/timeseries/mock_microgrid.py
@@ -363,6 +363,95 @@ class MockMicrogrid:  # pylint: disable=too-many-instance-attributes
             self._start_ev_charger_streaming(evc_id)
             self._connections.add(Connection(self._connect_to, evc_id))
 
+    async def send_meter_data(self, values: list[float]) -> None:
+        """Send raw meter data from the mock microgrid.
+
+        Args:
+            values: list of active power values for each meter.
+        """
+        assert len(values) == len(self.meter_ids)
+        timestamp = datetime.now(tz=timezone.utc)
+        for comp_id, value in zip(self.meter_ids, values):
+            await self._microgrid.send(
+                MeterDataWrapper(
+                    component_id=comp_id,
+                    timestamp=timestamp,
+                    active_power=value,
+                    current_per_phase=(
+                        value + 100.0,
+                        value + 101.0,
+                        value + 102.0,
+                    ),
+                )
+            )
+
+    async def send_battery_data(self, socs: list[float]) -> None:
+        """Send raw battery data from the mock microgrid.
+
+        Args:
+            values: list of soc values for each battery.
+        """
+        assert len(socs) == len(self.battery_ids)
+        timestamp = datetime.now(tz=timezone.utc)
+        for comp_id, value in zip(self.battery_ids, socs):
+            await self._microgrid.send(
+                BatteryDataWrapper(component_id=comp_id, timestamp=timestamp, soc=value)
+            )
+
+    async def send_battery_inverter_data(self, values: list[float]) -> None:
+        """Send raw battery inverter data from the mock microgrid.
+
+        Args:
+            values: list of active power values for each battery inverter.
+        """
+        assert len(values) == len(self.battery_inverter_ids)
+        timestamp = datetime.now(tz=timezone.utc)
+        for comp_id, value in zip(self.battery_inverter_ids, values):
+            await self._microgrid.send(
+                InverterDataWrapper(
+                    component_id=comp_id, timestamp=timestamp, active_power=value
+                )
+            )
+
+    async def send_pv_inverter_data(self, values: list[float]) -> None:
+        """Send raw pv inverter data from the mock microgrid.
+
+        Args:
+            values: list of active power values for each pv inverter.
+        """
+        assert len(values) == len(self.pv_inverter_ids)
+        timestamp = datetime.now(tz=timezone.utc)
+        for comp_id, value in zip(self.pv_inverter_ids, values):
+            await self._microgrid.send(
+                InverterDataWrapper(
+                    component_id=comp_id, timestamp=timestamp, active_power=value
+                )
+            )
+
+    async def send_ev_charger_data(self, values: list[float]) -> None:
+        """Send raw ev charger data from the mock microgrid.
+
+        Args:
+            values: list of active power values for each ev charger.
+        """
+        assert len(values) == len(self.evc_ids)
+        timestamp = datetime.now(tz=timezone.utc)
+        for comp_id, value in zip(self.evc_ids, values):
+            await self._microgrid.send(
+                EvChargerDataWrapper(
+                    component_id=comp_id,
+                    timestamp=timestamp,
+                    active_power=value,
+                    current_per_phase=(
+                        value + 100.0,
+                        value + 101.0,
+                        value + 102.0,
+                    ),
+                    component_state=self.evc_component_states[comp_id],
+                    cable_state=self.evc_cable_states[comp_id],
+                )
+            )
+
     async def cleanup(self) -> None:
         """Clean up after a test."""
         # pylint: disable=protected-access

--- a/tests/timeseries/mock_resampler.py
+++ b/tests/timeseries/mock_resampler.py
@@ -23,8 +23,8 @@ from frequenz.sdk.timeseries._quantities import Quantity
 # pylint: disable=too-many-instance-attributes
 
 
-class MockDataPipeline:
-    """Mock data_pipeline."""
+class MockResampler:
+    """Mock resampler."""
 
     def __init__(  # pylint: disable=too-many-arguments
         self,

--- a/tests/timeseries/test_ev_charger_pool.py
+++ b/tests/timeseries/test_ev_charger_pool.py
@@ -79,7 +79,7 @@ class TestEVChargerPool:
         """Test the ev power formula."""
         mockgrid = MockMicrogrid(grid_side_meter=False)
         mockgrid.add_ev_chargers(3)
-        await mockgrid.start_mock_datapipeline(mocker)
+        await mockgrid.start(mocker)
 
         ev_pool = microgrid.ev_charger_pool()
         power_receiver = ev_pool.power.new_receiver()
@@ -107,7 +107,7 @@ class TestEVChargerPool:
         )
         mockgrid.add_ev_chargers(1)
 
-        await mockgrid.start_mock_datapipeline(mocker)
+        await mockgrid.start(mocker)
 
         evc_id = mockgrid.evc_ids[0]
         ev_pool = microgrid.ev_charger_pool()

--- a/tests/timeseries/test_ev_charger_pool.py
+++ b/tests/timeseries/test_ev_charger_pool.py
@@ -32,13 +32,17 @@ class TestEVChargerPool:
             grid_side_meter=False, api_client_streaming=True, sample_rate_s=0.01
         )
         mockgrid.add_ev_chargers(5)
-        mockgrid.start_mock_client(lambda client: client.initialize(mocker))
+        await mockgrid.start(mocker)
 
         state_tracker = StateTracker(set(mockgrid.evc_ids))
+        await asyncio.sleep(0.05)
 
         async def check_states(
             expected: dict[int, EVChargerState],
         ) -> None:
+            await mockgrid.send_ev_charger_data(
+                [0.0] * 5  # for testing status updates, the values don't matter.
+            )
             await asyncio.sleep(0.05)
             for comp_id, exp_state in expected.items():
                 assert state_tracker.get(comp_id) == exp_state

--- a/tests/timeseries/test_ev_charger_pool.py
+++ b/tests/timeseries/test_ev_charger_pool.py
@@ -86,12 +86,12 @@ class TestEVChargerPool:
         production_receiver = ev_pool.production_power.new_receiver()
         consumption_receiver = ev_pool.consumption_power.new_receiver()
 
-        await mockgrid.mock_data.send_evc_power([2.0, 4.0, 10.0])
+        await mockgrid.mock_resampler.send_evc_power([2.0, 4.0, 10.0])
         assert (await power_receiver.receive()).value == Power.from_watts(16.0)
         assert (await production_receiver.receive()).value == Power.from_watts(0.0)
         assert (await consumption_receiver.receive()).value == Power.from_watts(16.0)
 
-        await mockgrid.mock_data.send_evc_power([2.0, 4.0, -10.0])
+        await mockgrid.mock_resampler.send_evc_power([2.0, 4.0, -10.0])
         assert (await power_receiver.receive()).value == Power.from_watts(-4.0)
         assert (await production_receiver.receive()).value == Power.from_watts(4.0)
         assert (await consumption_receiver.receive()).value == Power.from_watts(0.0)
@@ -118,7 +118,7 @@ class TestEVChargerPool:
             [0.0]  # only the status gets used from this.
         )
         await asyncio.sleep(0.05)
-        await mockgrid.mock_data.send_evc_current([[2, 3, 5]])
+        await mockgrid.mock_resampler.send_evc_current([[2, 3, 5]])
         status = await recv.receive()
         assert (
             status.current.value_p1,
@@ -135,7 +135,7 @@ class TestEVChargerPool:
             [0.0]  # only the status gets used from this.
         )
         await asyncio.sleep(0.05)
-        await mockgrid.mock_data.send_evc_current([[2, 3, None]])
+        await mockgrid.mock_resampler.send_evc_current([[2, 3, None]])
         status = await recv.receive()
         assert (
             status.current.value_p1,
@@ -152,7 +152,7 @@ class TestEVChargerPool:
             [0.0]  # only the status gets used from this.
         )
         await asyncio.sleep(0.05)
-        await mockgrid.mock_data.send_evc_current([[None, None, None]])
+        await mockgrid.mock_resampler.send_evc_current([[None, None, None]])
         status = await recv.receive()
         assert (
             status.current.value_p1,
@@ -170,7 +170,7 @@ class TestEVChargerPool:
             [0.0]  # only the status gets used from this.
         )
         await asyncio.sleep(0.05)
-        await mockgrid.mock_data.send_evc_current([[None, None, None]])
+        await mockgrid.mock_resampler.send_evc_current([[None, None, None]])
         status = await recv.receive()
         assert (
             status.current.value_p1,
@@ -187,7 +187,7 @@ class TestEVChargerPool:
             [0.0]  # only the status gets used from this.
         )
         await asyncio.sleep(0.05)
-        await mockgrid.mock_data.send_evc_current([[4, None, None]])
+        await mockgrid.mock_resampler.send_evc_current([[4, None, None]])
         status = await recv.receive()
         assert (
             status.current.value_p1,

--- a/tests/timeseries/test_logical_meter.py
+++ b/tests/timeseries/test_logical_meter.py
@@ -25,7 +25,7 @@ class TestLogicalMeter:
         mockgrid = MockMicrogrid(grid_side_meter=True)
         mockgrid.add_batteries(2)
         mockgrid.add_solar_inverters(1)
-        await mockgrid.start_mock_datapipeline(mocker)
+        await mockgrid.start(mocker)
         logical_meter = microgrid.logical_meter()
 
         grid_power_recv = logical_meter.grid_power.new_receiver()
@@ -65,7 +65,7 @@ class TestLogicalMeter:
         mockgrid = MockMicrogrid(grid_side_meter=False)
         mockgrid.add_batteries(2)
         mockgrid.add_solar_inverters(1)
-        await mockgrid.start_mock_datapipeline(mocker)
+        await mockgrid.start(mocker)
         logical_meter = microgrid.logical_meter()
 
         grid_power_recv = logical_meter.grid_power.new_receiver()
@@ -114,7 +114,7 @@ class TestLogicalMeter:
         mockgrid = MockMicrogrid(grid_side_meter=False)
         mockgrid.add_batteries(2)
         mockgrid.add_solar_inverters(1)
-        await mockgrid.start_mock_datapipeline(mocker)
+        await mockgrid.start(mocker)
 
         logical_meter = microgrid.logical_meter()
         grid_recv = logical_meter.grid_power.new_receiver()
@@ -136,7 +136,7 @@ class TestLogicalMeter:
         mockgrid = MockMicrogrid(grid_side_meter=False)
         mockgrid.add_chps(1)
         mockgrid.add_batteries(2)
-        await mockgrid.start_mock_datapipeline(mocker)
+        await mockgrid.start(mocker)
 
         logical_meter = microgrid.logical_meter()
         chp_power_receiver = logical_meter.chp_power.new_receiver()
@@ -169,7 +169,7 @@ class TestLogicalMeter:
         """Test the pv power formula."""
         mockgrid = MockMicrogrid(grid_side_meter=False)
         mockgrid.add_solar_inverters(2)
-        await mockgrid.start_mock_datapipeline(mocker)
+        await mockgrid.start(mocker)
 
         logical_meter = microgrid.logical_meter()
         pv_power_receiver = logical_meter.pv_power.new_receiver()
@@ -192,7 +192,7 @@ class TestLogicalMeter:
         mockgrid = MockMicrogrid(grid_side_meter=True)
         mockgrid.add_batteries(2)
         mockgrid.add_solar_inverters(2)
-        await mockgrid.start_mock_datapipeline(mocker)
+        await mockgrid.start(mocker)
 
         logical_meter = microgrid.logical_meter()
         consumer_power_receiver = logical_meter.consumer_power.new_receiver()
@@ -205,7 +205,7 @@ class TestLogicalMeter:
         mockgrid = MockMicrogrid(grid_side_meter=False)
         mockgrid.add_batteries(2)
         mockgrid.add_solar_inverters(2)
-        await mockgrid.start_mock_datapipeline(mocker)
+        await mockgrid.start(mocker)
 
         logical_meter = microgrid.logical_meter()
         consumer_power_receiver = logical_meter.consumer_power.new_receiver()
@@ -218,7 +218,7 @@ class TestLogicalMeter:
         mockgrid = MockMicrogrid(grid_side_meter=False)
         mockgrid.add_solar_inverters(2)
         mockgrid.add_chps(2)
-        await mockgrid.start_mock_datapipeline(mocker)
+        await mockgrid.start(mocker)
 
         logical_meter = microgrid.logical_meter()
         producer_power_receiver = logical_meter.producer_power.new_receiver()
@@ -230,7 +230,7 @@ class TestLogicalMeter:
         """Test the producer power formula without a chp."""
         mockgrid = MockMicrogrid(grid_side_meter=False)
         mockgrid.add_solar_inverters(2)
-        await mockgrid.start_mock_datapipeline(mocker)
+        await mockgrid.start(mocker)
 
         logical_meter = microgrid.logical_meter()
         producer_power_receiver = logical_meter.producer_power.new_receiver()
@@ -242,7 +242,7 @@ class TestLogicalMeter:
         """Test the producer power formula without pv."""
         mockgrid = MockMicrogrid(grid_side_meter=False)
         mockgrid.add_chps(1)
-        await mockgrid.start_mock_datapipeline(mocker)
+        await mockgrid.start(mocker)
 
         logical_meter = microgrid.logical_meter()
         producer_power_receiver = logical_meter.producer_power.new_receiver()
@@ -253,7 +253,7 @@ class TestLogicalMeter:
     async def test_no_producer_power(self, mocker: MockerFixture) -> None:
         """Test the producer power formula without producers."""
         mockgrid = MockMicrogrid(grid_side_meter=False)
-        await mockgrid.start_mock_datapipeline(mocker)
+        await mockgrid.start(mocker)
 
         logical_meter = microgrid.logical_meter()
         producer_power_receiver = logical_meter.producer_power.new_receiver()

--- a/tests/timeseries/test_logical_meter.py
+++ b/tests/timeseries/test_logical_meter.py
@@ -40,7 +40,9 @@ class TestLogicalMeter:
         results = []
         main_meter_data = []
         for count in range(10):
-            await mockgrid.mock_data.send_meter_power([20.0 + count, 12.0, -13.0, -5.0])
+            await mockgrid.mock_resampler.send_meter_power(
+                [20.0 + count, 12.0, -13.0, -5.0]
+            )
             val = await main_meter_recv.receive()
             assert (
                 val is not None
@@ -81,7 +83,9 @@ class TestLogicalMeter:
         results: list[Quantity] = []
         meter_sums: list[Quantity] = []
         for count in range(10):
-            await mockgrid.mock_data.send_meter_power([20.0 + count, 12.0, -13.0, -5.0])
+            await mockgrid.mock_resampler.send_meter_power(
+                [20.0 + count, 12.0, -13.0, -5.0]
+            )
             meter_sum = 0.0
             for recv in meter_receivers:
                 val = await recv.receive()
@@ -117,12 +121,12 @@ class TestLogicalMeter:
         grid_production_recv = logical_meter.grid_production_power.new_receiver()
         grid_consumption_recv = logical_meter.grid_consumption_power.new_receiver()
 
-        await mockgrid.mock_data.send_meter_power([1.0, 2.0, 3.0, 4.0])
+        await mockgrid.mock_resampler.send_meter_power([1.0, 2.0, 3.0, 4.0])
         assert (await grid_recv.receive()).value == Power.from_watts(10.0)
         assert (await grid_production_recv.receive()).value == Power.from_watts(0.0)
         assert (await grid_consumption_recv.receive()).value == Power.from_watts(10.0)
 
-        await mockgrid.mock_data.send_meter_power([1.0, 2.0, -3.0, -4.0])
+        await mockgrid.mock_resampler.send_meter_power([1.0, 2.0, -3.0, -4.0])
         assert (await grid_recv.receive()).value == Power.from_watts(-4.0)
         assert (await grid_production_recv.receive()).value == Power.from_watts(4.0)
         assert (await grid_consumption_recv.receive()).value == Power.from_watts(0.0)
@@ -143,7 +147,7 @@ class TestLogicalMeter:
             logical_meter.chp_consumption_power.new_receiver()
         )
 
-        await mockgrid.mock_data.send_meter_power([1.0, 2.0, 3.0, 4.0])
+        await mockgrid.mock_resampler.send_meter_power([1.0, 2.0, 3.0, 4.0])
         assert (await chp_power_receiver.receive()).value == Power.from_watts(2.0)
         assert (
             await chp_production_power_receiver.receive()
@@ -152,7 +156,7 @@ class TestLogicalMeter:
             await chp_consumption_power_receiver.receive()
         ).value == Power.from_watts(2.0)
 
-        await mockgrid.mock_data.send_meter_power([-4.0, -12.0, None, 10.2])
+        await mockgrid.mock_resampler.send_meter_power([-4.0, -12.0, None, 10.2])
         assert (await chp_power_receiver.receive()).value == Power.from_watts(-12.0)
         assert (
             await chp_production_power_receiver.receive()
@@ -174,7 +178,7 @@ class TestLogicalMeter:
             logical_meter.pv_consumption_power.new_receiver()
         )
 
-        await mockgrid.mock_data.send_meter_power([10.0, -1.0, -2.0])
+        await mockgrid.mock_resampler.send_meter_power([10.0, -1.0, -2.0])
         assert (await pv_power_receiver.receive()).value == Power.from_watts(-3.0)
         assert (await pv_production_power_receiver.receive()).value == Power.from_watts(
             3.0
@@ -193,7 +197,7 @@ class TestLogicalMeter:
         logical_meter = microgrid.logical_meter()
         consumer_power_receiver = logical_meter.consumer_power.new_receiver()
 
-        await mockgrid.mock_data.send_meter_power([20.0, 2.0, 3.0, 4.0, 5.0])
+        await mockgrid.mock_resampler.send_meter_power([20.0, 2.0, 3.0, 4.0, 5.0])
         assert (await consumer_power_receiver.receive()).value == Power.from_watts(6.0)
 
     async def test_consumer_power_no_grid_meter(self, mocker: MockerFixture) -> None:
@@ -206,7 +210,7 @@ class TestLogicalMeter:
         logical_meter = microgrid.logical_meter()
         consumer_power_receiver = logical_meter.consumer_power.new_receiver()
 
-        await mockgrid.mock_data.send_meter_power([20.0, 2.0, 3.0, 4.0, 5.0])
+        await mockgrid.mock_resampler.send_meter_power([20.0, 2.0, 3.0, 4.0, 5.0])
         assert (await consumer_power_receiver.receive()).value == Power.from_watts(20.0)
 
     async def test_producer_power(self, mocker: MockerFixture) -> None:
@@ -219,7 +223,7 @@ class TestLogicalMeter:
         logical_meter = microgrid.logical_meter()
         producer_power_receiver = logical_meter.producer_power.new_receiver()
 
-        await mockgrid.mock_data.send_meter_power([20.0, 2.0, 3.0, 4.0, 5.0])
+        await mockgrid.mock_resampler.send_meter_power([20.0, 2.0, 3.0, 4.0, 5.0])
         assert (await producer_power_receiver.receive()).value == Power.from_watts(14.0)
 
     async def test_producer_power_no_chp(self, mocker: MockerFixture) -> None:
@@ -231,7 +235,7 @@ class TestLogicalMeter:
         logical_meter = microgrid.logical_meter()
         producer_power_receiver = logical_meter.producer_power.new_receiver()
 
-        await mockgrid.mock_data.send_meter_power([20.0, 2.0, 3.0])
+        await mockgrid.mock_resampler.send_meter_power([20.0, 2.0, 3.0])
         assert (await producer_power_receiver.receive()).value == Power.from_watts(5.0)
 
     async def test_producer_power_no_pv(self, mocker: MockerFixture) -> None:
@@ -243,7 +247,7 @@ class TestLogicalMeter:
         logical_meter = microgrid.logical_meter()
         producer_power_receiver = logical_meter.producer_power.new_receiver()
 
-        await mockgrid.mock_data.send_meter_power([20.0, 2.0])
+        await mockgrid.mock_resampler.send_meter_power([20.0, 2.0])
         assert (await producer_power_receiver.receive()).value == Power.from_watts(2.0)
 
     async def test_no_producer_power(self, mocker: MockerFixture) -> None:
@@ -254,5 +258,5 @@ class TestLogicalMeter:
         logical_meter = microgrid.logical_meter()
         producer_power_receiver = logical_meter.producer_power.new_receiver()
 
-        await mockgrid.mock_data.send_non_existing_component_value()
+        await mockgrid.mock_resampler.send_non_existing_component_value()
         assert (await producer_power_receiver.receive()).value == Power.from_watts(0.0)


### PR DESCRIPTION
With this PR, there will be no remaining test dependencies on the flaky automatic raw-data streaming functionality of `MockMicrogrid`.  The benchmarks for the data sourcing actor still depends on this, but that can be dealt with later.

This PR also allows for the tests for the power distributing actor to use `MockMicrogrid`, because that would make it easy for the tests to be run on many different component graph configs,  rather than the single config it uses now.