### PR TITLE
Fix formatting bug for zero value Quantities

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -14,4 +14,6 @@
 
 ## Bug Fixes
 
+- Fix formatting issue for `Quantity` objects with zero values.
+
 <!-- Here goes notable bug fixes that are worth a special mention or explanation -->

--- a/src/frequenz/sdk/timeseries/_quantities.py
+++ b/src/frequenz/sdk/timeseries/_quantities.py
@@ -164,7 +164,7 @@ class Quantity:
             return f"{self._base_value:.{precision}f}"
 
         abs_value = abs(self._base_value)
-        exponent = math.floor(math.log10(abs_value))
+        exponent = math.floor(math.log10(abs_value)) if abs_value else 0
         unit_place = exponent - exponent % 3
         if unit_place < min(self._exponent_unit_map):
             unit = self._exponent_unit_map[min(self._exponent_unit_map.keys())]

--- a/tests/timeseries/test_quantities.py
+++ b/tests/timeseries/test_quantities.py
@@ -84,6 +84,11 @@ def test_string_representation() -> None:
     assert f"{Fz1(1.024445, exponent=-12)}" == "0 Hz"
     assert f"{Fz2(1.024445, exponent=-12)}" == "0 Hz"
 
+    assert f"{Fz1(0)}" == "0 Hz"
+
+    assert f"{Fz1(-20)}" == "-20 Hz"
+    assert f"{Fz1(-20000)}" == "-20 kHz"
+
 
 def test_addition_subtraction() -> None:
     """Test the addition and subtraction of the quantities."""


### PR DESCRIPTION
Also add tests for zero and negative values.

This is already part of a patch release v0.22.1.  Merging from v0.22.x to v0.x.x was a bit complicated, because of conflicts in the RELEASE_NOTES.md file, so making an independent PR.