### PR TITLE
Support float.inf and float.nan in quantities

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,16 +6,17 @@
 
 ## Upgrading
 
-<!-- Here goes notes on how to upgrade from previous versions, including deprecations and what they should be replaced with --> 
+<!-- Here goes notes on how to upgrade from previous versions, including deprecations and what they should be replaced with -->
 
 - `Channels` has been upgraded to version 0.16.0, for information on how to upgrade visit https://github.com/frequenz-floss/frequenz-channels-python/releases/tag/v0.16.0
 
 ## New Features
 
-* Add quantity class `Frequency` for frequency values.
+- Add quantity class `Frequency` for frequency values.
 
 ## Bug Fixes
 
 - Fix formatting issue for `Quantity` objects with zero values.
+- Fix formatting isuse for `Quantity` when the base value is float.inf or float.nan.
 
 <!-- Here goes notable bug fixes that are worth a special mention or explanation -->

--- a/src/frequenz/sdk/timeseries/_quantities.py
+++ b/src/frequenz/sdk/timeseries/_quantities.py
@@ -170,6 +170,9 @@ class Quantity:
         if not self._exponent_unit_map:
             return f"{self._base_value:.{precision}f}"
 
+        if math.isinf(self._base_value) or math.isnan(self._base_value):
+            return f"{self._base_value} {self._exponent_unit_map[0]}"
+
         abs_value = abs(self._base_value)
         exponent = math.floor(math.log10(abs_value)) if abs_value else 0
         unit_place = exponent - exponent % 3

--- a/tests/timeseries/test_quantities.py
+++ b/tests/timeseries/test_quantities.py
@@ -319,3 +319,34 @@ def test_neg() -> None:
     pct = Percentage.from_fraction(30)
     assert -pct == Percentage.from_fraction(-30)
     assert -(-pct) == pct
+
+
+def test_inf() -> None:
+    """Test proper formating when using inf in quantities"""
+    assert f"{Power.from_watts(float('inf'))}" == "inf W"
+    assert f"{Power.from_watts(float('-inf'))}" == "-inf W"
+
+    assert f"{Voltage.from_volts(float('inf'))}" == "inf V"
+    assert f"{Voltage.from_volts(float('-inf'))}" == "-inf V"
+
+    assert f"{Current.from_amperes(float('inf'))}" == "inf A"
+    assert f"{Current.from_amperes(float('-inf'))}" == "-inf A"
+
+    assert f"{Energy.from_watt_hours(float('inf'))}" == "inf Wh"
+    assert f"{Energy.from_watt_hours(float('-inf'))}" == "-inf Wh"
+
+    assert f"{Frequency.from_hertz(float('inf'))}" == "inf Hz"
+    assert f"{Frequency.from_hertz(float('-inf'))}" == "-inf Hz"
+
+    assert f"{Percentage.from_fraction(float('inf'))}" == "inf %"
+    assert f"{Percentage.from_fraction(float('-inf'))}" == "-inf %"
+
+
+def test_nan() -> None:
+    """Test proper formating when using nan in quantities"""
+    assert f"{Power.from_watts(float('nan'))}" == "nan W"
+    assert f"{Voltage.from_volts(float('nan'))}" == "nan V"
+    assert f"{Current.from_amperes(float('nan'))}" == "nan A"
+    assert f"{Energy.from_watt_hours(float('nan'))}" == "nan Wh"
+    assert f"{Frequency.from_hertz(float('nan'))}" == "nan Hz"
+    assert f"{Percentage.from_fraction(float('nan'))}" == "nan %"


### PR DESCRIPTION
This might be controversial, but my use case is the following:

```
        boundaries: list[tuple[Percentage, SoC]] = [
            (config.battery_bounds.lower, SoC.DISCHARGED),
            (reserve_bounds.lower, SoC.RESERVE),
            (config.target_soc_bounds_pct.lower, SoC.NORMAL),
            (config.target_soc_bounds_pct.upper, SoC.TARGET),
            (reserve_bounds.upper, SoC.NORMAL),
            (config.battery_bounds.upper, SoC.RESERVE),
            (Percentage.from_percent(float("inf")), SoC.CHARGED),
        ]

        for boundary, state in boundaries:
            if bat_soc_pct < boundary:
                return state

```

I am using inf here as a stop-marker that will always be larger than the last boundary. This way I can avoid having to add a special case for the last boundary.
