### PR TITLE
MovingWindow returns sorted np array, when wrapping around and new test

### DIFF
--- a/src/frequenz/sdk/timeseries/_moving_window.py
+++ b/src/frequenz/sdk/timeseries/_moving_window.py
@@ -322,6 +322,17 @@ class MovingWindow:
             if isinstance(key.start, datetime) and isinstance(key.stop, datetime):
                 return self._buffer.window(key.start, key.stop)
             if isinstance(key.start, int) and isinstance(key.stop, int):
+                new_start = self._buffer.wrap(key.start)
+                new_stop = self._buffer.wrap(key.stop)
+                if new_start >= new_stop:
+                    if (
+                        new_stop < 0
+                        and (self._buffer.maxlen - 1) + new_stop >= new_start
+                    ):
+                        return self._buffer[key]
+                    return np.concatenate(
+                        (self._buffer[new_start:], self._buffer[0:new_stop])
+                    )
                 return self._buffer[key]
         elif isinstance(key, datetime):
             _logger.debug("Returning value at time %s ", key)

--- a/tests/timeseries/test_moving_window.py
+++ b/tests/timeseries/test_moving_window.py
@@ -111,6 +111,13 @@ async def test_access_window_by_ts_slice() -> None:
     assert np.array_equal(window[time_start:time_end], np.array([3.0, 4.0]))  # type: ignore
 
 
+async def test_access_window_wraparound_int_slice() -> None:
+    """Test accessing a subwindow with an integer slice that wraps around the window"""
+    window, sender = init_moving_window(timedelta(seconds=5))
+    await push_logical_meter_data(sender, range(0, 5))
+    assert np.array_equal(window[3:7], np.array([3.0, 4.0, 0.0, 1.0]))
+
+
 async def test_window_size() -> None:
     """Test the size of the window."""
     window, sender = init_moving_window(timedelta(seconds=5))


### PR DESCRIPTION
I am not quite sure about the if-block when new_stop is < 0, but I thought it would be a convenient addition.
Fixes #212 