### PR TITLE
Add constant to FormulaEngine arithmetic

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -13,8 +13,9 @@
 ## New Features
 
 - Add `abs()` support for quantities.
-* Add quantity class `Frequency` for frequency values.
-* Quantities can now be multiplied with `Percentage` types.
+- Add quantity class `Frequency` for frequency values.
+- Quantities can now be multiplied with `Percentage` types.
+- `FormulaEngine` arithmetics now supports scalar multiplication with floats and addition with Quantities
 
 ## Bug Fixes
 

--- a/src/frequenz/sdk/timeseries/_formula_engine/_formula_engine.py
+++ b/src/frequenz/sdk/timeseries/_formula_engine/_formula_engine.py
@@ -9,15 +9,12 @@ import asyncio
 import logging
 from abc import ABC
 from collections import deque
-from datetime import datetime
-from math import isinf, isnan
 from typing import (
     Callable,
     Dict,
     Generic,
     List,
     Optional,
-    Set,
     Tuple,
     Type,
     TypeVar,
@@ -30,6 +27,7 @@ from frequenz.channels import Broadcast, Receiver
 from ..._internal._asyncio import cancel_and_await
 from .. import Sample, Sample3Phase
 from .._quantities import Quantity, QuantityT
+from ._formula_evaluator import FormulaEvaluator
 from ._formula_steps import (
     Adder,
     Averager,
@@ -54,126 +52,6 @@ _operator_precedence = {
     "+": 4,
     ")": 5,
 }
-
-
-class FormulaEvaluator(Generic[QuantityT]):
-    """A post-fix formula evaluator that operates on `Sample` receivers."""
-
-    def __init__(
-        self,
-        name: str,
-        steps: List[FormulaStep],
-        metric_fetchers: Dict[str, MetricFetcher[QuantityT]],
-        create_method: Callable[[float], QuantityT],
-    ) -> None:
-        """Create a `FormulaEngine` instance.
-
-        Args:
-            name: A name for the formula.
-            steps: Steps for the engine to execute, in post-fix order.
-            metric_fetchers: Fetchers for each metric stream the formula depends on.
-            create_method: A method to generate the output `Sample` value with.  If the
-                formula is for generating power values, this would be
-                `Power.from_watts`, for example.
-        """
-        self._name = name
-        self._steps = steps
-        self._metric_fetchers: Dict[str, MetricFetcher[QuantityT]] = metric_fetchers
-        self._first_run = True
-        self._create_method: Callable[[float], QuantityT] = create_method
-
-    async def _synchronize_metric_timestamps(
-        self, metrics: Set[asyncio.Task[Optional[Sample[QuantityT]]]]
-    ) -> datetime:
-        """Synchronize the metric streams.
-
-        For synchronised streams like data from the `ComponentMetricsResamplingActor`,
-        this a call to this function is required only once, before the first set of
-        inputs are fetched.
-
-        Args:
-            metrics: The finished tasks from the first `fetch_next` calls to all the
-                `MetricFetcher`s.
-
-        Returns:
-            The timestamp of the latest metric value.
-
-        Raises:
-            RuntimeError: when some streams have no value, or when the synchronization
-                of timestamps fails.
-        """
-        metrics_by_ts: Dict[datetime, list[str]] = {}
-        for metric in metrics:
-            result = metric.result()
-            name = metric.get_name()
-            if result is None:
-                raise RuntimeError(f"Stream closed for component: {name}")
-            metrics_by_ts.setdefault(result.timestamp, []).append(name)
-        latest_ts = max(metrics_by_ts)
-
-        # fetch the metrics with non-latest timestamps again until we have the values
-        # for the same ts for all metrics.
-        for metric_ts, names in metrics_by_ts.items():
-            if metric_ts == latest_ts:
-                continue
-            while metric_ts < latest_ts:
-                for name in names:
-                    fetcher = self._metric_fetchers[name]
-                    next_val = await fetcher.fetch_next()
-                    assert next_val is not None
-                    metric_ts = next_val.timestamp
-            if metric_ts > latest_ts:
-                raise RuntimeError(
-                    "Unable to synchronize resampled metric timestamps, "
-                    f"for formula: {self._name}"
-                )
-        self._first_run = False
-        return latest_ts
-
-    async def apply(self) -> Sample[QuantityT]:
-        """Fetch the latest metrics, apply the formula once and return the result.
-
-        Returns:
-            The result of the formula.
-
-        Raises:
-            RuntimeError: if some samples didn't arrive, or if formula application
-                failed.
-        """
-        eval_stack: List[float] = []
-        ready_metrics, pending = await asyncio.wait(
-            [
-                asyncio.create_task(fetcher.fetch_next(), name=name)
-                for name, fetcher in self._metric_fetchers.items()
-            ],
-            return_when=asyncio.ALL_COMPLETED,
-        )
-
-        if pending or any(res.result() is None for res in iter(ready_metrics)):
-            raise RuntimeError(
-                f"Some resampled metrics didn't arrive, for formula: {self._name}"
-            )
-
-        if self._first_run:
-            metric_ts = await self._synchronize_metric_timestamps(ready_metrics)
-        else:
-            sample = next(iter(ready_metrics)).result()
-            assert sample is not None
-            metric_ts = sample.timestamp
-
-        for step in self._steps:
-            step.apply(eval_stack)
-
-        # if all steps were applied and the formula was correct, there should only be a
-        # single value in the evaluation stack, and that would be the formula result.
-        if len(eval_stack) != 1:
-            raise RuntimeError(f"Formula application failed: {self._name}")
-
-        res = eval_stack.pop()
-        if isnan(res) or isinf(res):
-            return Sample(metric_ts, None)
-
-        return Sample(metric_ts, self._create_method(res))
 
 
 _CompositionType = Union[

--- a/src/frequenz/sdk/timeseries/_formula_engine/_formula_evaluator.py
+++ b/src/frequenz/sdk/timeseries/_formula_engine/_formula_evaluator.py
@@ -1,0 +1,133 @@
+# License: MIT
+# Copyright © 2022 Frequenz Energy-as-a-Service GmbH
+
+"""A post-fix formula evaluator that operates on `Sample` receivers."""
+
+import asyncio
+from datetime import datetime
+from math import isinf, isnan
+from typing import Callable, Dict, Generic, List, Optional, Set
+
+from .. import Sample
+from .._quantities import QuantityT
+from ._formula_steps import FormulaStep, MetricFetcher
+
+
+class FormulaEvaluator(Generic[QuantityT]):
+    """A post-fix formula evaluator that operates on `Sample` receivers."""
+
+    def __init__(
+        self,
+        name: str,
+        steps: List[FormulaStep],
+        metric_fetchers: Dict[str, MetricFetcher[QuantityT]],
+        create_method: Callable[[float], QuantityT],
+    ) -> None:
+        """Create a `FormulaEngine` instance.
+
+        Args:
+            name: A name for the formula.
+            steps: Steps for the engine to execute, in post-fix order.
+            metric_fetchers: Fetchers for each metric stream the formula depends on.
+            create_method: A method to generate the output `Sample` value with.  If the
+                formula is for generating power values, this would be
+                `Power.from_watts`, for example.
+        """
+        self._name = name
+        self._steps = steps
+        self._metric_fetchers: Dict[str, MetricFetcher[QuantityT]] = metric_fetchers
+        self._first_run = True
+        self._create_method: Callable[[float], QuantityT] = create_method
+
+    async def _synchronize_metric_timestamps(
+        self, metrics: Set[asyncio.Task[Optional[Sample[QuantityT]]]]
+    ) -> datetime:
+        """Synchronize the metric streams.
+
+        For synchronised streams like data from the `ComponentMetricsResamplingActor`,
+        this a call to this function is required only once, before the first set of
+        inputs are fetched.
+
+        Args:
+            metrics: The finished tasks from the first `fetch_next` calls to all the
+                `MetricFetcher`s.
+
+        Returns:
+            The timestamp of the latest metric value.
+
+        Raises:
+            RuntimeError: when some streams have no value, or when the synchronization
+                of timestamps fails.
+        """
+        metrics_by_ts: Dict[datetime, list[str]] = {}
+        for metric in metrics:
+            result = metric.result()
+            name = metric.get_name()
+            if result is None:
+                raise RuntimeError(f"Stream closed for component: {name}")
+            metrics_by_ts.setdefault(result.timestamp, []).append(name)
+        latest_ts = max(metrics_by_ts)
+
+        # fetch the metrics with non-latest timestamps again until we have the values
+        # for the same ts for all metrics.
+        for metric_ts, names in metrics_by_ts.items():
+            if metric_ts == latest_ts:
+                continue
+            while metric_ts < latest_ts:
+                for name in names:
+                    fetcher = self._metric_fetchers[name]
+                    next_val = await fetcher.fetch_next()
+                    assert next_val is not None
+                    metric_ts = next_val.timestamp
+            if metric_ts > latest_ts:
+                raise RuntimeError(
+                    "Unable to synchronize resampled metric timestamps, "
+                    f"for formula: {self._name}"
+                )
+        self._first_run = False
+        return latest_ts
+
+    async def apply(self) -> Sample[QuantityT]:
+        """Fetch the latest metrics, apply the formula once and return the result.
+
+        Returns:
+            The result of the formula.
+
+        Raises:
+            RuntimeError: if some samples didn't arrive, or if formula application
+                failed.
+        """
+        eval_stack: List[float] = []
+        ready_metrics, pending = await asyncio.wait(
+            [
+                asyncio.create_task(fetcher.fetch_next(), name=name)
+                for name, fetcher in self._metric_fetchers.items()
+            ],
+            return_when=asyncio.ALL_COMPLETED,
+        )
+
+        if pending or any(res.result() is None for res in iter(ready_metrics)):
+            raise RuntimeError(
+                f"Some resampled metrics didn't arrive, for formula: {self._name}"
+            )
+
+        if self._first_run:
+            metric_ts = await self._synchronize_metric_timestamps(ready_metrics)
+        else:
+            sample = next(iter(ready_metrics)).result()
+            assert sample is not None
+            metric_ts = sample.timestamp
+
+        for step in self._steps:
+            step.apply(eval_stack)
+
+        # if all steps were applied and the formula was correct, there should only be a
+        # single value in the evaluation stack, and that would be the formula result.
+        if len(eval_stack) != 1:
+            raise RuntimeError(f"Formula application failed: {self._name}")
+
+        res = eval_stack.pop()
+        if isnan(res) or isinf(res):
+            return Sample(metric_ts, None)
+
+        return Sample(metric_ts, self._create_method(res))

--- a/src/frequenz/sdk/timeseries/_formula_engine/_tokenizer.py
+++ b/src/frequenz/sdk/timeseries/_formula_engine/_tokenizer.py
@@ -79,7 +79,8 @@ class TokenType(Enum):
     """Represents the types of tokens the Tokenizer can return."""
 
     COMPONENT_METRIC = 0
-    OPER = 1
+    CONSTANT = 1
+    OPER = 2
 
 
 @dataclass

--- a/tests/timeseries/_formula_engine/test_formula_composition.py
+++ b/tests/timeseries/_formula_engine/test_formula_composition.py
@@ -6,6 +6,7 @@
 
 import math
 
+import pytest
 from pytest_mock import MockerFixture
 
 from frequenz.sdk import microgrid
@@ -218,6 +219,20 @@ class TestFormulaComposition:
             grid_power_division.value.as_watts(),
             50.0,
         )
+
+        # Test multiplication with a Quantity
+        with pytest.raises(RuntimeError):
+            engine_assert = (
+                logical_meter.grid_power * Power.from_watts(2.0)  # type: ignore
+            ).build("grid_power_multiplication")
+            await engine_assert.new_receiver().receive()
+
+        # Test addition with a float
+        with pytest.raises(RuntimeError):
+            engine_assert = (logical_meter.grid_power + 2.0).build(  # type: ignore
+                "grid_power_multiplication"
+            )
+            await engine_assert.new_receiver().receive()
 
         await engine_add._stop()  # pylint: disable=protected-access
         await engine_sub._stop()  # pylint: disable=protected-access


### PR DESCRIPTION
We can now use constants for all formula engine operations.

**Example:**
```python
scaled_grid_power = (microgrid.logical_meter().grid_power * 5).build()
```