### PR TITLE
Implement dunder iadd, isub, imul methods for Quantity

### DIFF
--- a/src/frequenz/sdk/timeseries/_quantities.py
+++ b/src/frequenz/sdk/timeseries/_quantities.py
@@ -3,6 +3,8 @@
 
 """Types for holding quantities with units."""
 
+# pylint: disable=too-many-lines
+
 from __future__ import annotations
 
 import math
@@ -236,6 +238,48 @@ class Quantity:
         product = type(self).__new__(type(self))
         product._base_value = self._base_value * percent.as_fraction()
         return product
+
+    def __iadd__(self, other: Self) -> Self:
+        """Add another quantity to this one.
+
+        Args:
+            other: The other quantity.
+
+        Returns:
+            This quantity.
+        """
+        if not type(other) is type(self):
+            return NotImplemented
+        self._base_value += other._base_value
+        return self
+
+    def __isub__(self, other: Self) -> Self:
+        """Subtract another quantity from this one.
+
+        Args:
+            other: The other quantity.
+
+        Returns:
+            This quantity.
+        """
+        if not type(other) is type(self):
+            return NotImplemented
+        self._base_value -= other._base_value
+        return self
+
+    def __imul__(self, percent: Percentage) -> Self:
+        """Multiply this quantity by a percentage.
+
+        Args:
+            percent: The percentage.
+
+        Returns:
+            This quantity.
+        """
+        if not isinstance(percent, Percentage):
+            return NotImplemented
+        self._base_value *= percent.as_fraction()
+        return self
 
     def __gt__(self, other: Self) -> bool:
         """Return whether this quantity is greater than another.

--- a/tests/timeseries/test_quantities.py
+++ b/tests/timeseries/test_quantities.py
@@ -105,6 +105,15 @@ def test_addition_subtraction() -> None:
         assert Fz1(1) - Fz2(1)  # type: ignore
     assert excinfo.value.args[0] == "unsupported operand type(s) for -: 'Fz1' and 'Fz2'"
 
+    fz1 = Fz1(1.0)
+    fz1 += Fz1(4.0)
+    assert fz1 == Fz1(5.0)
+    fz1 -= Fz1(9.0)
+    assert fz1 == Fz1(-4.0)
+
+    with pytest.raises(TypeError) as excinfo:
+        fz1 += Fz2(1.0)  # type: ignore
+
 
 def test_comparison() -> None:
     """Test the comparison of the quantities."""
@@ -394,6 +403,17 @@ def test_quantity_multiplied_with_precentage() -> None:
     assert energy * percentage == Energy.from_kilowatt_hours(6)
     assert percentage_ * percentage == Percentage.from_percent(25)
 
+    power *= percentage
+    assert power == Power.from_watts(500.0)
+    voltage *= percentage
+    assert voltage == Voltage.from_volts(115.0)
+    current *= percentage
+    assert current == Current.from_amperes(1)
+    energy *= percentage
+    assert energy == Energy.from_kilowatt_hours(6)
+    percentage_ *= percentage
+    assert percentage_ == Percentage.from_percent(25)
+
 
 def test_invalid_multiplications() -> None:
     """Test the multiplication of quantities with invalid quantities."""
@@ -405,19 +425,29 @@ def test_invalid_multiplications() -> None:
     for quantity in [power, voltage, current, energy]:
         with pytest.raises(TypeError):
             _ = power * quantity  # type: ignore
+        with pytest.raises(TypeError):
+            power *= quantity  # type: ignore
 
     for quantity in [voltage, power, energy]:
         with pytest.raises(TypeError):
             _ = voltage * quantity  # type: ignore
+        with pytest.raises(TypeError):
+            voltage *= quantity  # type: ignore
 
     for quantity in [current, power, energy]:
         with pytest.raises(TypeError):
             _ = current * quantity  # type: ignore
+        with pytest.raises(TypeError):
+            current *= quantity  # type: ignore
 
     for quantity in [energy, power, voltage, current]:
         with pytest.raises(TypeError):
             _ = energy * quantity  # type: ignore
+        with pytest.raises(TypeError):
+            energy *= quantity  # type: ignore
 
     for quantity in [power, voltage, current, energy, Percentage.from_percent(50)]:
         with pytest.raises(TypeError):
             _ = quantity * 200.0  # type: ignore
+        with pytest.raises(TypeError):
+            quantity *= 200.0  # type: ignore


### PR DESCRIPTION
imul is implemented only for `Percentage` because, all other
multiplications that we have produce outputs of a new type, which is
not possible with imul.

With this usage like this becomes possible:

```python
power = Power.from_watts(1000.0)
power += Power.from_watts(3.2)
```