### PR TITLE
Improvements to the `ConfigManagingActor`

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,10 +7,11 @@
 ## Upgrading
 
 - Upgrade to microgrid API v0.15.1.  If you're using any of the lower level microgrid interfaces, you will need to upgrade your code.
+- The argument `conf_file` of the `ConfigManagingActor` constructor was renamed to `config_path`.
 
 ## New Features
 
-<!-- Here goes the main new features and examples or instructions on how to use them -->
+- The `ConfigManagingActor` constructor now can accept a `pathlib.Path` as `config_path` too (before it accepted only a `str`).
 
 ## Bug Fixes
 

--- a/src/frequenz/sdk/actor/_config_managing.py
+++ b/src/frequenz/sdk/actor/_config_managing.py
@@ -7,7 +7,7 @@ import logging
 import os
 import tomllib
 from collections import abc
-from typing import Any, Dict
+from typing import Any
 
 from frequenz.channels import Sender
 from frequenz.channels.util import FileWatcher
@@ -49,7 +49,7 @@ class ConfigManagingActor:
         )
         self._output = output
 
-    def _read_config(self) -> Dict[str, Any]:
+    def _read_config(self) -> dict[str, Any]:
         """Read the contents of the config file.
 
         Raises:

--- a/src/frequenz/sdk/actor/_config_managing.py
+++ b/src/frequenz/sdk/actor/_config_managing.py
@@ -64,7 +64,7 @@ class ConfigManagingActor:
             with open(self._conf_file, "rb") as toml_file:
                 return tomllib.load(toml_file)
         except ValueError as err:
-            logging.error("Can't read config file, err: %s", err)
+            logging.error("%s: Can't read config file, err: %s", self, err)
             raise
 
     async def send_config(self) -> None:
@@ -81,9 +81,8 @@ class ConfigManagingActor:
             if event.type != FileWatcher.EventType.DELETE:
                 if str(event.path) == self._conf_file:
                     _logger.info(
-                        "Update configs, because file %s was modified.",
+                        "%s: Update configs, because file %s was modified.",
+                        self,
                         self._conf_file,
                     )
                     await self.send_config()
-
-        _logger.debug("ConfigManager stopped.")

--- a/src/frequenz/sdk/actor/_config_managing.py
+++ b/src/frequenz/sdk/actor/_config_managing.py
@@ -46,10 +46,10 @@ class ConfigManagingActor:
         """
         self._conf_file: str = conf_file
         self._conf_dir: str = os.path.dirname(conf_file)
-        self._file_watcher = FileWatcher(
+        self._file_watcher: FileWatcher = FileWatcher(
             paths=[self._conf_dir], event_types=event_types
         )
-        self._output = output
+        self._output: Sender[Config] = output
 
     def _read_config(self) -> dict[str, Any]:
         """Read the contents of the configuration file.

--- a/tests/actor/test_config_manager.py
+++ b/tests/actor/test_config_manager.py
@@ -80,9 +80,7 @@ class TestActorConfigManager:
         config_channel: Broadcast[Config] = Broadcast(
             "Config Channel", resend_latest=True
         )
-        _config_manager = ConfigManagingActor(
-            conf_file=str(config_file), output=config_channel.new_sender()
-        )
+        _config_manager = ConfigManagingActor(config_file, config_channel.new_sender())
 
         config_receiver = config_channel.new_receiver()
 


### PR DESCRIPTION
While working on the migration to the new `Actor` class I noticed several small issues with the `ConfigManagingActor`:

- Use built-in types for typing
- Improve documentation for `ConfigManagingActor`
- Improve logging for `ConfigManagingActor`
- Add missing type hints to attributes
- Rename `conf_file` to `config_path` and accept `pathlib.Path`
- Add clarification about watching the parent directory
- Use match to process the file watcher events
