### PR TITLE
Allow running release notes check in merge queues

### DIFF
--- a/.github/workflows/release_notes_check.yml
+++ b/.github/workflows/release_notes_check.yml
@@ -1,6 +1,7 @@
 name: Release Notes Check
 
 on:
+  merge_group:
   pull_request:
     types:
       # On by default if you specify no types.
@@ -11,12 +12,14 @@ on:
       - "labeled"
       - "unlabeled"
 
+
 jobs:
   check-release-notes:
     name: Check release notes are updated
     runs-on: ubuntu-latest
     steps:
       - name: Check for a release notes update
+        if: github.event_name == 'pull_request'
         uses: brettcannon/check-for-changed-files@294a99714e0d350b5083472a293d41bc91804e68 # v1.1.1
         with:
           file-pattern: "RELEASE_NOTES.md"


### PR DESCRIPTION
The check will do nothing for merge queues, as we need the PR information to be able to check anything. But in any case, checking again is not necessary because PRs should be queued for merge only when they already pass the release notes check.
