### PR TITLE
Add docs cross-linking to APIs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -105,7 +105,9 @@ plugins:
           import:
             # See https://mkdocstrings.github.io/python/usage/#import for details
             - https://docs.python.org/3/objects.inv
+            - https://frequenz-floss.github.io/frequenz-api-common/v0.3/objects.inv
             - https://frequenz-floss.github.io/frequenz-channels-python/v0.14/objects.inv
+            - https://frequenz-floss.github.io/frequenz-api-microgrid/v0.15/objects.inv
             - https://grpc.github.io/grpc/python/objects.inv
             - https://networkx.org/documentation/stable/objects.inv
             - https://numpy.org/doc/stable/objects.inv

--- a/src/frequenz/sdk/microgrid/component/_component_data.py
+++ b/src/frequenz/sdk/microgrid/component/_component_data.py
@@ -137,7 +137,9 @@ class BatteryData(ComponentData):
     This is the lower limit of the range within which power requests are allowed for the
     battery.
 
-    More details [here](https://github.com/frequenz-floss/frequenz-api-common/blob/v0.3.0/proto/frequenz/api/common/metrics.proto#L37-L91).
+    See [`frequenz.api.common.metrics_pb2.Metric.system_inclusion_bounds`][] and
+    [`frequenz.api.common.metrics_pb2.Metric.system_exclusion_bounds`][] for more
+    details.
     """
 
     power_exclusion_lower_bound: float
@@ -146,7 +148,9 @@ class BatteryData(ComponentData):
     This is the lower limit of the range within which power requests are not allowed for
     the battery.
 
-    More details [here](https://github.com/frequenz-floss/frequenz-api-common/blob/v0.3.0/proto/frequenz/api/common/metrics.proto#L37-L91).
+    See [`frequenz.api.common.metrics_pb2.Metric.system_inclusion_bounds`][] and
+    [`frequenz.api.common.metrics_pb2.Metric.system_exclusion_bounds`][] for more
+    details.
     """
 
     power_inclusion_upper_bound: float
@@ -155,7 +159,9 @@ class BatteryData(ComponentData):
     This is the upper limit of the range within which power requests are allowed for the
     battery.
 
-    More details [here](https://github.com/frequenz-floss/frequenz-api-common/blob/v0.3.0/proto/frequenz/api/common/metrics.proto#L37-L91).
+    See [`frequenz.api.common.metrics_pb2.Metric.system_inclusion_bounds`][] and
+    [`frequenz.api.common.metrics_pb2.Metric.system_exclusion_bounds`][] for more
+    details.
     """
 
     power_exclusion_upper_bound: float
@@ -164,7 +170,9 @@ class BatteryData(ComponentData):
     This is the upper limit of the range within which power requests are not allowed for
     the battery.
 
-    More details [here](https://github.com/frequenz-floss/frequenz-api-common/blob/v0.3.0/proto/frequenz/api/common/metrics.proto#L37-L91).
+    See [`frequenz.api.common.metrics_pb2.Metric.system_inclusion_bounds`][] and
+    [`frequenz.api.common.metrics_pb2.Metric.system_exclusion_bounds`][] for more
+    details.
     """
     # pylint: enable=line-too-long
 
@@ -228,7 +236,9 @@ class InverterData(ComponentData):
     This is the lower limit of the range within which power requests are allowed for the
     inverter.
 
-    More details [here](https://github.com/frequenz-floss/frequenz-api-common/blob/v0.3.0/proto/frequenz/api/common/metrics.proto#L37-L91).
+    See [`frequenz.api.common.metrics_pb2.Metric.system_inclusion_bounds`][] and
+    [`frequenz.api.common.metrics_pb2.Metric.system_exclusion_bounds`][] for more
+    details.
     """
 
     active_power_exclusion_lower_bound: float
@@ -237,7 +247,9 @@ class InverterData(ComponentData):
     This is the lower limit of the range within which power requests are not allowed for
     the inverter.
 
-    More details [here](https://github.com/frequenz-floss/frequenz-api-common/blob/v0.3.0/proto/frequenz/api/common/metrics.proto#L37-L91).
+    See [`frequenz.api.common.metrics_pb2.Metric.system_inclusion_bounds`][] and
+    [`frequenz.api.common.metrics_pb2.Metric.system_exclusion_bounds`][] for more
+    details.
     """
 
     active_power_inclusion_upper_bound: float
@@ -246,7 +258,9 @@ class InverterData(ComponentData):
     This is the upper limit of the range within which power requests are allowed for the
     inverter.
 
-    More details [here](https://github.com/frequenz-floss/frequenz-api-common/blob/v0.3.0/proto/frequenz/api/common/metrics.proto#L37-L91).
+    See [`frequenz.api.common.metrics_pb2.Metric.system_inclusion_bounds`][] and
+    [`frequenz.api.common.metrics_pb2.Metric.system_exclusion_bounds`][] for more
+    details.
     """
 
     active_power_exclusion_upper_bound: float
@@ -255,7 +269,9 @@ class InverterData(ComponentData):
     This is the upper limit of the range within which power requests are not allowed for
     the inverter.
 
-    More details [here](https://github.com/frequenz-floss/frequenz-api-common/blob/v0.3.0/proto/frequenz/api/common/metrics.proto#L37-L91).
+    See [`frequenz.api.common.metrics_pb2.Metric.system_inclusion_bounds`][] and
+    [`frequenz.api.common.metrics_pb2.Metric.system_exclusion_bounds`][] for more
+    details.
     """
     # pylint: enable=line-too-long
 

--- a/src/frequenz/sdk/timeseries/battery_pool/_result_types.py
+++ b/src/frequenz/sdk/timeseries/battery_pool/_result_types.py
@@ -37,7 +37,9 @@ class PowerMetrics:
     When exclusion bounds are present, they will exclude a subset of the inclusion
     bounds.
 
-    More details [here](https://github.com/frequenz-floss/frequenz-api-common/blob/v0.3.0/proto/frequenz/api/common/metrics.proto#L37-L91).
+    See [`frequenz.api.common.metrics_pb2.Metric.system_inclusion_bounds`][] and
+    [`frequenz.api.common.metrics_pb2.Metric.system_exclusion_bounds`][] for more
+    details.
     """
 
     exclusion_bounds: Bounds
@@ -46,6 +48,8 @@ class PowerMetrics:
     This is the range within which power requests are NOT allowed by the battery pool.
     If present, they will be a subset of the inclusion bounds.
 
-    More details [here](https://github.com/frequenz-floss/frequenz-api-common/blob/v0.3.0/proto/frequenz/api/common/metrics.proto#L37-L91).
+    See [`frequenz.api.common.metrics_pb2.Metric.system_inclusion_bounds`][] and
+    [`frequenz.api.common.metrics_pb2.Metric.system_exclusion_bounds`][] for more
+    details.
     """
     # pylint: enable=line-too-long


### PR DESCRIPTION
For APIs now we can use cross-referencing, which is more user-friendly but also easier to maintain as we only need to update the version we want to point to in one place (the `mkdocs.yml` file).

- mkdocs: Add cross-linking object inventory for APIs
- Change links to the source with links to the docs
