### PR TITLE
Fix ring buffer gap cleanup code

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -16,3 +16,7 @@ Now the microgrid API v0.15.x is being used. The SDK can only connect to microgr
 - The `ConfigManagingActor` constructor now can accept a `pathlib.Path` as `config_path` too (before it accepted only a `str`).
 
 - The `PowerDistributingActor` now considers exclusion bounds, when finding an optimal distribution for power between batteries.
+
+## Bug Fixes
+
+- Fixes a bug in the ring buffer updating the end timestamp of gaps when they are outdated.

--- a/tests/timeseries/test_ringbuffer.py
+++ b/tests/timeseries/test_ringbuffer.py
@@ -369,3 +369,24 @@ def test_off_by_one_gap_logic_bug() -> None:
 
     assert buffer.is_missing(times[0]) is False
     assert buffer.is_missing(times[1]) is False
+
+
+def test_cleanup_oldest_gap_timestamp() -> None:
+    """Test that gaps are updated such that they are fully contained in the buffer."""
+    buffer = OrderedRingBuffer(
+        np.empty(shape=15, dtype=float),
+        sampling_period=timedelta(seconds=1),
+        align_to=datetime(1, 1, 1, tzinfo=timezone.utc),
+    )
+
+    for i in range(10):
+        buffer.update(
+            Sample(datetime.fromtimestamp(200 + i, tz=timezone.utc), Quantity(i))
+        )
+
+    gap = Gap(
+        datetime.fromtimestamp(195, tz=timezone.utc),
+        datetime.fromtimestamp(200, tz=timezone.utc),
+    )
+
+    assert gap == buffer.gaps[0]

--- a/tests/timeseries/test_ringbuffer.py
+++ b/tests/timeseries/test_ringbuffer.py
@@ -390,3 +390,25 @@ def test_cleanup_oldest_gap_timestamp() -> None:
     )
 
     assert gap == buffer.gaps[0]
+
+
+def test_delete_oudated_gap() -> None:
+    """
+    Update the buffer such that the gap is no longer valid.
+    We introduce two gaps and check that the oldest is removed.
+    """
+    buffer = OrderedRingBuffer(
+        np.empty(shape=3, dtype=float),
+        sampling_period=timedelta(seconds=1),
+        align_to=datetime(1, 1, 1, tzinfo=timezone.utc),
+    )
+
+    for i in range(2):
+        buffer.update(
+            Sample(datetime.fromtimestamp(200 + i, tz=timezone.utc), Quantity(i))
+        )
+    assert len(buffer.gaps) == 1
+
+    buffer.update(Sample(datetime.fromtimestamp(202, tz=timezone.utc), Quantity(2)))
+
+    assert len(buffer.gaps) == 0


### PR DESCRIPTION
When cleaning up gaps the case that a gaps start date can become older then the oldest stored value in the buffer wasn't covered. Furthermore the cases for cleaning up a single gap didn't run for the last gaps, since the loop was stopping to early.
