### PR TITLE
Support PV configurations with no or only some meters

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -15,3 +15,7 @@
 ## Bug Fixes
 
 - Fixes a bug in the ring buffer updating the end timestamp of gaps when they are outdated.
+- Properly handles PV configurations with no or only some meters before the PV
+  component.
+  So far we only had configurations like this: Meter -> Inverter -> PV. However
+  the scenario with Inverter -> PV is also possible and now handled correctly.

--- a/src/frequenz/sdk/timeseries/_formula_engine/_formula_generators/_consumer_power_formula.py
+++ b/src/frequenz/sdk/timeseries/_formula_engine/_formula_generators/_consumer_power_formula.py
@@ -37,20 +37,9 @@ class ConsumerPowerFormula(FormulaGenerator[Power]):
         builder = self._get_builder(
             "consumer-power", ComponentMetricId.ACTIVE_POWER, Power.from_watts
         )
-        component_graph = connection_manager.get().component_graph
-        grid_component = next(
-            (
-                comp
-                for comp in component_graph.components()
-                if comp.category == ComponentCategory.GRID
-            ),
-            None,
-        )
 
-        if grid_component is None:
-            raise ComponentNotFound("Grid component not found in the component graph.")
+        grid_successors = self._get_grid_component_successors()
 
-        grid_successors = component_graph.successors(grid_component.component_id)
         if not grid_successors:
             raise ComponentNotFound("No components found in the component graph.")
 

--- a/src/frequenz/sdk/timeseries/_formula_engine/_formula_generators/_formula_generator.py
+++ b/src/frequenz/sdk/timeseries/_formula_engine/_formula_generators/_formula_generator.py
@@ -15,6 +15,7 @@ from typing import Callable, Generic
 from frequenz.channels import Sender
 
 from ....actor import ChannelRegistry, ComponentMetricRequest
+from ....microgrid import component, connection_manager
 from ....microgrid.component import ComponentMetricId
 from ..._quantities import QuantityT
 from .._formula_engine import FormulaEngine, FormulaEngine3Phase
@@ -99,6 +100,36 @@ class FormulaGenerator(ABC, Generic[QuantityT]):
             create_method,
         )
         return builder
+
+    def _get_grid_component_successors(self) -> set[component.Component]:
+        """Get the set of grid component successors in the component graph.
+
+        Returns:
+            A set of grid component successors.
+
+        Raises:
+            ComponentNotFound: If the grid component is not found in the component graph.
+            ComponentNotFound: If no successor components are found in the component graph.
+        """
+        component_graph = connection_manager.get().component_graph
+        grid_component = next(
+            iter(
+                component_graph.components(
+                    component_category={component.ComponentCategory.GRID}
+                )
+            ),
+            None,
+        )
+
+        if grid_component is None:
+            raise ComponentNotFound("Grid component not found in the component graph.")
+
+        grid_successors = component_graph.successors(grid_component.component_id)
+
+        if not grid_successors:
+            raise ComponentNotFound("No components found in the component graph.")
+
+        return grid_successors
 
     @abstractmethod
     def generate(

--- a/src/frequenz/sdk/timeseries/_formula_engine/_formula_generators/_grid_current_formula.py
+++ b/src/frequenz/sdk/timeseries/_formula_engine/_formula_generators/_grid_current_formula.py
@@ -5,11 +5,10 @@
 
 from typing import Set
 
-from ....microgrid import connection_manager
 from ....microgrid.component import Component, ComponentCategory, ComponentMetricId
 from ..._quantities import Current
 from .._formula_engine import FormulaEngine, FormulaEngine3Phase
-from ._formula_generator import ComponentNotFound, FormulaGenerator
+from ._formula_generator import FormulaGenerator
 
 
 class GridCurrentFormula(FormulaGenerator[Current]):
@@ -24,22 +23,7 @@ class GridCurrentFormula(FormulaGenerator[Current]):
         Raises:
             ComponentNotFound: when the component graph doesn't have a `GRID` component.
         """
-        component_graph = connection_manager.get().component_graph
-        grid_component = next(
-            (
-                comp
-                for comp in component_graph.components()
-                if comp.category == ComponentCategory.GRID
-            ),
-            None,
-        )
-
-        if grid_component is None:
-            raise ComponentNotFound(
-                "Unable to find a GRID component from the component graph."
-            )
-
-        grid_successors = component_graph.successors(grid_component.component_id)
+        grid_successors = self._get_grid_component_successors()
 
         return FormulaEngine3Phase(
             "grid-current",

--- a/src/frequenz/sdk/timeseries/_formula_engine/_formula_generators/_grid_power_formula.py
+++ b/src/frequenz/sdk/timeseries/_formula_engine/_formula_generators/_grid_power_formula.py
@@ -3,11 +3,10 @@
 
 """Formula generator from component graph for Grid Power."""
 
-from ....microgrid import connection_manager
 from ....microgrid.component import ComponentCategory, ComponentMetricId
 from ..._quantities import Power
 from .._formula_engine import FormulaEngine
-from ._formula_generator import ComponentNotFound, FormulaGenerator, FormulaType
+from ._formula_generator import FormulaGenerator, FormulaType
 
 
 class GridPowerFormula(FormulaGenerator[Power]):
@@ -27,22 +26,7 @@ class GridPowerFormula(FormulaGenerator[Power]):
         builder = self._get_builder(
             "grid-power", ComponentMetricId.ACTIVE_POWER, Power.from_watts
         )
-        component_graph = connection_manager.get().component_graph
-        grid_component = next(
-            (
-                comp
-                for comp in component_graph.components()
-                if comp.category == ComponentCategory.GRID
-            ),
-            None,
-        )
-
-        if grid_component is None:
-            raise ComponentNotFound(
-                "Unable to find a GRID component from the component graph."
-            )
-
-        grid_successors = component_graph.successors(grid_component.component_id)
+        grid_successors = self._get_grid_component_successors()
 
         # generate a formula that just adds values from all commponents that are
         # directly connected to the grid.  If the requested formula type is

--- a/src/frequenz/sdk/timeseries/_formula_engine/_formula_generators/_producer_power_formula.py
+++ b/src/frequenz/sdk/timeseries/_formula_engine/_formula_generators/_producer_power_formula.py
@@ -9,11 +9,7 @@ from ....microgrid import connection_manager
 from ....microgrid.component import ComponentCategory, ComponentMetricId
 from ..._quantities import Power
 from .._formula_engine import FormulaEngine
-from ._formula_generator import (
-    NON_EXISTING_COMPONENT_ID,
-    ComponentNotFound,
-    FormulaGenerator,
-)
+from ._formula_generator import NON_EXISTING_COMPONENT_ID, FormulaGenerator
 
 
 class ProducerPowerFormula(FormulaGenerator[Power]):
@@ -39,19 +35,7 @@ class ProducerPowerFormula(FormulaGenerator[Power]):
             "producer_power", ComponentMetricId.ACTIVE_POWER, Power.from_watts
         )
         component_graph = connection_manager.get().component_graph
-        grid_component = next(
-            iter(
-                component_graph.components(component_category={ComponentCategory.GRID})
-            ),
-            None,
-        )
-
-        if grid_component is None:
-            raise ComponentNotFound("Grid component not found in the component graph.")
-
-        grid_successors = component_graph.successors(grid_component.component_id)
-        if not grid_successors:
-            raise ComponentNotFound("No components found in the component graph.")
+        grid_successors = self._get_grid_component_successors()
 
         if len(grid_successors) == 1:
             grid_meter = next(iter(grid_successors))

--- a/tests/timeseries/mock_microgrid.py
+++ b/tests/timeseries/mock_microgrid.py
@@ -295,26 +295,20 @@ class MockMicrogrid:  # pylint: disable=too-many-instance-attributes
                 self._connections.add(Connection(meter_id, inv_id))
             self._connections.add(Connection(inv_id, bat_id))
 
-    def add_solar_inverters(self, count: int) -> None:
+    def add_solar_inverters(self, count: int, no_meter: bool = False) -> None:
         """Add pv inverters and connected pv meters to the microgrid.
 
         Args:
             count: number of inverters to add to the microgrid.
+            no_meter: if True, do not add a meter for each inverter.
         """
         for _ in range(count):
             meter_id = self._id_increment * 10 + self.meter_id_suffix
             inv_id = self._id_increment * 10 + self.inverter_id_suffix
             self._id_increment += 1
 
-            self.meter_ids.append(meter_id)
             self.pv_inverter_ids.append(inv_id)
 
-            self._components.add(
-                Component(
-                    meter_id,
-                    ComponentCategory.METER,
-                )
-            )
             self._components.add(
                 Component(
                     inv_id,
@@ -323,9 +317,20 @@ class MockMicrogrid:  # pylint: disable=too-many-instance-attributes
                 )
             )
             self._start_inverter_streaming(inv_id)
-            self._start_meter_streaming(meter_id)
-            self._connections.add(Connection(self._connect_to, meter_id))
-            self._connections.add(Connection(meter_id, inv_id))
+
+            if no_meter:
+                self._connections.add(Connection(self._connect_to, inv_id))
+            else:
+                self.meter_ids.append(meter_id)
+                self._components.add(
+                    Component(
+                        meter_id,
+                        ComponentCategory.METER,
+                    )
+                )
+                self._start_meter_streaming(meter_id)
+                self._connections.add(Connection(self._connect_to, meter_id))
+                self._connections.add(Connection(meter_id, inv_id))
 
     def add_ev_chargers(self, count: int) -> None:
         """Add EV Chargers to the microgrid.

--- a/tests/timeseries/mock_resampler.py
+++ b/tests/timeseries/mock_resampler.py
@@ -145,6 +145,13 @@ class MockResampler:
             sample = Sample(self._next_ts, None if not value else Quantity(value))
             await chan.send(sample)
 
+    async def send_pv_inverter_power(self, values: list[float | None]) -> None:
+        """Send the given values as resampler output for PV Inverter power."""
+        assert len(values) == len(self._pv_inverter_power_senders)
+        for chan, value in zip(self._pv_inverter_power_senders, values):
+            sample = Sample(self._next_ts, None if not value else Quantity(value))
+            await chan.send(sample)
+
     async def send_evc_power(self, values: list[float | None]) -> None:
         """Send the given values as resampler output for EV Charger power."""
         assert len(values) == len(self._ev_power_senders)


### PR DESCRIPTION
- Put frequently used code in base function.
- Properly handle PV power requests when no or only some meters exist.
  So far we only had configurations like this: Meter -> Inverter -> PV. However
the scenario with Inverter -> PV is also possible and now handled correctly.
