### PR TITLE
Fix `consumer_power()` not working certain configurations.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -19,3 +19,6 @@
   component.
   So far we only had configurations like this: Meter -> Inverter -> PV. However
   the scenario with Inverter -> PV is also possible and now handled correctly.
+- Fix `consumer_power()` not working certain configurations.
+  In microgrids without consumers and no main meter, the formula
+  would never return any values.

--- a/benchmarks/timeseries/benchmark_datasourcing.py
+++ b/benchmarks/timeseries/benchmark_datasourcing.py
@@ -70,7 +70,7 @@ async def benchmark_data_sourcing(
         num_ev_chargers * len(COMPONENT_METRIC_IDS) * num_msgs_per_battery
     )
     mock_grid = MockMicrogrid(
-        grid_side_meter=False, num_values=num_msgs_per_battery, sample_rate_s=0.0
+        grid_meter=False, num_values=num_msgs_per_battery, sample_rate_s=0.0
     )
 
     mock_grid.add_ev_chargers(num_ev_chargers)

--- a/tests/actor/test_battery_pool_status.py
+++ b/tests/actor/test_battery_pool_status.py
@@ -30,7 +30,7 @@ class TestBatteryPoolStatus:
         Args:
             mock_microgrid: mock microgrid client
         """
-        mock_microgrid = MockMicrogrid(grid_side_meter=True)
+        mock_microgrid = MockMicrogrid(grid_meter=True)
         mock_microgrid.add_batteries(3)
         await mock_microgrid.start(mocker)
 

--- a/tests/actor/test_battery_status.py
+++ b/tests/actor/test_battery_status.py
@@ -156,7 +156,7 @@ class TestBatteryStatus:
         Args:
             mock_microgrid: mock_microgrid fixture
         """
-        mock_microgrid = MockMicrogrid(grid_side_meter=True)
+        mock_microgrid = MockMicrogrid(grid_meter=True)
         mock_microgrid.add_batteries(3)
         await mock_microgrid.start(mocker)
 
@@ -318,7 +318,7 @@ class TestBatteryStatus:
         Args:
             mock_microgrid: mock_microgrid fixture
         """
-        mock_microgrid = MockMicrogrid(grid_side_meter=True)
+        mock_microgrid = MockMicrogrid(grid_meter=True)
         mock_microgrid.add_batteries(3)
         await mock_microgrid.start(mocker)
 
@@ -435,7 +435,7 @@ class TestBatteryStatus:
         Args:
             mock_microgrid: mock_microgrid fixture
         """
-        mock_microgrid = MockMicrogrid(grid_side_meter=True)
+        mock_microgrid = MockMicrogrid(grid_meter=True)
         mock_microgrid.add_batteries(3)
         await mock_microgrid.start(mocker)
 
@@ -486,7 +486,7 @@ class TestBatteryStatus:
         Args:
             mock_microgrid: mock_microgrid fixture
         """
-        mock_microgrid = MockMicrogrid(grid_side_meter=True)
+        mock_microgrid = MockMicrogrid(grid_meter=True)
         mock_microgrid.add_batteries(3)
         await mock_microgrid.start(mocker)
 
@@ -547,7 +547,7 @@ class TestBatteryStatus:
             mock_microgrid: mock_microgrid fixture
             mocker: pytest mocker instance
         """
-        mock_microgrid = MockMicrogrid(grid_side_meter=True)
+        mock_microgrid = MockMicrogrid(grid_meter=True)
         mock_microgrid.add_batteries(3)
         await mock_microgrid.start(mocker)
 
@@ -609,7 +609,7 @@ class TestBatteryStatus:
         Args:
             mock_microgrid: mock_microgrid fixture
         """
-        mock_microgrid = MockMicrogrid(grid_side_meter=True)
+        mock_microgrid = MockMicrogrid(grid_meter=True)
         mock_microgrid.add_batteries(3)
         await mock_microgrid.start(mocker)
 
@@ -690,7 +690,7 @@ class TestBatteryStatusRecovery:
         self, mocker: MockerFixture
     ) -> AsyncIterator[tuple[MockMicrogrid, Receiver[Status]]]:
         """Setup a BatteryStatusTracker instance to run tests with."""
-        mock_microgrid = MockMicrogrid(grid_side_meter=True)
+        mock_microgrid = MockMicrogrid(grid_meter=True)
         mock_microgrid.add_batteries(1)
         await mock_microgrid.start(mocker)
 

--- a/tests/actor/test_power_distributing.py
+++ b/tests/actor/test_power_distributing.py
@@ -47,7 +47,7 @@ class TestPowerDistributingActor:
 
     async def test_constructor(self, mocker: MockerFixture) -> None:
         """Test if gets all necessary data."""
-        mockgrid = MockMicrogrid(grid_side_meter=True)
+        mockgrid = MockMicrogrid(grid_meter=True)
         mockgrid.add_batteries(2)
         mockgrid.add_batteries(1, no_meter=True)
         await mockgrid.start(mocker)
@@ -68,7 +68,7 @@ class TestPowerDistributingActor:
         await mockgrid.cleanup()
 
         # Test if it works without grid side meter
-        mockgrid = MockMicrogrid(grid_side_meter=False)
+        mockgrid = MockMicrogrid(grid_meter=False)
         mockgrid.add_batteries(1)
         mockgrid.add_batteries(2, no_meter=True)
         await mockgrid.start(mocker)
@@ -108,7 +108,7 @@ class TestPowerDistributingActor:
 
     async def test_power_distributor_one_user(self, mocker: MockerFixture) -> None:
         """Test if power distribution works with single user works."""
-        mockgrid = MockMicrogrid(grid_side_meter=False)
+        mockgrid = MockMicrogrid(grid_meter=False)
         mockgrid.add_batteries(3)
         await mockgrid.start(mocker)
         await self.init_component_data(mockgrid)
@@ -157,7 +157,7 @@ class TestPowerDistributingActor:
 
     async def test_battery_soc_nan(self, mocker: MockerFixture) -> None:
         """Test if battery with SoC==NaN is not used."""
-        mockgrid = MockMicrogrid(grid_side_meter=False)
+        mockgrid = MockMicrogrid(grid_meter=False)
         mockgrid.add_batteries(3)
         await mockgrid.start(mocker)
         await self.init_component_data(mockgrid)
@@ -222,7 +222,7 @@ class TestPowerDistributingActor:
 
     async def test_battery_capacity_nan(self, mocker: MockerFixture) -> None:
         """Test battery with capacity set to NaN is not used."""
-        mockgrid = MockMicrogrid(grid_side_meter=False)
+        mockgrid = MockMicrogrid(grid_meter=False)
         mockgrid.add_batteries(3)
         await mockgrid.start(mocker)
         await self.init_component_data(mockgrid)
@@ -280,7 +280,7 @@ class TestPowerDistributingActor:
 
     async def test_battery_power_bounds_nan(self, mocker: MockerFixture) -> None:
         """Test battery with power bounds set to NaN is not used."""
-        mockgrid = MockMicrogrid(grid_side_meter=False)
+        mockgrid = MockMicrogrid(grid_meter=False)
         mockgrid.add_batteries(3)
         await mockgrid.start(mocker)
         await self.init_component_data(mockgrid)
@@ -356,7 +356,7 @@ class TestPowerDistributingActor:
         self, mocker: MockerFixture
     ) -> None:
         """Test if power distribution raises error if any battery id is invalid."""
-        mockgrid = MockMicrogrid(grid_side_meter=False)
+        mockgrid = MockMicrogrid(grid_meter=False)
         mockgrid.add_batteries(3)
         await mockgrid.start(mocker)
         await self.init_component_data(mockgrid)
@@ -404,7 +404,7 @@ class TestPowerDistributingActor:
         self, mocker: MockerFixture
     ) -> None:
         """Test if power distribution works with single user works."""
-        mockgrid = MockMicrogrid(grid_side_meter=False)
+        mockgrid = MockMicrogrid(grid_meter=False)
         mockgrid.add_batteries(3)
         await mockgrid.start(mocker)
         await self.init_component_data(mockgrid)
@@ -457,7 +457,7 @@ class TestPowerDistributingActor:
         self, mocker: MockerFixture
     ) -> None:
         """Test if power distribution works with single user works."""
-        mockgrid = MockMicrogrid(grid_side_meter=False)
+        mockgrid = MockMicrogrid(grid_meter=False)
         mockgrid.add_batteries(3)
         await mockgrid.start(mocker)
         await self.init_component_data(mockgrid)
@@ -510,7 +510,7 @@ class TestPowerDistributingActor:
         self, mocker: MockerFixture
     ) -> None:
         """Test if power distribution works with single user works."""
-        mockgrid = MockMicrogrid(grid_side_meter=False)
+        mockgrid = MockMicrogrid(grid_meter=False)
         mockgrid.add_batteries(3)
         await mockgrid.start(mocker)
         await self.init_component_data(mockgrid)
@@ -561,7 +561,7 @@ class TestPowerDistributingActor:
 
     async def test_not_all_batteries_are_working(self, mocker: MockerFixture) -> None:
         """Test if power distribution works if not all batteries are working."""
-        mockgrid = MockMicrogrid(grid_side_meter=False)
+        mockgrid = MockMicrogrid(grid_meter=False)
         mockgrid.add_batteries(3)
         await mockgrid.start(mocker)
         await self.init_component_data(mockgrid)
@@ -615,7 +615,7 @@ class TestPowerDistributingActor:
         self, mocker: MockerFixture
     ) -> None:
         """Test all batteries are used if none of them works."""
-        mockgrid = MockMicrogrid(grid_side_meter=False)
+        mockgrid = MockMicrogrid(grid_meter=False)
         mockgrid.add_batteries(3)
         await mockgrid.start(mocker)
         await self.init_component_data(mockgrid)
@@ -668,7 +668,7 @@ class TestPowerDistributingActor:
         self, mocker: MockerFixture
     ) -> None:
         """Test force request when a battery is not working."""
-        mockgrid = MockMicrogrid(grid_side_meter=False)
+        mockgrid = MockMicrogrid(grid_meter=False)
         mockgrid.add_batteries(3)
         await mockgrid.start(mocker)
         await self.init_component_data(mockgrid)
@@ -724,7 +724,7 @@ class TestPowerDistributingActor:
     ) -> None:
         """Test battery with NaN in SoC, capacity or power is used if request is forced."""
         # pylint: disable=too-many-locals
-        mockgrid = MockMicrogrid(grid_side_meter=False)
+        mockgrid = MockMicrogrid(grid_meter=False)
         mockgrid.add_batteries(3)
         await mockgrid.start(mocker)
         await self.init_component_data(mockgrid)
@@ -797,7 +797,7 @@ class TestPowerDistributingActor:
         self, mocker: MockerFixture
     ) -> None:
         """Test battery with NaN in SoC, capacity or power is used if request is forced."""
-        mockgrid = MockMicrogrid(grid_side_meter=False)
+        mockgrid = MockMicrogrid(grid_meter=False)
         mockgrid.add_batteries(3)
         await mockgrid.start(mocker)
         await self.init_component_data(mockgrid)

--- a/tests/timeseries/_battery_pool/test_battery_pool.py
+++ b/tests/timeseries/_battery_pool/test_battery_pool.py
@@ -461,7 +461,7 @@ async def run_test_battery_status_channel(  # pylint: disable=too-many-arguments
 
 async def test_battery_pool_power(mocker: MockerFixture) -> None:
     """Test `BatteryPool.{,production,consumption}_power` methods."""
-    mockgrid = MockMicrogrid(grid_side_meter=True)
+    mockgrid = MockMicrogrid(grid_meter=True)
     mockgrid.add_batteries(2)
     await mockgrid.start(mocker)
 

--- a/tests/timeseries/mock_resampler.py
+++ b/tests/timeseries/mock_resampler.py
@@ -145,6 +145,13 @@ class MockResampler:
             sample = Sample(self._next_ts, None if not value else Quantity(value))
             await chan.send(sample)
 
+    async def send_chp_power(self, values: list[float | None]) -> None:
+        """Send the given values as resampler output for CHP power."""
+        assert len(values) == len(self._chp_power_senders)
+        for chan, value in zip(self._chp_power_senders, values):
+            sample = Sample(self._next_ts, None if not value else Quantity(value))
+            await chan.send(sample)
+
     async def send_pv_inverter_power(self, values: list[float | None]) -> None:
         """Send the given values as resampler output for PV Inverter power."""
         assert len(values) == len(self._pv_inverter_power_senders)

--- a/tests/timeseries/test_ev_charger_pool.py
+++ b/tests/timeseries/test_ev_charger_pool.py
@@ -29,7 +29,7 @@ class TestEVChargerPool:
         """Test ev charger state updates are visible."""
 
         mockgrid = MockMicrogrid(
-            grid_side_meter=False, api_client_streaming=True, sample_rate_s=0.01
+            grid_meter=False, api_client_streaming=True, sample_rate_s=0.01
         )
         mockgrid.add_ev_chargers(5)
         await mockgrid.start(mocker)
@@ -81,7 +81,7 @@ class TestEVChargerPool:
         mocker: MockerFixture,
     ) -> None:
         """Test the ev power formula."""
-        mockgrid = MockMicrogrid(grid_side_meter=False)
+        mockgrid = MockMicrogrid(grid_meter=False)
         mockgrid.add_ev_chargers(3)
         await mockgrid.start(mocker)
 
@@ -105,7 +105,7 @@ class TestEVChargerPool:
     async def test_ev_component_data(self, mocker: MockerFixture) -> None:
         """Test the component_data method of EVChargerPool."""
         mockgrid = MockMicrogrid(
-            grid_side_meter=False,
+            grid_meter=False,
             api_client_streaming=True,
             sample_rate_s=0.05,
         )

--- a/tests/timeseries/test_logical_meter.py
+++ b/tests/timeseries/test_logical_meter.py
@@ -267,6 +267,21 @@ class TestLogicalMeter:
         await mockgrid.mock_resampler.send_meter_power([20.0, 2.0, 3.0, 4.0, 5.0])
         assert (await consumer_power_receiver.receive()).value == Power.from_watts(20.0)
 
+    async def test_consumer_power_no_grid_meter_no_consumer_meter(
+        self, mocker: MockerFixture
+    ) -> None:
+        """Test the consumer power formula without a grid meter."""
+        mockgrid = MockMicrogrid(grid_meter=False)
+        mockgrid.add_batteries(2)
+        mockgrid.add_solar_inverters(2)
+        await mockgrid.start(mocker)
+
+        logical_meter = microgrid.logical_meter()
+        consumer_power_receiver = logical_meter.consumer_power.new_receiver()
+
+        await mockgrid.mock_resampler.send_non_existing_component_value()
+        assert (await consumer_power_receiver.receive()).value == Power.from_watts(0.0)
+
     async def test_producer_power(self, mocker: MockerFixture) -> None:
         """Test the producer power formula."""
         mockgrid = MockMicrogrid(grid_meter=False)

--- a/tests/timeseries/test_logical_meter.py
+++ b/tests/timeseries/test_logical_meter.py
@@ -22,7 +22,7 @@ class TestLogicalMeter:
 
     async def test_grid_power_1(self, mocker: MockerFixture) -> None:
         """Test the grid power formula with a grid side meter."""
-        mockgrid = MockMicrogrid(grid_side_meter=True)
+        mockgrid = MockMicrogrid(grid_meter=True)
         mockgrid.add_batteries(2)
         mockgrid.add_solar_inverters(1)
         await mockgrid.start(mocker)
@@ -30,39 +30,40 @@ class TestLogicalMeter:
 
         grid_power_recv = logical_meter.grid_power.new_receiver()
 
-        main_meter_recv = get_resampled_stream(
+        grid_meter_recv = get_resampled_stream(
             logical_meter._namespace,  # pylint: disable=protected-access
-            mockgrid.main_meter_id,
+            mockgrid.meter_ids[0],
             ComponentMetricId.ACTIVE_POWER,
             Power.from_watts,
         )
 
         results = []
-        main_meter_data = []
+        grid_meter_data = []
         for count in range(10):
             await mockgrid.mock_resampler.send_meter_power(
                 [20.0 + count, 12.0, -13.0, -5.0]
             )
-            val = await main_meter_recv.receive()
+            val = await grid_meter_recv.receive()
             assert (
                 val is not None
                 and val.value is not None
                 and val.value.as_watts() != 0.0
             )
-            main_meter_data.append(val.value)
+            grid_meter_data.append(val.value)
 
             val = await grid_power_recv.receive()
             assert val is not None and val.value is not None
             results.append(val.value)
         await mockgrid.cleanup()
-        assert equal_float_lists(results, main_meter_data)
+        assert equal_float_lists(results, grid_meter_data)
 
     async def test_grid_power_2(
         self,
         mocker: MockerFixture,
     ) -> None:
         """Test the grid power formula without a grid side meter."""
-        mockgrid = MockMicrogrid(grid_side_meter=False)
+        mockgrid = MockMicrogrid(grid_meter=False)
+        mockgrid.add_consumer_meters(1)
         mockgrid.add_batteries(1, no_meter=False)
         mockgrid.add_batteries(1, no_meter=True)
         mockgrid.add_solar_inverters(1)
@@ -110,12 +111,13 @@ class TestLogicalMeter:
         assert len(results) == 10
         assert equal_float_lists(results, meter_sums)
 
-    async def test_grid_production_consumption_power(
+    async def test_grid_production_consumption_power_consumer_meter(
         self,
         mocker: MockerFixture,
     ) -> None:
         """Test the grid production and consumption power formulas."""
-        mockgrid = MockMicrogrid(grid_side_meter=False)
+        mockgrid = MockMicrogrid(grid_meter=False)
+        mockgrid.add_consumer_meters()
         mockgrid.add_batteries(2)
         mockgrid.add_solar_inverters(1)
         await mockgrid.start(mocker)
@@ -137,7 +139,7 @@ class TestLogicalMeter:
 
     async def test_chp_power(self, mocker: MockerFixture) -> None:
         """Test the chp power formula."""
-        mockgrid = MockMicrogrid(grid_side_meter=False)
+        mockgrid = MockMicrogrid(grid_meter=False)
         mockgrid.add_chps(1)
         mockgrid.add_batteries(2)
         await mockgrid.start(mocker)
@@ -151,7 +153,7 @@ class TestLogicalMeter:
             logical_meter.chp_consumption_power.new_receiver()
         )
 
-        await mockgrid.mock_resampler.send_meter_power([1.0, 2.0, 3.0, 4.0])
+        await mockgrid.mock_resampler.send_meter_power([2.0, 3.0, 4.0])
         assert (await chp_power_receiver.receive()).value == Power.from_watts(2.0)
         assert (
             await chp_production_power_receiver.receive()
@@ -160,7 +162,7 @@ class TestLogicalMeter:
             await chp_consumption_power_receiver.receive()
         ).value == Power.from_watts(2.0)
 
-        await mockgrid.mock_resampler.send_meter_power([-4.0, -12.0, None, 10.2])
+        await mockgrid.mock_resampler.send_meter_power([-12.0, None, 10.2])
         assert (await chp_power_receiver.receive()).value == Power.from_watts(-12.0)
         assert (
             await chp_production_power_receiver.receive()
@@ -171,7 +173,7 @@ class TestLogicalMeter:
 
     async def test_pv_power(self, mocker: MockerFixture) -> None:
         """Test the pv power formula."""
-        mockgrid = MockMicrogrid(grid_side_meter=False)
+        mockgrid = MockMicrogrid(grid_meter=False)
         mockgrid.add_solar_inverters(2)
         await mockgrid.start(mocker)
 
@@ -182,7 +184,7 @@ class TestLogicalMeter:
             logical_meter.pv_consumption_power.new_receiver()
         )
 
-        await mockgrid.mock_resampler.send_meter_power([10.0, -1.0, -2.0])
+        await mockgrid.mock_resampler.send_meter_power([-1.0, -2.0])
         assert (await pv_power_receiver.receive()).value == Power.from_watts(-3.0)
         assert (await pv_production_power_receiver.receive()).value == Power.from_watts(
             3.0
@@ -193,7 +195,7 @@ class TestLogicalMeter:
 
     async def test_pv_power_no_meter(self, mocker: MockerFixture) -> None:
         """Test the pv power formula."""
-        mockgrid = MockMicrogrid(grid_side_meter=False)
+        mockgrid = MockMicrogrid(grid_meter=False)
         mockgrid.add_solar_inverters(2, no_meter=True)
         await mockgrid.start(mocker)
 
@@ -215,7 +217,7 @@ class TestLogicalMeter:
 
     async def test_consumer_power_grid_meter(self, mocker: MockerFixture) -> None:
         """Test the consumer power formula with a grid meter."""
-        mockgrid = MockMicrogrid(grid_side_meter=True)
+        mockgrid = MockMicrogrid(grid_meter=True)
         mockgrid.add_batteries(2)
         mockgrid.add_solar_inverters(2)
         await mockgrid.start(mocker)
@@ -228,7 +230,8 @@ class TestLogicalMeter:
 
     async def test_consumer_power_no_grid_meter(self, mocker: MockerFixture) -> None:
         """Test the consumer power formula without a grid meter."""
-        mockgrid = MockMicrogrid(grid_side_meter=False)
+        mockgrid = MockMicrogrid(grid_meter=False)
+        mockgrid.add_consumer_meters()
         mockgrid.add_batteries(2)
         mockgrid.add_solar_inverters(2)
         await mockgrid.start(mocker)
@@ -241,7 +244,7 @@ class TestLogicalMeter:
 
     async def test_producer_power(self, mocker: MockerFixture) -> None:
         """Test the producer power formula."""
-        mockgrid = MockMicrogrid(grid_side_meter=False)
+        mockgrid = MockMicrogrid(grid_meter=False)
         mockgrid.add_solar_inverters(2)
         mockgrid.add_chps(2)
         await mockgrid.start(mocker)
@@ -249,24 +252,26 @@ class TestLogicalMeter:
         logical_meter = microgrid.logical_meter()
         producer_power_receiver = logical_meter.producer_power.new_receiver()
 
-        await mockgrid.mock_resampler.send_meter_power([20.0, 2.0, 3.0, 4.0, 5.0])
+        await mockgrid.mock_resampler.send_meter_power([2.0, 3.0, 4.0, 5.0])
         assert (await producer_power_receiver.receive()).value == Power.from_watts(14.0)
 
     async def test_producer_power_no_chp(self, mocker: MockerFixture) -> None:
         """Test the producer power formula without a chp."""
-        mockgrid = MockMicrogrid(grid_side_meter=False)
+        mockgrid = MockMicrogrid(grid_meter=False)
         mockgrid.add_solar_inverters(2)
+
         await mockgrid.start(mocker)
 
         logical_meter = microgrid.logical_meter()
         producer_power_receiver = logical_meter.producer_power.new_receiver()
 
-        await mockgrid.mock_resampler.send_meter_power([20.0, 2.0, 3.0])
+        await mockgrid.mock_resampler.send_meter_power([2.0, 3.0])
         assert (await producer_power_receiver.receive()).value == Power.from_watts(5.0)
 
     async def test_producer_power_no_pv(self, mocker: MockerFixture) -> None:
         """Test the producer power formula without pv."""
-        mockgrid = MockMicrogrid(grid_side_meter=False)
+        mockgrid = MockMicrogrid(grid_meter=False)
+        mockgrid.add_consumer_meters()
         mockgrid.add_chps(1)
         await mockgrid.start(mocker)
 
@@ -278,7 +283,7 @@ class TestLogicalMeter:
 
     async def test_no_producer_power(self, mocker: MockerFixture) -> None:
         """Test the producer power formula without producers."""
-        mockgrid = MockMicrogrid(grid_side_meter=False)
+        mockgrid = MockMicrogrid(grid_meter=True)
         await mockgrid.start(mocker)
 
         logical_meter = microgrid.logical_meter()


### PR DESCRIPTION
- Fix MockMicrogrid bug not properly disabling main meter
- Fix `consumer_power()` not working certain configurations.
    In microgrids without consumers and no main meter, the formula
    would never return any values.
    This was undiscovered as we didn't test that scenario in the MockMicrogrid class used
    for testing.
