### PR TITLE
Add depth first search for components 

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,7 +10,7 @@
 
 ## New Features
 
-<!-- Here goes the main new features and examples or instructions on how to use them -->
+- DFS for compentent graph
 
 ## Bug Fixes
 

--- a/src/frequenz/sdk/timeseries/_formula_engine/_formula_generators/_formula_generator.py
+++ b/src/frequenz/sdk/timeseries/_formula_engine/_formula_generators/_formula_generator.py
@@ -101,15 +101,15 @@ class FormulaGenerator(ABC, Generic[QuantityT]):
         )
         return builder
 
-    def _get_grid_component_successors(self) -> set[component.Component]:
-        """Get the set of grid component successors in the component graph.
+    def _get_grid_component(self) -> component.Component:
+        """
+        Get the grid component in the component graph.
 
         Returns:
-            A set of grid component successors.
+            The first grid component found in the graph.
 
         Raises:
             ComponentNotFound: If the grid component is not found in the component graph.
-            ComponentNotFound: If no successor components are found in the component graph.
         """
         component_graph = connection_manager.get().component_graph
         grid_component = next(
@@ -120,10 +120,22 @@ class FormulaGenerator(ABC, Generic[QuantityT]):
             ),
             None,
         )
-
         if grid_component is None:
             raise ComponentNotFound("Grid component not found in the component graph.")
 
+        return grid_component
+
+    def _get_grid_component_successors(self) -> set[component.Component]:
+        """Get the set of grid component successors in the component graph.
+
+        Returns:
+            A set of grid component successors.
+
+        Raises:
+            ComponentNotFound: If no successor components are found in the component graph.
+        """
+        grid_component = self._get_grid_component()
+        component_graph = connection_manager.get().component_graph
         grid_successors = component_graph.successors(grid_component.component_id)
 
         if not grid_successors:


### PR DESCRIPTION
In this PR we add a dfs component search to the component graph. The search continues to go into depth until the condition is fulfilled. The condition has to be provided as a lambda.

Furthermore we add function that returns the grid component such that it can be used in the dfs search, whenever the search should begin at the `GRID` component.