### PR TITLE
[ci] Add test for installation in multiple architectures

### DIFF
--- a/.github/containers/test-installation/Dockerfile
+++ b/.github/containers/test-installation/Dockerfile
@@ -1,0 +1,10 @@
+# This dockerfile is used to test the installation of the python package in
+# multiple platforms in the CI. It is not used to build the package itself.
+
+FROM --platform=${TARGETPLATFORM} python:3.11-slim
+
+RUN python -m pip install --upgrade --no-cache-dir pip
+
+COPY dist dist
+RUN pip install dist/*.whl && \
+    rm -rf dist

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -146,7 +146,7 @@ jobs:
 
   publish-docs:
     name: Publish documentation website to GitHub pages
-    needs: ["nox", "build"]
+    needs: ["nox", "test-installation"]
     if: github.event_name == 'push'
     runs-on: ubuntu-20.04
     permissions:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -83,6 +83,31 @@ jobs:
           path: dist/
           if-no-files-found: error
 
+  test-installation:
+    name: Test package installation in different architectures
+    needs: ["build"]
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Fetch sources
+        uses: actions/checkout@v3
+      - name: Download package
+        uses: actions/download-artifact@v3
+        with:
+          name: dist-packages
+          path: dist
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up docker-buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Test Installation
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: .github/containers/test-installation/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          tags: localhost/test-installation
+          push: false
+
   test-docs:
     name: Test documentation website generation
     if: github.event_name != 'push'


### PR DESCRIPTION
Users should be able to install the frequenz-sdk package in amd64 and arm64 systems. This commit adds a simple test to the CI to validate this.

The aforementioned test builds a multi-platform docker image with the generated wheel package. If the image gets successfully generated, then the test passes.

Additionally the updated docs are published only if this test is passed.