### PR TITLE
Improve error message for incorrect component graphs

### DIFF
--- a/src/frequenz/sdk/microgrid/_graph.py
+++ b/src/frequenz/sdk/microgrid/_graph.py
@@ -491,6 +491,7 @@ class _MicrogridComponentGraph(ComponentGraph):
         try:
             _provisional.validate()
         except Exception as err:
+            _logger.error("Failed to parse component graph: %s", err)
             raise InvalidGraphError(
                 "Cannot populate component graph from provided input!"
             ) from err


### PR DESCRIPTION
The error message did not show the cause when validations for component graphs would fail. The error message has been updated to show it now.