### PR TITLE
Replace absolute imports with relative imports

### DIFF
--- a/src/frequenz/sdk/actor/power_distributing/_battery_status.py
+++ b/src/frequenz/sdk/actor/power_distributing/_battery_status.py
@@ -22,9 +22,9 @@ from frequenz.api.microgrid.inverter_pb2 import ComponentState as InverterCompon
 from frequenz.channels import Receiver, Sender
 from frequenz.channels.util import Timer, select, selected_from
 
-from frequenz.sdk._internal._asyncio import cancel_and_await
-from frequenz.sdk.microgrid import connection_manager
-from frequenz.sdk.microgrid.component import (
+from ..._internal._asyncio import cancel_and_await
+from ...microgrid import connection_manager
+from ...microgrid.component import (
     BatteryData,
     ComponentCategory,
     ComponentData,

--- a/src/frequenz/sdk/actor/power_distributing/_distribution_algorithm/_distribution_algorithm.py
+++ b/src/frequenz/sdk/actor/power_distributing/_distribution_algorithm/_distribution_algorithm.py
@@ -8,8 +8,7 @@ import math
 from dataclasses import dataclass
 from typing import Dict, List, NamedTuple, Tuple
 
-from frequenz.sdk._internal._math import is_close_to_zero
-
+from ...._internal._math import is_close_to_zero
 from ....microgrid.component import BatteryData, InverterData
 
 _logger = logging.getLogger(__name__)

--- a/src/frequenz/sdk/timeseries/ev_charger_pool/_state_tracker.py
+++ b/src/frequenz/sdk/timeseries/ev_charger_pool/_state_tracker.py
@@ -12,9 +12,8 @@ from typing import Optional
 from frequenz.channels import Receiver
 from frequenz.channels.util import Merge
 
-from frequenz.sdk import microgrid
-from frequenz.sdk._internal._asyncio import cancel_and_await
-
+from ... import microgrid
+from ..._internal._asyncio import cancel_and_await
 from ...microgrid.component import (
     EVChargerCableState,
     EVChargerComponentState,


### PR DESCRIPTION
The issues with absolute imports were reported when running mypy directly, as `.nox/mypy/bin/mypy --strict src/`.

E.g., the older version of `_distribution_algorithm.py` causes the error:
```
$ .nox/mypy/bin/mypy --strict src/
src/frequenz/sdk/microgrid/_graph.py: error: Source file found twice under different module names: "sdk._internal._math" and "frequenz.sdk._internal._math"
src/frequenz/sdk/microgrid/_graph.py: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#mapping-file-paths-to-modules for more info
src/frequenz/sdk/microgrid/_graph.py: note: Common resolutions include: a) adding `__init__.py` somewhere, b) using `--explicit-package-bases` or adjusting MYPYPATH
Found 1 error in 1 file (errors prevented further checking
```