### PR TITLE
Make nones_are_zeros a keyword-only parameter

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -90,6 +90,8 @@ This release replaces the `@actor` decorator with a new `Actor` class.
 
 - Within the `EVChargerPool.set_bounds` method, the parameter `max_amps` has been redefined as `max_current`, and it is now represented using a `Current` object instead of a `float`.
 
+- The argument `nones_are_zeros` in `FormulaEngine` and related classes and methods is now a keyword-only argument.
+
 ## New Features
 
 - Added `DFS` to the component graph

--- a/src/frequenz/sdk/timeseries/_formula_engine/_formula_engine_pool.py
+++ b/src/frequenz/sdk/timeseries/_formula_engine/_formula_engine_pool.py
@@ -55,6 +55,7 @@ class FormulaEnginePool:
         self,
         formula: str,
         component_metric_id: ComponentMetricId,
+        *,
         nones_are_zeros: bool = False,
     ) -> FormulaEngine[Quantity]:
         """Get a receiver for a manual formula.
@@ -81,7 +82,7 @@ class FormulaEnginePool:
             component_metric_id,
             Quantity,
         )
-        formula_engine = builder.from_string(formula, nones_are_zeros)
+        formula_engine = builder.from_string(formula, nones_are_zeros=nones_are_zeros)
         self._string_engines[channel_key] = formula_engine
 
         return formula_engine

--- a/src/frequenz/sdk/timeseries/_formula_engine/_formula_steps.py
+++ b/src/frequenz/sdk/timeseries/_formula_engine/_formula_steps.py
@@ -268,6 +268,7 @@ class MetricFetcher(Generic[QuantityT], FormulaStep):
         self,
         name: str,
         stream: Receiver[Sample[QuantityT]],
+        *,
         nones_are_zeros: bool,
     ) -> None:
         """Create a `MetricFetcher` instance.

--- a/src/frequenz/sdk/timeseries/_formula_engine/_resampled_formula_builder.py
+++ b/src/frequenz/sdk/timeseries/_formula_engine/_resampled_formula_builder.py
@@ -84,11 +84,12 @@ class ResampledFormulaBuilder(Generic[QuantityT], FormulaBuilder[QuantityT]):
                 False, the returned value will be a None.
         """
         receiver = self._get_resampled_receiver(component_id, self._metric_id)
-        self.push_metric(f"#{component_id}", receiver, nones_are_zeros)
+        self.push_metric(f"#{component_id}", receiver, nones_are_zeros=nones_are_zeros)
 
     def from_string(
         self,
         formula: str,
+        *,
         nones_are_zeros: bool,
     ) -> FormulaEngine[QuantityT]:
         """Construct a `FormulaEngine` from the given formula string.

--- a/src/frequenz/sdk/timeseries/logical_meter/_logical_meter.py
+++ b/src/frequenz/sdk/timeseries/logical_meter/_logical_meter.py
@@ -123,6 +123,7 @@ class LogicalMeter:
         self,
         formula: str,
         component_metric_id: ComponentMetricId,
+        *,
         nones_are_zeros: bool = False,
     ) -> FormulaEngine[Quantity]:
         """Start execution of the given formula.
@@ -144,7 +145,7 @@ class LogicalMeter:
             A FormulaEngine that applies the formula and streams values.
         """
         return self._formula_pool.from_string(
-            formula, component_metric_id, nones_are_zeros
+            formula, component_metric_id, nones_are_zeros=nones_are_zeros
         )
 
     @property

--- a/tests/timeseries/test_formula_engine.py
+++ b/tests/timeseries/test_formula_engine.py
@@ -65,7 +65,7 @@ class TestFormulaEngine:
                 builder.push_metric(
                     f"#{token.value}",
                     channels[token.value].new_receiver(),
-                    nones_are_zeros,
+                    nones_are_zeros=nones_are_zeros,
                 )
             elif token.type == TokenType.OPER:
                 builder.push_oper(token.value)
@@ -345,7 +345,7 @@ class TestFormulaEngineComposition:
             for ctr in range(num_items)
         ]
         builder = make_builder(*l1_engines)
-        engine = builder.build("l2 formula", nones_are_zeros)
+        engine = builder.build("l2 formula", nones_are_zeros=nones_are_zeros)
         result_chan = engine.new_receiver()
 
         now = datetime.now()
@@ -651,11 +651,15 @@ class TestConstantValue:
         sender_2 = channel_2.new_sender()
 
         builder = FormulaBuilder("test_constant_value", create_method=Quantity)
-        builder.push_metric("channel_1", channel_1.new_receiver(), False)
+        builder.push_metric(
+            "channel_1", channel_1.new_receiver(), nones_are_zeros=False
+        )
         builder.push_oper("+")
         builder.push_constant(2.0)
         builder.push_oper("*")
-        builder.push_metric("channel_2", channel_2.new_receiver(), False)
+        builder.push_metric(
+            "channel_2", channel_2.new_receiver(), nones_are_zeros=False
+        )
 
         engine = builder.build()
 
@@ -672,12 +676,16 @@ class TestConstantValue:
 
         builder = FormulaBuilder("test_constant_value", create_method=Quantity)
         builder.push_oper("(")
-        builder.push_metric("channel_1", channel_1.new_receiver(), False)
+        builder.push_metric(
+            "channel_1", channel_1.new_receiver(), nones_are_zeros=False
+        )
         builder.push_oper("+")
         builder.push_constant(2.0)
         builder.push_oper(")")
         builder.push_oper("*")
-        builder.push_metric("channel_2", channel_2.new_receiver(), False)
+        builder.push_metric(
+            "channel_2", channel_2.new_receiver(), nones_are_zeros=False
+        )
 
         engine = builder.build()
 
@@ -705,9 +713,13 @@ class TestClipper:
         sender_2 = channel_2.new_sender()
 
         builder = FormulaBuilder("test_clipper", create_method=Quantity)
-        builder.push_metric("channel_1", channel_1.new_receiver(), False)
+        builder.push_metric(
+            "channel_1", channel_1.new_receiver(), nones_are_zeros=False
+        )
         builder.push_oper("+")
-        builder.push_metric("channel_2", channel_2.new_receiver(), False)
+        builder.push_metric(
+            "channel_2", channel_2.new_receiver(), nones_are_zeros=False
+        )
         builder.push_clipper(0.0, 100.0)
         engine = builder.build()
 
@@ -728,9 +740,13 @@ class TestClipper:
 
         builder = FormulaBuilder("test_clipper", create_method=Quantity)
         builder.push_oper("(")
-        builder.push_metric("channel_1", channel_1.new_receiver(), False)
+        builder.push_metric(
+            "channel_1", channel_1.new_receiver(), nones_are_zeros=False
+        )
         builder.push_oper("+")
-        builder.push_metric("channel_2", channel_2.new_receiver(), False)
+        builder.push_metric(
+            "channel_2", channel_2.new_receiver(), nones_are_zeros=False
+        )
         builder.push_oper(")")
         builder.push_clipper(0.0, 100.0)
         engine = builder.build()
@@ -763,9 +779,13 @@ class TestFormulaOutputTyping:
         sender_2 = channel_2.new_sender()
 
         builder = FormulaBuilder("test_typing", create_method=Power.from_watts)
-        builder.push_metric("channel_1", channel_1.new_receiver(), False)
+        builder.push_metric(
+            "channel_1", channel_1.new_receiver(), nones_are_zeros=False
+        )
         builder.push_oper("+")
-        builder.push_metric("channel_2", channel_2.new_receiver(), False)
+        builder.push_metric(
+            "channel_2", channel_2.new_receiver(), nones_are_zeros=False
+        )
         engine = builder.build()
 
         results_rx = engine.new_receiver()
@@ -787,7 +807,7 @@ class TestFromReceiver:
         sender = channel.new_sender()
 
         builder = FormulaBuilder("test_from_receiver", create_method=Power.from_watts)
-        builder.push_metric("channel_1", channel.new_receiver(), False)
+        builder.push_metric("channel_1", channel.new_receiver(), nones_are_zeros=False)
         engine = builder.build()
 
         engine_from_receiver = FormulaEngine.from_receiver(


### PR DESCRIPTION
Accept keyword-only argument `nones_are_zeros` in `FormulaEngine` and related classes and methods in order to clarify behavior at the caller's end, eliminating the need to inspect function definitions for understanding.

Fixes #100