### PR TITLE
Fixes on copy behavior in ring buffer window method

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -26,6 +26,10 @@
   - NaN values are treated as missing when gaps are determined in the `OrderedRingBuffer`.
   - Provide access to `capacity` (maximum number of elements) in `MovingWindow`.
   - Methods to retrieve oldest and newest timestamp of valid samples are added to both.
+  - `MovingWindow` exposes underlying buffers `window` method.
+  - `OrderedRingBuffer.window`:
+    - By default returns a copy.
+    - Can also return a view if the window contains `None` values and if `force_copy` is set to `True`.
 
 - Now when printing `FormulaEngine` for debugging purposes the the formula will be shown in infix notation, which should be easier to read.
 
@@ -35,4 +39,7 @@
 
 ## Bug Fixes
 
-<!-- Here goes notable bug fixes that are worth a special mention or explanation -->
+- `OrderedRingBuffer.window`:
+  - Fixed `force_copy` option for specific case.
+  - Removed buggy enforcement of copies when None values in queried window.
+  - Fixed behavior for start equals end case.

--- a/src/frequenz/sdk/timeseries/_moving_window.py
+++ b/src/frequenz/sdk/timeseries/_moving_window.py
@@ -241,6 +241,34 @@ class MovingWindow(BackgroundService):
         """
         return self._buffer.maxlen
 
+    def window(
+        self,
+        start: datetime,
+        end: datetime,
+        *,
+        force_copy: bool = True,
+    ) -> ArrayLike:
+        """
+        Return an array containing the samples in the given time interval.
+
+        Args:
+            start: The start of the time interval. Only datetime objects are supported.
+            end: The end of the time interval. Only datetime objects are supported.
+            force_copy: If `True`, the returned array is a copy of the underlying
+                data. Otherwise, if possible, a view of the underlying data is
+                returned.
+
+        Returns:
+            An array containing the samples in the given time interval.
+
+        Raises:
+            IndexError: if `start` or `end` are not datetime objects.
+        """
+        if not isinstance(start, datetime) or not isinstance(end, datetime):
+            raise IndexError("Only datetime objects are supported as start and end.")
+
+        return self._buffer.window(start, end, force_copy=force_copy)
+
     async def _run_impl(self) -> None:
         """Awaits samples from the receiver and updates the underlying ring buffer.
 

--- a/src/frequenz/sdk/timeseries/_ringbuffer/buffer.py
+++ b/src/frequenz/sdk/timeseries/_ringbuffer/buffer.py
@@ -292,6 +292,9 @@ class OrderedRingBuffer(Generic[FloatArray]):
                 f"end parameter {end} has to predate start parameter {start}"
             )
 
+        if start == end:
+            return np.array([]) if isinstance(self._buffer, np.ndarray) else []
+
         start_index = self.datetime_to_index(start)
         end_index = self.datetime_to_index(end)
 

--- a/src/frequenz/sdk/timeseries/_ringbuffer/buffer.py
+++ b/src/frequenz/sdk/timeseries/_ringbuffer/buffer.py
@@ -301,7 +301,10 @@ class OrderedRingBuffer(Generic[FloatArray]):
 
     @staticmethod
     def _wrapped_buffer_window(
-        buffer: FloatArray, start_pos: int, end_pos: int, force_copy: bool = True
+        buffer: FloatArray,
+        start_pos: int,
+        end_pos: int,
+        force_copy: bool = True,
     ) -> FloatArray:
         """Get a wrapped window from the given buffer.
 
@@ -321,17 +324,20 @@ class OrderedRingBuffer(Generic[FloatArray]):
         """
         # Requested window wraps around the ends
         if start_pos >= end_pos:
+            if isinstance(buffer, list):
+                return buffer[start_pos:] + buffer[0:end_pos]
+            assert isinstance(
+                buffer, np.ndarray
+            ), f"Unsupported buffer type: {type(buffer)}"
             if end_pos > 0:
-                if isinstance(buffer, list):
-                    return buffer[start_pos:] + buffer[0:end_pos]
-                if isinstance(buffer, np.ndarray):
-                    return np.concatenate((buffer[start_pos:], buffer[0:end_pos]))
-                assert False, f"Unknown buffer type: {type(buffer)}"
-            return buffer[start_pos:]
+                return np.concatenate((buffer[start_pos:], buffer[0:end_pos]))
+            arr = buffer[start_pos:]
+        else:
+            arr = buffer[start_pos:end_pos]
 
         if force_copy:
-            return deepcopy(buffer[start_pos:end_pos])
-        return buffer[start_pos:end_pos]
+            return deepcopy(arr)
+        return arr
 
     def is_missing(self, timestamp: datetime) -> bool:
         """Check if the given timestamp falls within a gap.

--- a/src/frequenz/sdk/timeseries/_ringbuffer/buffer.py
+++ b/src/frequenz/sdk/timeseries/_ringbuffer/buffer.py
@@ -257,7 +257,7 @@ class OrderedRingBuffer(Generic[FloatArray]):
         )
 
     def window(
-        self, start: datetime, end: datetime, force_copy: bool = False
+        self, start: datetime, end: datetime, *, force_copy: bool = True
     ) -> FloatArray:
         """Request a view on the data between start timestamp and end timestamp.
 
@@ -266,7 +266,7 @@ class OrderedRingBuffer(Generic[FloatArray]):
 
         Will return a copy in the following cases:
         * The requested time period is crossing the start/end of the buffer.
-        * The force_copy parameter was set to True (default False).
+        * The force_copy parameter was set to True (default True).
 
         The first case can be avoided by using the appropriate
         `align_to` value in the constructor so that the data lines up
@@ -278,7 +278,7 @@ class OrderedRingBuffer(Generic[FloatArray]):
         Args:
             start: start time of the window.
             end: end time of the window.
-            force_copy: optional, default False. If True, will always create a
+            force_copy: optional, default True. If True, will always create a
                 copy of the data.
 
         Raises:

--- a/src/frequenz/sdk/timeseries/_ringbuffer/buffer.py
+++ b/src/frequenz/sdk/timeseries/_ringbuffer/buffer.py
@@ -266,7 +266,6 @@ class OrderedRingBuffer(Generic[FloatArray]):
 
         Will return a copy in the following cases:
         * The requested time period is crossing the start/end of the buffer.
-        * The requested time period contains missing entries.
         * The force_copy parameter was set to True (default False).
 
         The first case can be avoided by using the appropriate
@@ -308,10 +307,7 @@ class OrderedRingBuffer(Generic[FloatArray]):
                 assert False, f"Unknown _buffer type: {type(self._buffer)}"
             return self._buffer[start_index:]
 
-        # Return a copy if there are none-values in the data
-        if force_copy or any(
-            map(lambda gap: gap.contains(start) or gap.contains(end), self._gaps)
-        ):
+        if force_copy:
             return deepcopy(self[start_index:end_index])
 
         return self[start_index:end_index]

--- a/tests/timeseries/test_ringbuffer.py
+++ b/tests/timeseries/test_ringbuffer.py
@@ -519,6 +519,6 @@ def test_window() -> None:
     assert [0, np.nan, 2] == list(win)
     buffer._buffer[1] = 1  # pylint: disable=protected-access
     # Test whether the window is a view or a copy
-    assert [0, 1, 2] == list(win)  # NB: second element should be NaN according to docs
+    assert [0, 1, 2] == list(win)
     win = buffer.window(dt(0), dt(3), force_copy=False)
     assert [0, 1, 2] == list(win)

--- a/tests/timeseries/test_ringbuffer.py
+++ b/tests/timeseries/test_ringbuffer.py
@@ -522,6 +522,13 @@ def test_window() -> None:
     assert [0, 1, 2] == list(win)
     win = buffer.window(dt(0), dt(3), force_copy=False)
     assert [0, 1, 2] == list(win)
+    # Empty array
+    assert 0 == buffer.window(dt(1), dt(1)).size
+
+    buffer = get_orb([0.0, 1.0, 2.0, 3.0, 4.0])  # type: ignore
+    assert [0, 1, 2] == buffer.window(dt(0), dt(3))
+    assert [] == buffer.window(dt(0), dt(0))
+    assert [] == buffer.window(dt(1), dt(1))
 
 
 def test_wrapped_buffer_window() -> None:

--- a/tests/timeseries/test_ringbuffer.py
+++ b/tests/timeseries/test_ringbuffer.py
@@ -581,5 +581,5 @@ def test_wrapped_buffer_window() -> None:
     assert [3, 9] == list(res1_view)
     assert [3, 4] == list(res1_copy)
     assert [3, 9] == list(res2_view)
-    # assert [3, 4] == list(res2_copy) #Fails because of a bug
+    assert [3, 4] == list(res2_copy)
     assert [4, 0] == list(res3_copy)


### PR DESCRIPTION
This PR introduces several copy-related updates to the ring buffer window functionality

Changes:
* Default Copy Behavior: Changed the default behavior to copy data in the ring buffer window. This is to prioritize data integrity over performance, which is a minor concern for most expected use-cases. Made `force_copy` as a keyword argument.
* Moved the logic for extracting wrapped buffers into a separate method to fix a bug and allow for better testing and future maintainability.
* Handling None Values: Fixed an issue where None values were being forcibly copied in the ring buffer window. The decision to enforce a copy is now left to the user, even when the data contains None values.
* Test Coverage: Added tests for the window method in the ring buffer, including tests for expected copy behavior on missing values.
* Fix to return an empty array in case start = end in ring buffer window.
* Expose restricted ring buffer window by moving window.

Part of https://github.com/frequenz-floss/frequenz-sdk-python/issues/214