### PR TITLE
Move "fake_time" fixture to conftest.py

### DIFF
--- a/tests/actor/test_resampling.py
+++ b/tests/actor/test_resampling.py
@@ -35,13 +35,6 @@ def event_loop() -> Iterator[async_solipsism.EventLoop]:
     loop.close()
 
 
-@pytest.fixture
-def fake_time() -> Iterator[time_machine.Coordinates]:
-    """Replace real time with a time machine that doesn't automatically tick."""
-    with time_machine.travel(0, tick=False) as traveller:
-        yield traveller
-
-
 def _now() -> datetime:
     return datetime.now(timezone.utc)
 

--- a/tests/actor/test_run_utils.py
+++ b/tests/actor/test_run_utils.py
@@ -23,13 +23,6 @@ def event_loop() -> Iterator[async_solipsism.EventLoop]:
     loop.close()
 
 
-@pytest.fixture
-def fake_time() -> Iterator[time_machine.Coordinates]:
-    """Replace real time with a time machine that doesn't automatically tick."""
-    with time_machine.travel(0, tick=False) as traveller:
-        yield traveller
-
-
 class FaultyActor(Actor):
     """A test faulty actor."""
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ from collections.abc import Iterator
 from datetime import timedelta
 
 import pytest
+import time_machine
 
 from frequenz.sdk.actor import _actor
 
@@ -52,3 +53,10 @@ def actor_auto_restart_once() -> Iterator[None]:
     """Make actors restart only once."""
     with actor_restart_limit(1):
         yield
+
+
+@pytest.fixture
+def fake_time() -> Iterator[time_machine.Coordinates]:
+    """Replace real time with a time machine that doesn't automatically tick."""
+    with time_machine.travel(0, tick=False) as traveller:
+        yield traveller

--- a/tests/timeseries/test_moving_window.py
+++ b/tests/timeseries/test_moving_window.py
@@ -28,13 +28,6 @@ def event_loop() -> Iterator[async_solipsism.EventLoop]:
     loop.close()
 
 
-@pytest.fixture
-def fake_time() -> Iterator[time_machine.Coordinates]:
-    """Replace real time with a time machine that doesn't automatically tick."""
-    with time_machine.travel(0, tick=False) as traveller:
-        yield traveller
-
-
 async def push_logical_meter_data(
     sender: Sender[Sample[Quantity]], test_seq: Sequence[float]
 ) -> None:

--- a/tests/timeseries/test_resampling.py
+++ b/tests/timeseries/test_resampling.py
@@ -48,13 +48,6 @@ def event_loop() -> Iterator[async_solipsism.EventLoop]:
 
 
 @pytest.fixture
-def fake_time() -> Iterator[time_machine.Coordinates]:
-    """Replace real time with a time machine that doesn't automatically tick."""
-    with time_machine.travel(0, tick=False) as traveller:
-        yield traveller
-
-
-@pytest.fixture
 async def source_chan() -> AsyncIterator[Broadcast[Sample[Quantity]]]:
     """Create a broadcast channel of samples."""
     chan = Broadcast[Sample[Quantity]]("test")


### PR DESCRIPTION
"conftest.py" contains fixtures that are shared among multiple test cases.

Fixes #223