### PR TITLE
Replace obsolete types

### DIFF
--- a/benchmarks/power_distribution/power_distributor.py
+++ b/benchmarks/power_distribution/power_distributor.py
@@ -7,8 +7,9 @@ import asyncio
 import csv
 import random
 import timeit
+from collections.abc import Coroutine
 from datetime import timedelta
-from typing import Any, Coroutine, Dict, List, Set  # pylint: disable=unused-import
+from typing import Any, Dict, List, Set  # pylint: disable=unused-import
 
 from frequenz.channels import Broadcast
 
@@ -32,7 +33,7 @@ HOST = "microgrid.sandbox.api.frequenz.io"
 PORT = 61060
 
 
-async def send_requests(batteries: Set[int], request_num: int) -> List[Result]:
+async def send_requests(batteries: set[int], request_num: int) -> list[Result]:
     """Send requests to the PowerDistributingActor and wait for the response.
 
     Args:
@@ -47,7 +48,7 @@ async def send_requests(batteries: Set[int], request_num: int) -> List[Result]:
     """
     battery_pool = microgrid.battery_pool(batteries)
     results_rx = battery_pool.power_distribution_results()
-    result: List[Result] = []
+    result: list[Result] = []
     for _ in range(request_num):
         await battery_pool.set_power(Power(float(random.randrange(100000, 1000000))))
         try:
@@ -61,7 +62,7 @@ async def send_requests(batteries: Set[int], request_num: int) -> List[Result]:
     return result
 
 
-def parse_result(result: List[List[Result]]) -> Dict[str, float]:
+def parse_result(result: list[list[Result]]) -> dict[str, float]:
     """Parse result.
 
     Args:
@@ -91,8 +92,8 @@ def parse_result(result: List[List[Result]]) -> Dict[str, float]:
 
 async def run_test(  # pylint: disable=too-many-locals
     num_requests: int,
-    batteries: Set[int],
-) -> Dict[str, Any]:
+    batteries: set[int],
+) -> dict[str, Any]:
     """Run test.
 
     Args:
@@ -112,7 +113,7 @@ async def run_test(  # pylint: disable=too-many-locals
         requests_receiver=power_request_channel.new_receiver(),
         battery_status_sender=battery_status_channel.new_sender(),
     ):
-        tasks: List[Coroutine[Any, Any, List[Result]]] = []
+        tasks: list[Coroutine[Any, Any, list[Result]]] = []
         tasks.append(send_requests(batteries, num_requests))
 
         result = await asyncio.gather(*tasks)
@@ -133,7 +134,7 @@ async def run() -> None:
         HOST, PORT, ResamplerConfig(resampling_period=timedelta(seconds=1.0))
     )
 
-    all_batteries: Set[Component] = connection_manager.get().component_graph.components(
+    all_batteries: set[Component] = connection_manager.get().component_graph.components(
         component_category={ComponentCategory.BATTERY}
     )
     batteries_ids = {c.component_id for c in all_batteries}

--- a/benchmarks/power_distribution/power_distributor.py
+++ b/benchmarks/power_distribution/power_distributor.py
@@ -9,7 +9,7 @@ import random
 import timeit
 from collections.abc import Coroutine
 from datetime import timedelta
-from typing import Any, Dict, List, Set  # pylint: disable=unused-import
+from typing import Any
 
 from frequenz.channels import Broadcast
 

--- a/benchmarks/timeseries/benchmark_datasourcing.py
+++ b/benchmarks/timeseries/benchmark_datasourcing.py
@@ -14,7 +14,7 @@ import asyncio
 import sys
 import tracemalloc
 from time import perf_counter
-from typing import Any, Tuple
+from typing import Any
 
 from frequenz.channels import Broadcast, Receiver, ReceiverStoppedError
 

--- a/benchmarks/timeseries/benchmark_datasourcing.py
+++ b/benchmarks/timeseries/benchmark_datasourcing.py
@@ -131,7 +131,7 @@ async def benchmark_data_sourcing(
         )
 
 
-def parse_args() -> Tuple[int, int, bool]:
+def parse_args() -> tuple[int, int, bool]:
     """Parse the command line arguments.
 
     Returns:

--- a/benchmarks/timeseries/benchmark_ringbuffer.py
+++ b/benchmarks/timeseries/benchmark_ringbuffer.py
@@ -6,7 +6,7 @@
 import random
 import timeit
 from datetime import datetime, timedelta, timezone
-from typing import Any, Dict, TypeVar
+from typing import Any, TypeVar
 
 import numpy as np
 

--- a/benchmarks/timeseries/benchmark_ringbuffer.py
+++ b/benchmarks/timeseries/benchmark_ringbuffer.py
@@ -66,7 +66,7 @@ def test_slices(days: int, buffer: OrderedRingBuffer[Any], median: bool) -> None
                 total += float(np.average(minutes))
 
 
-def test_29_days_list(num_runs: int) -> Dict[str, float]:
+def test_29_days_list(num_runs: int) -> dict[str, float]:
     """Run the 29 day test on the list backend."""
     days = 29
     buffer = OrderedRingBuffer([0.0] * MINUTES_IN_29_DAYS, timedelta(minutes=1))
@@ -76,7 +76,7 @@ def test_29_days_list(num_runs: int) -> Dict[str, float]:
     return {"fill": fill_time, "test": test_time}
 
 
-def test_29_days_array(num_runs: int) -> Dict[str, float]:
+def test_29_days_array(num_runs: int) -> dict[str, float]:
     """Run the 29 day test on the array backend."""
     days = 29
     buffer = OrderedRingBuffer(
@@ -91,7 +91,7 @@ def test_29_days_array(num_runs: int) -> Dict[str, float]:
     return {"fill": fill_time, "test": test_time}
 
 
-def test_29_days_slicing_list(num_runs: int) -> Dict[str, float]:
+def test_29_days_slicing_list(num_runs: int) -> dict[str, float]:
     """Run slicing tests on list backend."""
     days = 29
     buffer = OrderedRingBuffer([0.0] * MINUTES_IN_29_DAYS, timedelta(minutes=1))
@@ -107,7 +107,7 @@ def test_29_days_slicing_list(num_runs: int) -> Dict[str, float]:
     return {"fill": fill_time, "median": median_test_time, "avg": avg_test_time}
 
 
-def test_29_days_slicing_array(num_runs: int) -> Dict[str, float]:
+def test_29_days_slicing_array(num_runs: int) -> dict[str, float]:
     """Run slicing tests on array backend."""
     days = 29
     buffer = OrderedRingBuffer(

--- a/benchmarks/timeseries/periodic_feature_extractor.py
+++ b/benchmarks/timeseries/periodic_feature_extractor.py
@@ -9,7 +9,6 @@ the performance of a numpy implementation with a python
 implementation.
 """
 
-from __future__ import annotations
 
 import asyncio
 import collections.abc

--- a/benchmarks/timeseries/periodic_feature_extractor.py
+++ b/benchmarks/timeseries/periodic_feature_extractor.py
@@ -18,7 +18,6 @@ import logging
 from datetime import datetime, timedelta, timezone
 from functools import partial
 from timeit import timeit
-from typing import List
 
 import numpy as np
 from frequenz.channels import Broadcast

--- a/benchmarks/timeseries/periodic_feature_extractor.py
+++ b/benchmarks/timeseries/periodic_feature_extractor.py
@@ -79,7 +79,7 @@ def _calculate_avg_window_py(
     feature_extractor: PeriodicFeatureExtractor,
     window: NDArray[np.float_],
     window_size: int,
-    weights: List[float] | None = None,
+    weights: list[float] | None = None,
 ) -> NDArray[np.float_]:
     """
     Plain python version of the average calculator.

--- a/benchmarks/timeseries/resampling.py
+++ b/benchmarks/timeseries/resampling.py
@@ -3,9 +3,9 @@
 
 """Benchmark resampling."""
 
+from collections.abc import Sequence
 from datetime import datetime, timedelta, timezone
 from timeit import timeit
-from typing import Sequence
 
 from frequenz.sdk.timeseries import Sample
 from frequenz.sdk.timeseries._quantities import Quantity

--- a/benchmarks/timeseries/ringbuffer_memusage.py
+++ b/benchmarks/timeseries/ringbuffer_memusage.py
@@ -3,7 +3,6 @@
 
 """Memory allocation benchmark for the ringbuffer."""
 
-from __future__ import annotations
 
 import argparse
 import tracemalloc

--- a/benchmarks/timeseries/ringbuffer_serialization.py
+++ b/benchmarks/timeseries/ringbuffer_serialization.py
@@ -3,7 +3,6 @@
 
 """Benchmarks the serialization of the `OrderedRingBuffer` class."""
 
-from __future__ import annotations
 
 import fnmatch
 import os

--- a/examples/battery_pool.py
+++ b/examples/battery_pool.py
@@ -3,7 +3,6 @@
 
 """Script with an example how to use BatteryPool."""
 
-from __future__ import annotations
 
 import asyncio
 import logging

--- a/examples/battery_pool.py
+++ b/examples/battery_pool.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from datetime import timedelta
-from typing import Any, Dict
+from typing import Any
 
 from frequenz.channels import Receiver
 from frequenz.channels.util import MergeNamed

--- a/examples/battery_pool.py
+++ b/examples/battery_pool.py
@@ -32,7 +32,7 @@ async def main() -> None:
     )
 
     battery_pool = microgrid.battery_pool()
-    receivers: Dict[str, Receiver[Any]] = {
+    receivers: dict[str, Receiver[Any]] = {
         "soc": battery_pool.soc.new_receiver(maxsize=1),
         "capacity": battery_pool.capacity.new_receiver(maxsize=1),
         "power_bounds": battery_pool.power_bounds.new_receiver(maxsize=1),

--- a/src/frequenz/sdk/_internal/_asyncio.py
+++ b/src/frequenz/sdk/_internal/_asyncio.py
@@ -3,7 +3,6 @@
 
 """General purpose async tools."""
 
-from __future__ import annotations
 
 import asyncio
 from abc import ABC

--- a/src/frequenz/sdk/_internal/_singleton_meta.py
+++ b/src/frequenz/sdk/_internal/_singleton_meta.py
@@ -10,7 +10,7 @@ from typing import Any, Dict
 class SingletonMeta(type):
     """This is a thread-safe implementation of Singleton."""
 
-    _instances: Dict[Any, type] = {}
+    _instances: dict[Any, type] = {}
     """The dictionary of instances of the singleton classes."""
 
     _lock: Lock = Lock()

--- a/src/frequenz/sdk/_internal/_singleton_meta.py
+++ b/src/frequenz/sdk/_internal/_singleton_meta.py
@@ -4,7 +4,7 @@
 """Definition of Singleton metaclass."""
 
 from threading import Lock
-from typing import Any, Dict
+from typing import Any
 
 
 class SingletonMeta(type):

--- a/src/frequenz/sdk/actor/_channel_registry.py
+++ b/src/frequenz/sdk/actor/_channel_registry.py
@@ -22,7 +22,7 @@ class ChannelRegistry:
             name: A unique name for the registry.
         """
         self._name = name
-        self._channels: Dict[str, Broadcast[Any]] = {}
+        self._channels: dict[str, Broadcast[Any]] = {}
 
     def new_sender(self, key: str) -> Sender[Any]:
         """Get a sender to a dynamically created channel with the given key.

--- a/src/frequenz/sdk/actor/_channel_registry.py
+++ b/src/frequenz/sdk/actor/_channel_registry.py
@@ -3,7 +3,7 @@
 
 """A class that would dynamically create, own and provide access to channels."""
 
-from typing import Any, Dict
+from typing import Any
 
 from frequenz.channels import Broadcast, Receiver, Sender
 

--- a/src/frequenz/sdk/actor/_data_sourcing/microgrid_api_source.py
+++ b/src/frequenz/sdk/actor/_data_sourcing/microgrid_api_source.py
@@ -6,7 +6,7 @@
 import asyncio
 import logging
 from collections.abc import Callable
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any
 
 from frequenz.channels import Receiver, Sender
 

--- a/src/frequenz/sdk/actor/_resampling.py
+++ b/src/frequenz/sdk/actor/_resampling.py
@@ -3,7 +3,6 @@
 
 """An actor to resample microgrid component metrics."""
 
-from __future__ import annotations
 
 import asyncio
 import dataclasses

--- a/src/frequenz/sdk/actor/_run_utils.py
+++ b/src/frequenz/sdk/actor/_run_utils.py
@@ -28,7 +28,7 @@ async def run(*actors: Actor) -> None:
             actor.start()
 
     # Wait until all actors are done
-    pending_tasks = set(asyncio.create_task(a.wait(), name=str(a)) for a in actors)
+    pending_tasks = {asyncio.create_task(a.wait(), name=str(a)) for a in actors}
     while pending_tasks:
         done_tasks, pending_tasks = await asyncio.wait(
             pending_tasks, return_when=asyncio.FIRST_COMPLETED

--- a/src/frequenz/sdk/actor/power_distributing/_battery_pool_status.py
+++ b/src/frequenz/sdk/actor/power_distributing/_battery_pool_status.py
@@ -23,13 +23,13 @@ _logger = logging.getLogger(__name__)
 class BatteryStatus:
     """Status of the batteries."""
 
-    working: Set[int]
+    working: set[int]
     """Set of working battery ids."""
 
-    uncertain: Set[int]
+    uncertain: set[int]
     """Set of batteries that should be used only if there are no working batteries."""
 
-    def get_working_batteries(self, batteries: abc.Set[int]) -> Set[int]:
+    def get_working_batteries(self, batteries: abc.Set[int]) -> set[int]:
         """From the given set of batteries return working batteries.
 
         Args:
@@ -72,7 +72,7 @@ class BatteryPoolStatus:
 
     def __init__(  # noqa: DOC502 (RuntimeError is raised indirectly by BatteryStatus)
         self,
-        battery_ids: Set[int],
+        battery_ids: set[int],
         battery_status_sender: Sender[BatteryStatus],
         max_data_age_sec: float,
         max_blocking_duration_sec: float,
@@ -101,11 +101,11 @@ class BatteryPoolStatus:
         set_power_result_channel = Broadcast[SetPowerResult]("battery_request_status")
         self._set_power_result_sender = set_power_result_channel.new_sender()
 
-        self._batteries: Dict[str, BatteryStatusTracker] = {}
+        self._batteries: dict[str, BatteryStatusTracker] = {}
 
         # Receivers for individual battery statuses are needed to create a `MergeNamed`
         # object.
-        receivers: Dict[str, Receiver[Status]] = {}
+        receivers: dict[str, Receiver[Status]] = {}
 
         for battery_id in battery_ids:
             channel = _BatteryStatusChannelHelper(battery_id)
@@ -188,7 +188,7 @@ class BatteryPoolStatus:
             await battery_status_sender.send(self._current_status)
 
     async def update_status(
-        self, succeed_batteries: Set[int], failed_batteries: Set[int]
+        self, succeed_batteries: set[int], failed_batteries: set[int]
     ) -> None:
         """Notify which batteries succeed and failed in the request.
 
@@ -204,7 +204,7 @@ class BatteryPoolStatus:
             SetPowerResult(succeed_batteries, failed_batteries)
         )
 
-    def get_working_batteries(self, batteries: abc.Set[int]) -> Set[int]:
+    def get_working_batteries(self, batteries: abc.Set[int]) -> set[int]:
         """From the given set of batteries get working.
 
         Args:

--- a/src/frequenz/sdk/actor/power_distributing/_battery_pool_status.py
+++ b/src/frequenz/sdk/actor/power_distributing/_battery_pool_status.py
@@ -8,7 +8,6 @@ import asyncio
 import logging
 from collections import abc
 from dataclasses import dataclass
-from typing import Dict, Set
 
 from frequenz.channels import Broadcast, Receiver, Sender
 from frequenz.channels.util import MergeNamed

--- a/src/frequenz/sdk/actor/power_distributing/_battery_pool_status.py
+++ b/src/frequenz/sdk/actor/power_distributing/_battery_pool_status.py
@@ -2,7 +2,6 @@
 # Copyright © 2022 Frequenz Energy-as-a-Service GmbH
 """Class that stores pool of batteries and manage them."""
 
-from __future__ import annotations
 
 import asyncio
 import logging

--- a/src/frequenz/sdk/actor/power_distributing/_battery_status.py
+++ b/src/frequenz/sdk/actor/power_distributing/_battery_status.py
@@ -11,7 +11,6 @@ from collections.abc import Iterable
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from enum import Enum
-from typing import Optional, Set, Union
 
 # pylint: disable=no-name-in-module
 from frequenz.api.microgrid.battery_pb2 import ComponentState as BatteryComponentState

--- a/src/frequenz/sdk/actor/power_distributing/_battery_status.py
+++ b/src/frequenz/sdk/actor/power_distributing/_battery_status.py
@@ -7,10 +7,11 @@ from __future__ import annotations
 import asyncio
 import logging
 import math
+from collections.abc import Iterable
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from enum import Enum
-from typing import Iterable, Optional, Set, Union
+from typing import Optional, Set, Union
 
 # pylint: disable=no-name-in-module
 from frequenz.api.microgrid.battery_pb2 import ComponentState as BatteryComponentState
@@ -155,7 +156,7 @@ class BatteryStatusTracker:
     Status updates are sent out only when there is a status change.
     """
 
-    _battery_valid_relay: Set[BatteryRelayState.ValueType] = {
+    _battery_valid_relay: set[BatteryRelayState.ValueType] = {
         BatteryRelayState.RELAY_STATE_CLOSED
     }
     """The list of valid relay states of a battery.
@@ -163,7 +164,7 @@ class BatteryStatusTracker:
     A working battery in any other battery relay state will be reported as failing.
     """
 
-    _battery_valid_state: Set[BatteryComponentState.ValueType] = {
+    _battery_valid_state: set[BatteryComponentState.ValueType] = {
         BatteryComponentState.COMPONENT_STATE_IDLE,
         BatteryComponentState.COMPONENT_STATE_CHARGING,
         BatteryComponentState.COMPONENT_STATE_DISCHARGING,
@@ -173,7 +174,7 @@ class BatteryStatusTracker:
     A working battery in any other battery state will be reported as failing.
     """
 
-    _inverter_valid_state: Set[InverterComponentState.ValueType] = {
+    _inverter_valid_state: set[InverterComponentState.ValueType] = {
         InverterComponentState.COMPONENT_STATE_STANDBY,
         InverterComponentState.COMPONENT_STATE_IDLE,
         InverterComponentState.COMPONENT_STATE_CHARGING,
@@ -302,7 +303,7 @@ class BatteryStatusTracker:
                 self._inverter.last_msg_timestamp,
             )
 
-    def _get_new_status_if_changed(self) -> Optional[Status]:
+    def _get_new_status_if_changed(self) -> Status | None:
         current_status = self._get_current_status()
         if self._last_status != current_status:
             self._last_status = current_status
@@ -433,7 +434,7 @@ class BatteryStatusTracker:
             return False
         return True
 
-    def _no_critical_error(self, msg: Union[BatteryData, InverterData]) -> bool:
+    def _no_critical_error(self, msg: BatteryData | InverterData) -> bool:
         """Check if battery or inverter message has any critical error.
 
         Args:
@@ -544,7 +545,7 @@ class BatteryStatusTracker:
 
         return not is_outdated
 
-    def _find_adjacent_inverter_id(self, battery_id: int) -> Optional[int]:
+    def _find_adjacent_inverter_id(self, battery_id: int) -> int | None:
         """Find inverter adjacent to this battery.
 
         Args:

--- a/src/frequenz/sdk/actor/power_distributing/_battery_status.py
+++ b/src/frequenz/sdk/actor/power_distributing/_battery_status.py
@@ -2,7 +2,6 @@
 # Copyright © 2022 Frequenz Energy-as-a-Service GmbH
 """Class to return battery status."""
 
-from __future__ import annotations
 
 import asyncio
 import logging

--- a/src/frequenz/sdk/actor/power_distributing/_distribution_algorithm/_distribution_algorithm.py
+++ b/src/frequenz/sdk/actor/power_distributing/_distribution_algorithm/_distribution_algorithm.py
@@ -6,7 +6,7 @@
 import logging
 import math
 from dataclasses import dataclass
-from typing import Dict, List, NamedTuple, Tuple
+from typing import NamedTuple
 
 from ...._internal._math import is_close_to_zero
 from ....microgrid.component import BatteryData, InverterData

--- a/src/frequenz/sdk/actor/power_distributing/_distribution_algorithm/_distribution_algorithm.py
+++ b/src/frequenz/sdk/actor/power_distributing/_distribution_algorithm/_distribution_algorithm.py
@@ -28,7 +28,7 @@ class InvBatPair(NamedTuple):
 class DistributionResult:
     """Distribution result."""
 
-    distribution: Dict[int, float]
+    distribution: dict[int, float]
     """The power to be set for each inverter.
 
     The key is inverter ID, and the value is the power that should be set for
@@ -202,7 +202,7 @@ class DistributionAlgorithm:
             raise ValueError("Distribution factor should be float >= 0.")
         self._distributor_exponent: float = distributor_exponent
 
-    def _total_capacity(self, components: List[InvBatPair]) -> float:
+    def _total_capacity(self, components: list[InvBatPair]) -> float:
         """Sum capacity between all batteries in the components list.
 
         Args:
@@ -224,10 +224,10 @@ class DistributionAlgorithm:
 
     def _compute_battery_availability_ratio(
         self,
-        components: List[InvBatPair],
-        available_soc: Dict[int, float],
-        excl_bounds: Dict[int, float],
-    ) -> Tuple[List[Tuple[InvBatPair, float, float]], float]:
+        components: list[InvBatPair],
+        available_soc: dict[int, float],
+        excl_bounds: dict[int, float],
+    ) -> tuple[list[tuple[InvBatPair, float, float]], float]:
         r"""Compute battery ratio and the total sum of all of them.
 
         battery_availability_ratio = capacity_ratio[i] * available_soc[i]
@@ -249,7 +249,7 @@ class DistributionAlgorithm:
                 of all battery ratios in the list.
         """
         total_capacity = self._total_capacity(components)
-        battery_availability_ratio: List[Tuple[InvBatPair, float, float]] = []
+        battery_availability_ratio: list[tuple[InvBatPair, float, float]] = []
         total_battery_availability_ratio: float = 0.0
 
         for pair in components:
@@ -273,11 +273,11 @@ class DistributionAlgorithm:
 
     def _distribute_power(  # pylint: disable=too-many-arguments
         self,
-        components: List[InvBatPair],
+        components: list[InvBatPair],
         power_w: float,
-        available_soc: Dict[int, float],
-        incl_bounds: Dict[int, float],
-        excl_bounds: Dict[int, float],
+        available_soc: dict[int, float],
+        incl_bounds: dict[int, float],
+        excl_bounds: dict[int, float],
     ) -> DistributionResult:
         # pylint: disable=too-many-locals,too-many-branches,too-many-statements
         """Distribute power between given components.
@@ -304,7 +304,7 @@ class DistributionAlgorithm:
             components, available_soc, excl_bounds
         )
 
-        distribution: Dict[int, float] = {}
+        distribution: dict[int, float] = {}
         # sum_ratio == 0 means that all batteries are fully charged / discharged
         if is_close_to_zero(sum_ratio):
             distribution = {inverter.component_id: 0 for _, inverter in components}
@@ -379,8 +379,8 @@ class DistributionAlgorithm:
 
     def _greedy_distribute_remaining_power(
         self,
-        distribution: Dict[int, float],
-        upper_bounds: Dict[int, float],
+        distribution: dict[int, float],
+        upper_bounds: dict[int, float],
         remaining_power: float,
     ) -> DistributionResult:
         """Add remaining power greedily to the given distribution.
@@ -399,7 +399,7 @@ class DistributionAlgorithm:
         if is_close_to_zero(remaining_power):
             return DistributionResult(distribution, remaining_power)
 
-        new_distribution: Dict[int, float] = {}
+        new_distribution: dict[int, float] = {}
 
         for inverter_id, power in distribution.items():
             if is_close_to_zero(remaining_power) or is_close_to_zero(power):
@@ -434,7 +434,7 @@ class DistributionAlgorithm:
         )
 
     def distribute_power(
-        self, power: float, components: List[InvBatPair]
+        self, power: float, components: list[InvBatPair]
     ) -> DistributionResult:
         """Distribute given power between given components.
 
@@ -451,7 +451,7 @@ class DistributionAlgorithm:
         return self._distribute_supply_power(power, components)
 
     def _distribute_consume_power(
-        self, power_w: float, components: List[InvBatPair]
+        self, power_w: float, components: list[InvBatPair]
     ) -> DistributionResult:
         """Distribute power between the given components.
 
@@ -470,14 +470,14 @@ class DistributionAlgorithm:
         # If SoC exceeded bound then remaining SoC should be 0.
         # Otherwise algorithm would try to supply power from that battery
         # in order to keep equal SoC level.
-        available_soc: Dict[int, float] = {}
+        available_soc: dict[int, float] = {}
         for battery, _ in components:
             available_soc[battery.component_id] = max(
                 0.0, battery.soc_upper_bound - battery.soc
             )
 
-        incl_bounds: Dict[int, float] = {}
-        excl_bounds: Dict[int, float] = {}
+        incl_bounds: dict[int, float] = {}
+        excl_bounds: dict[int, float] = {}
         for battery, inverter in components:
             # We can supply/consume with int only
             incl_bounds[inverter.component_id] = min(
@@ -494,7 +494,7 @@ class DistributionAlgorithm:
         )
 
     def _distribute_supply_power(
-        self, power_w: float, components: List[InvBatPair]
+        self, power_w: float, components: list[InvBatPair]
     ) -> DistributionResult:
         """Distribute power between the given components.
 
@@ -510,14 +510,14 @@ class DistributionAlgorithm:
         Returns:
             Distribution result.
         """
-        available_soc: Dict[int, float] = {}
+        available_soc: dict[int, float] = {}
         for battery, _ in components:
             available_soc[battery.component_id] = max(
                 0.0, battery.soc - battery.soc_lower_bound
             )
 
-        incl_bounds: Dict[int, float] = {}
-        excl_bounds: Dict[int, float] = {}
+        incl_bounds: dict[int, float] = {}
+        excl_bounds: dict[int, float] = {}
         for battery, inverter in components:
             incl_bounds[inverter.component_id] = -1 * max(
                 inverter.active_power_inclusion_lower_bound,

--- a/src/frequenz/sdk/actor/power_distributing/power_distributing.py
+++ b/src/frequenz/sdk/actor/power_distributing/power_distributing.py
@@ -22,7 +22,7 @@ from collections.abc import Iterable
 from dataclasses import dataclass, replace
 from datetime import timedelta
 from math import isnan
-from typing import Any, Dict, List, Optional, Self, Set, Tuple
+from typing import Any, Self
 
 import grpc
 from frequenz.channels import Peekable, Receiver, Sender

--- a/src/frequenz/sdk/actor/power_distributing/power_distributing.py
+++ b/src/frequenz/sdk/actor/power_distributing/power_distributing.py
@@ -11,7 +11,6 @@ amount power to charge/discharge.
 Purpose of this actor is to keep SoC level of each component at the equal level.
 """
 
-from __future__ import annotations
 
 import asyncio
 import logging

--- a/src/frequenz/sdk/actor/power_distributing/request.py
+++ b/src/frequenz/sdk/actor/power_distributing/request.py
@@ -2,7 +2,6 @@
 # Copyright © 2022 Frequenz Energy-as-a-Service GmbH
 """Definition of the user request."""
 
-from __future__ import annotations
 
 import dataclasses
 from collections import abc

--- a/src/frequenz/sdk/actor/power_distributing/result.py
+++ b/src/frequenz/sdk/actor/power_distributing/result.py
@@ -3,7 +3,6 @@
 
 """Results from PowerDistributingActor."""
 
-from __future__ import annotations
 
 import dataclasses
 

--- a/src/frequenz/sdk/config/_config.py
+++ b/src/frequenz/sdk/config/_config.py
@@ -4,7 +4,7 @@
 """Read and update config variables."""
 
 import logging
-from typing import Any, Dict, Optional, TypeVar
+from typing import Any, TypeVar
 
 # pylint not finding parse_raw_as is a false positive
 from pydantic import ValidationError, parse_raw_as  # pylint: disable=no-name-in-module

--- a/src/frequenz/sdk/config/_config.py
+++ b/src/frequenz/sdk/config/_config.py
@@ -24,13 +24,13 @@ class Config:
     If new file is read, then previous configs will be forgotten.
     """
 
-    def __init__(self, conf_vars: Dict[str, Any]):
+    def __init__(self, conf_vars: dict[str, Any]):
         """Instantiate the config store and read config variables from the file.
 
         Args:
             conf_vars: Dict containing configuration variables
         """
-        self._conf_store: Dict[str, Any] = conf_vars
+        self._conf_store: dict[str, Any] = conf_vars
 
     def get(self, key: str, default: Any = None) -> Any:
         """Get the value for the specified key.
@@ -48,8 +48,8 @@ class Config:
         return self._conf_store.get(key, default)
 
     def get_dict(
-        self, key_prefix: str, expected_values_type: Optional[T]
-    ) -> Dict[str, Any]:
+        self, key_prefix: str, expected_values_type: T | None
+    ) -> dict[str, Any]:
         """Get a dictionary based on config key prefixes.
 
         For example, if key_prefix is "my_dict", then the following config store:
@@ -74,7 +74,7 @@ class Config:
             A dictionary containing the keys prefixed with `key_prefix` as keys
                 (but with the prefix removed) and the values as values.
         """
-        result: Dict[str, Any] = {}
+        result: dict[str, Any] = {}
         for key, value in self._conf_store.items():
             if key.startswith(key_prefix):
                 new_key = key[len(key_prefix) :]

--- a/src/frequenz/sdk/microgrid/_data_pipeline.py
+++ b/src/frequenz/sdk/microgrid/_data_pipeline.py
@@ -63,7 +63,7 @@ class _ActorInfo(typing.Generic[_T]):
     actor: _T
     """The actor instance."""
 
-    channel: Broadcast["ComponentMetricRequest"]
+    channel: Broadcast[ComponentMetricRequest]
     """The request channel for the actor."""
 
 
@@ -102,11 +102,11 @@ class _DataPipeline:
             "Power Distributing Actor, Broadcast Channel"
         )
 
-        self._power_distributing_actor: "PowerDistributingActor" | None = None
+        self._power_distributing_actor: PowerDistributingActor | None = None
 
-        self._logical_meter: "LogicalMeter" | None = None
-        self._ev_charger_pools: dict[frozenset[int], "EVChargerPool"] = {}
-        self._battery_pools: dict[frozenset[int], "BatteryPool"] = {}
+        self._logical_meter: LogicalMeter | None = None
+        self._ev_charger_pools: dict[frozenset[int], EVChargerPool] = {}
+        self._battery_pools: dict[frozenset[int], BatteryPool] = {}
         self._frequency_pool: dict[int, GridFrequency] = {}
 
     def frequency(self, component: Component | None = None) -> GridFrequency:

--- a/src/frequenz/sdk/microgrid/_graph.py
+++ b/src/frequenz/sdk/microgrid/_graph.py
@@ -26,7 +26,6 @@ import logging
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Iterable
 from dataclasses import asdict
-from typing import List, Optional, Set
 
 import networkx as nx
 

--- a/src/frequenz/sdk/microgrid/_graph.py
+++ b/src/frequenz/sdk/microgrid/_graph.py
@@ -24,8 +24,9 @@ flow of power.
 import asyncio
 import logging
 from abc import ABC, abstractmethod
+from collections.abc import Callable, Iterable
 from dataclasses import asdict
-from typing import Callable, Iterable, List, Optional, Set
+from typing import List, Optional, Set
 
 import networkx as nx
 
@@ -45,9 +46,9 @@ class ComponentGraph(ABC):
     @abstractmethod
     def components(
         self,
-        component_id: Optional[Set[int]] = None,
-        component_category: Optional[Set[ComponentCategory]] = None,
-    ) -> Set[Component]:
+        component_id: set[int] | None = None,
+        component_category: set[ComponentCategory] | None = None,
+    ) -> set[Component]:
         """Fetch the components of the microgrid.
 
         Args:
@@ -63,9 +64,9 @@ class ComponentGraph(ABC):
     @abstractmethod
     def connections(
         self,
-        start: Optional[Set[int]] = None,
-        end: Optional[Set[int]] = None,
-    ) -> Set[Connection]:
+        start: set[int] | None = None,
+        end: set[int] | None = None,
+    ) -> set[Connection]:
         """Fetch the connections between microgrid components.
 
         Args:
@@ -80,7 +81,7 @@ class ComponentGraph(ABC):
         """
 
     @abstractmethod
-    def predecessors(self, component_id: int) -> Set[Component]:
+    def predecessors(self, component_id: int) -> set[Component]:
         """Fetch the graph predecessors of the specified component.
 
         Args:
@@ -97,7 +98,7 @@ class ComponentGraph(ABC):
         """
 
     @abstractmethod
-    def successors(self, component_id: int) -> Set[Component]:
+    def successors(self, component_id: int) -> set[Component]:
         """Fetch the graph successors of the specified component.
 
         Args:
@@ -270,9 +271,9 @@ class ComponentGraph(ABC):
     def dfs(
         self,
         current_node: Component,
-        visited: Set[Component],
+        visited: set[Component],
         condition: Callable[[Component], bool],
-    ) -> Set[Component]:
+    ) -> set[Component]:
         """
         Search for components that fulfill the condition in the Graph.
 
@@ -298,8 +299,8 @@ class _MicrogridComponentGraph(ComponentGraph):
 
     def __init__(
         self,
-        components: Optional[Set[Component]] = None,
-        connections: Optional[Set[Connection]] = None,
+        components: set[Component] | None = None,
+        connections: set[Connection] | None = None,
     ) -> None:
         """Initialize the component graph.
 
@@ -331,9 +332,9 @@ class _MicrogridComponentGraph(ComponentGraph):
 
     def components(
         self,
-        component_id: Optional[Set[int]] = None,
-        component_category: Optional[Set[ComponentCategory]] = None,
-    ) -> Set[Component]:
+        component_id: set[int] | None = None,
+        component_category: set[ComponentCategory] | None = None,
+    ) -> set[Component]:
         """Fetch the components of the microgrid.
 
         Args:
@@ -355,16 +356,16 @@ class _MicrogridComponentGraph(ComponentGraph):
             selection = map(lambda idx: Component(**self._graph.nodes[idx]), valid_ids)
 
         if component_category is not None:
-            types: Set[ComponentCategory] = component_category
+            types: set[ComponentCategory] = component_category
             selection = filter(lambda c: c.category in types, selection)
 
         return set(selection)
 
     def connections(
         self,
-        start: Optional[Set[int]] = None,
-        end: Optional[Set[int]] = None,
-    ) -> Set[Connection]:
+        start: set[int] | None = None,
+        end: set[int] | None = None,
+    ) -> set[Connection]:
         """Fetch the connections between microgrid components.
 
         Args:
@@ -386,12 +387,12 @@ class _MicrogridComponentGraph(ComponentGraph):
         else:
             selection = self._graph.out_edges(start)
             if end is not None:
-                end_ids: Set[int] = end
+                end_ids: set[int] = end
                 selection = filter(lambda c: c[1] in end_ids, selection)
 
         return set(map(lambda c: Connection(c[0], c[1]), selection))
 
-    def predecessors(self, component_id: int) -> Set[Component]:
+    def predecessors(self, component_id: int) -> set[Component]:
         """Fetch the graph predecessors of the specified component.
 
         Args:
@@ -417,7 +418,7 @@ class _MicrogridComponentGraph(ComponentGraph):
             map(lambda idx: Component(**self._graph.nodes[idx]), predecessors_ids)
         )
 
-    def successors(self, component_id: int) -> Set[Component]:
+    def successors(self, component_id: int) -> set[Component]:
         """Fetch the graph successors of the specified component.
 
         Args:
@@ -443,9 +444,9 @@ class _MicrogridComponentGraph(ComponentGraph):
 
     def refresh_from(
         self,
-        components: Set[Component],
-        connections: Set[Connection],
-        correct_errors: Optional[Callable[["_MicrogridComponentGraph"], None]] = None,
+        components: set[Component],
+        connections: set[Connection],
+        correct_errors: Callable[["_MicrogridComponentGraph"], None] | None = None,
     ) -> None:
         """Refresh the graph from the provided list of components and connections.
 
@@ -503,7 +504,7 @@ class _MicrogridComponentGraph(ComponentGraph):
     async def refresh_from_api(
         self,
         api: MicrogridApiClient,
-        correct_errors: Optional[Callable[["_MicrogridComponentGraph"], None]] = None,
+        correct_errors: Callable[["_MicrogridComponentGraph"], None] | None = None,
     ) -> None:
         """Refresh the contents of a component graph from the remote API.
 
@@ -715,9 +716,9 @@ class _MicrogridComponentGraph(ComponentGraph):
     def dfs(
         self,
         current_node: Component,
-        visited: Set[Component],
+        visited: set[Component],
         condition: Callable[[Component], bool],
-    ) -> Set[Component]:
+    ) -> set[Component]:
         """
         Search for components that fulfill the condition in the Graph.
 
@@ -741,7 +742,7 @@ class _MicrogridComponentGraph(ComponentGraph):
         if condition(current_node):
             return {current_node}
 
-        component: Set[Component] = set()
+        component: set[Component] = set()
 
         for successor in self.successors(current_node.component_id):
             component.update(self.dfs(successor, visited, condition))
@@ -766,7 +767,7 @@ class _MicrogridComponentGraph(ComponentGraph):
 
         # node[0] is required by the graph definition
         # If any node has not node[1], then it will not pass validations step.
-        undefined: List[int] = [
+        undefined: list[int] = [
             node[0] for node in self._graph.nodes(data=True) if len(node[1]) == 0
         ]
 

--- a/src/frequenz/sdk/microgrid/client/_client.py
+++ b/src/frequenz/sdk/microgrid/client/_client.py
@@ -7,7 +7,7 @@ import asyncio
 import logging
 from abc import ABC, abstractmethod
 from collections.abc import Awaitable, Callable, Iterable
-from typing import Any, Dict, Optional, Set, TypeVar, cast
+from typing import Any, TypeVar, cast
 
 import grpc
 from frequenz.api.common import components_pb2 as components_pb

--- a/src/frequenz/sdk/microgrid/client/_client.py
+++ b/src/frequenz/sdk/microgrid/client/_client.py
@@ -6,17 +6,8 @@
 import asyncio
 import logging
 from abc import ABC, abstractmethod
-from typing import (
-    Any,
-    Awaitable,
-    Callable,
-    Dict,
-    Iterable,
-    Optional,
-    Set,
-    TypeVar,
-    cast,
-)
+from collections.abc import Awaitable, Callable, Iterable
+from typing import Any, Dict, Optional, Set, TypeVar, cast
 
 import grpc
 from frequenz.api.common import components_pb2 as components_pb
@@ -74,8 +65,8 @@ class MicrogridApiClient(ABC):
     @abstractmethod
     async def connections(
         self,
-        starts: Optional[Set[int]] = None,
-        ends: Optional[Set[int]] = None,
+        starts: set[int] | None = None,
+        ends: set[int] | None = None,
     ) -> Iterable[Connection]:
         """Fetch the connections between components in the microgrid.
 
@@ -221,8 +212,8 @@ class MicrogridGrpcClient(MicrogridApiClient):
         self.api = MicrogridStub(grpc_channel)
         """The gRPC stub for the microgrid API."""
 
-        self._component_streams: Dict[int, Broadcast[Any]] = {}
-        self._streaming_tasks: Dict[int, asyncio.Task[None]] = {}
+        self._component_streams: dict[int, Broadcast[Any]] = {}
+        self._streaming_tasks: dict[int, asyncio.Task[None]] = {}
         self._retry_spec = retry_spec
 
     async def components(self) -> Iterable[Component]:
@@ -270,8 +261,8 @@ class MicrogridGrpcClient(MicrogridApiClient):
 
     async def connections(
         self,
-        starts: Optional[Set[int]] = None,
-        ends: Optional[Set[int]] = None,
+        starts: set[int] | None = None,
+        ends: set[int] | None = None,
     ) -> Iterable[Connection]:
         """Fetch the connections between components in the microgrid.
 

--- a/src/frequenz/sdk/microgrid/client/_retry.py
+++ b/src/frequenz/sdk/microgrid/client/_retry.py
@@ -7,8 +7,9 @@ from __future__ import annotations
 
 import random
 from abc import ABC, abstractmethod
+from collections.abc import Iterator
 from copy import deepcopy
-from typing import Iterator, Optional
+from typing import Optional
 
 DEFAULT_RETRY_INTERVAL = 3.0
 """Default retry interval, in seconds."""
@@ -20,11 +21,11 @@ DEFAULT_RETRY_JITTER = 1.0
 class RetryStrategy(ABC):
     """Interface for implementing retry strategies."""
 
-    _limit: Optional[int]
+    _limit: int | None
     _count: int
 
     @abstractmethod
-    def next_interval(self) -> Optional[float]:
+    def next_interval(self) -> float | None:
         """Return the time to wait before the next retry.
 
         Returns `None` if the retry limit has been reached, and no more retries
@@ -82,7 +83,7 @@ class LinearBackoff(RetryStrategy):
         self,
         interval: float = DEFAULT_RETRY_INTERVAL,
         jitter: float = DEFAULT_RETRY_JITTER,
-        limit: Optional[int] = None,
+        limit: int | None = None,
     ) -> None:
         """Create a `LinearBackoff` instance.
 
@@ -98,7 +99,7 @@ class LinearBackoff(RetryStrategy):
 
         self._count = 0
 
-    def next_interval(self) -> Optional[float]:
+    def next_interval(self) -> float | None:
         """Return the time to wait before the next retry.
 
         Returns `None` if the retry limit has been reached, and no more retries
@@ -132,7 +133,7 @@ class ExponentialBackoff(RetryStrategy):
         max_interval: float = DEFAULT_MAX_INTERVAL,
         multiplier: float = DEFAULT_MULTIPLIER,
         jitter: float = DEFAULT_RETRY_JITTER,
-        limit: Optional[int] = None,
+        limit: int | None = None,
     ) -> None:
         """Create a `ExponentialBackoff` instance.
 
@@ -153,7 +154,7 @@ class ExponentialBackoff(RetryStrategy):
 
         self._count = 0
 
-    def next_interval(self) -> Optional[float]:
+    def next_interval(self) -> float | None:
         """Return the time to wait before the next retry.
 
         Returns `None` if the retry limit has been reached, and no more retries

--- a/src/frequenz/sdk/microgrid/client/_retry.py
+++ b/src/frequenz/sdk/microgrid/client/_retry.py
@@ -9,7 +9,6 @@ import random
 from abc import ABC, abstractmethod
 from collections.abc import Iterator
 from copy import deepcopy
-from typing import Optional
 
 DEFAULT_RETRY_INTERVAL = 3.0
 """Default retry interval, in seconds."""

--- a/src/frequenz/sdk/microgrid/component/_component.py
+++ b/src/frequenz/sdk/microgrid/component/_component.py
@@ -3,8 +3,6 @@
 
 """Defines the components that can be used in a microgrid."""
 
-from __future__ import annotations
-
 from dataclasses import dataclass
 from enum import Enum
 

--- a/src/frequenz/sdk/microgrid/component/_component_data.py
+++ b/src/frequenz/sdk/microgrid/component/_component_data.py
@@ -31,7 +31,7 @@ class ComponentData(ABC):
     # data from a protobuf message. The whole protobuf message is stored as the `raw`
     # attribute. When `ComponentData` is not instantiated from a protobuf message,
     # i.e. using the constructor, `raw` will be set to `None`.
-    raw: Optional[microgrid_pb.ComponentData] = field(default=None, init=False)
+    raw: microgrid_pb.ComponentData | None = field(default=None, init=False)
     """Raw component data as decoded from the wire."""
 
     def _set_raw(self, raw: microgrid_pb.ComponentData) -> None:
@@ -69,13 +69,13 @@ class MeterData(ComponentData):
             -ve current means supply into the grid.
     """
 
-    current_per_phase: Tuple[float, float, float]
+    current_per_phase: tuple[float, float, float]
     """AC current in Amperes (A) for phase/line 1,2 and 3 respectively.
             +ve current means consumption, away from the grid.
             -ve current means supply into the grid.
     """
 
-    voltage_per_phase: Tuple[float, float, float]
+    voltage_per_phase: tuple[float, float, float]
     """The ac voltage in volts (v) between the line and the neutral wire for phase/line
         1,2 and 3 respectively.
     """
@@ -188,7 +188,7 @@ class BatteryData(ComponentData):
     _component_state: battery_pb.ComponentState.ValueType
     """State of the battery."""
 
-    _errors: List[battery_pb.Error]
+    _errors: list[battery_pb.Error]
     """List of errors in protobuf struct."""
 
     @classmethod
@@ -284,7 +284,7 @@ class InverterData(ComponentData):
     _component_state: inverter_pb.ComponentState.ValueType
     """State of the inverter."""
 
-    _errors: List[inverter_pb.Error]
+    _errors: list[inverter_pb.Error]
     """List of errors from the component."""
 
     @classmethod
@@ -325,13 +325,13 @@ class EVChargerData(ComponentData):
         -ve current means supply into the grid.
     """
 
-    current_per_phase: Tuple[float, float, float]
+    current_per_phase: tuple[float, float, float]
     """AC current in Amperes (A) for phase/line 1,2 and 3 respectively.
         +ve current means consumption, away from the grid.
         -ve current means supply into the grid.
     """
 
-    voltage_per_phase: Tuple[float, float, float]
+    voltage_per_phase: tuple[float, float, float]
     """The AC voltage in Volts (V) between the line and the neutral
         wire for phase/line 1,2 and 3 respectively.
     """

--- a/src/frequenz/sdk/microgrid/component/_component_data.py
+++ b/src/frequenz/sdk/microgrid/component/_component_data.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from typing import List, Optional, Tuple
 
 import frequenz.api.microgrid.battery_pb2 as battery_pb
 import frequenz.api.microgrid.inverter_pb2 as inverter_pb

--- a/src/frequenz/sdk/microgrid/connection_manager.py
+++ b/src/frequenz/sdk/microgrid/connection_manager.py
@@ -10,7 +10,6 @@ component graph.
 
 import logging
 from abc import ABC, abstractmethod
-from typing import Optional
 
 import grpc.aio as grpcaio
 

--- a/src/frequenz/sdk/microgrid/connection_manager.py
+++ b/src/frequenz/sdk/microgrid/connection_manager.py
@@ -140,7 +140,7 @@ class _InsecureConnectionManager(ConnectionManager):
         await self._graph.refresh_from_api(self._api)
 
 
-_CONNECTION_MANAGER: Optional[ConnectionManager] = None
+_CONNECTION_MANAGER: ConnectionManager | None = None
 """The ConnectionManager singleton instance."""
 
 

--- a/src/frequenz/sdk/timeseries/_base_types.py
+++ b/src/frequenz/sdk/timeseries/_base_types.py
@@ -4,9 +4,10 @@
 """Timeseries basic types."""
 
 import functools
+from collections.abc import Callable, Iterator
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import Callable, Generic, Iterator, Self, overload
+from typing import Generic, Self, overload
 
 from ._quantities import QuantityT
 

--- a/src/frequenz/sdk/timeseries/_formula_engine/_formula_engine.py
+++ b/src/frequenz/sdk/timeseries/_formula_engine/_formula_engine.py
@@ -10,7 +10,7 @@ import logging
 from abc import ABC
 from collections import deque
 from collections.abc import Callable
-from typing import Dict, Generic, List, Optional, Tuple, Type, TypeVar, Union, overload
+from typing import Generic, TypeVar, Union, overload
 
 from frequenz.channels import Broadcast, Receiver
 

--- a/src/frequenz/sdk/timeseries/_formula_engine/_formula_engine.py
+++ b/src/frequenz/sdk/timeseries/_formula_engine/_formula_engine.py
@@ -9,18 +9,8 @@ import asyncio
 import logging
 from abc import ABC
 from collections import deque
-from typing import (
-    Callable,
-    Dict,
-    Generic,
-    List,
-    Optional,
-    Tuple,
-    Type,
-    TypeVar,
-    Union,
-    overload,
-)
+from collections.abc import Callable
+from typing import Dict, Generic, List, Optional, Tuple, Type, TypeVar, Union, overload
 
 from frequenz.channels import Broadcast, Receiver
 
@@ -102,7 +92,7 @@ class _ComposableFormulaEngine(
     """A base class for formula engines."""
 
     _create_method: Callable[[float], QuantityT]
-    _higher_order_builder: Type[_GenericHigherOrderBuilder]
+    _higher_order_builder: type[_GenericHigherOrderBuilder]
     _task: asyncio.Task[None] | None = None
 
     async def _stop(self) -> None:
@@ -315,7 +305,7 @@ class FormulaEngine(
                 await sender.send(msg)
 
     def new_receiver(
-        self, name: Optional[str] = None, max_size: int = 50
+        self, name: str | None = None, max_size: int = 50
     ) -> Receiver[Sample[QuantityT]]:
         """Create a new receiver that streams the output of the formula engine.
 
@@ -361,7 +351,7 @@ class FormulaEngine3Phase(
         self,
         name: str,
         create_method: Callable[[float], QuantityT],
-        phase_streams: Tuple[
+        phase_streams: tuple[
             FormulaEngine[QuantityT],
             FormulaEngine[QuantityT],
             FormulaEngine[QuantityT],
@@ -411,7 +401,7 @@ class FormulaEngine3Phase(
                 await sender.send(msg)
 
     def new_receiver(
-        self, name: Optional[str] = None, max_size: int = 50
+        self, name: str | None = None, max_size: int = 50
     ) -> Receiver[Sample3Phase[QuantityT]]:
         """Create a new receiver that streams the output of the formula engine.
 
@@ -467,9 +457,9 @@ class FormulaBuilder(Generic[QuantityT]):
         """
         self._name = name
         self._create_method: Callable[[float], QuantityT] = create_method
-        self._build_stack: List[FormulaStep] = []
-        self._steps: List[FormulaStep] = []
-        self._metric_fetchers: Dict[str, MetricFetcher[QuantityT]] = {}
+        self._build_stack: list[FormulaStep] = []
+        self._steps: list[FormulaStep] = []
+        self._metric_fetchers: dict[str, MetricFetcher[QuantityT]] = {}
 
     def push_oper(self, oper: str) -> None:
         """Push an operator into the engine.
@@ -584,14 +574,14 @@ class FormulaBuilder(Generic[QuantityT]):
         self._steps.append(Clipper(min_value, max_value))
 
     def push_average(
-        self, metrics: List[Tuple[str, Receiver[Sample[QuantityT]], bool]]
+        self, metrics: list[tuple[str, Receiver[Sample[QuantityT]], bool]]
     ) -> None:
         """Push an average calculator into the engine.
 
         Args:
             metrics: list of arguments to pass to each `MetricFetcher`.
         """
-        fetchers: List[MetricFetcher[QuantityT]] = []
+        fetchers: list[MetricFetcher[QuantityT]] = []
         for metric in metrics:
             fetcher = self._metric_fetchers.setdefault(
                 metric[0],

--- a/src/frequenz/sdk/timeseries/_formula_engine/_formula_engine_pool.py
+++ b/src/frequenz/sdk/timeseries/_formula_engine/_formula_engine_pool.py
@@ -90,7 +90,7 @@ class FormulaEnginePool:
     def from_power_formula_generator(
         self,
         channel_key: str,
-        generator: Type[FormulaGenerator[Power]],
+        generator: type[FormulaGenerator[Power]],
         config: FormulaGeneratorConfig = FormulaGeneratorConfig(),
     ) -> FormulaEngine[Power]:
         """Get a receiver for a formula from a generator.
@@ -124,7 +124,7 @@ class FormulaEnginePool:
     def from_3_phase_current_formula_generator(
         self,
         channel_key: str,
-        generator: "Type[FormulaGenerator[Current]]",
+        generator: Type[FormulaGenerator[Current]],
         config: FormulaGeneratorConfig = FormulaGeneratorConfig(),
     ) -> FormulaEngine3Phase[Current]:
         """Get a receiver for a formula from a generator.

--- a/src/frequenz/sdk/timeseries/_formula_engine/_formula_engine_pool.py
+++ b/src/frequenz/sdk/timeseries/_formula_engine/_formula_engine_pool.py
@@ -124,7 +124,7 @@ class FormulaEnginePool:
     def from_3_phase_current_formula_generator(
         self,
         channel_key: str,
-        generator: Type[FormulaGenerator[Current]],
+        generator: type[FormulaGenerator[Current]],
         config: FormulaGeneratorConfig = FormulaGeneratorConfig(),
     ) -> FormulaEngine3Phase[Current]:
         """Get a receiver for a formula from a generator.

--- a/src/frequenz/sdk/timeseries/_formula_engine/_formula_engine_pool.py
+++ b/src/frequenz/sdk/timeseries/_formula_engine/_formula_engine_pool.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Type
+from typing import TYPE_CHECKING
 
 from frequenz.channels import Sender
 

--- a/src/frequenz/sdk/timeseries/_formula_engine/_formula_evaluator.py
+++ b/src/frequenz/sdk/timeseries/_formula_engine/_formula_evaluator.py
@@ -7,7 +7,7 @@ import asyncio
 from collections.abc import Callable
 from datetime import datetime
 from math import isinf, isnan
-from typing import Dict, Generic, List, Optional, Set
+from typing import Generic
 
 from .. import Sample
 from .._quantities import QuantityT

--- a/src/frequenz/sdk/timeseries/_formula_engine/_formula_evaluator.py
+++ b/src/frequenz/sdk/timeseries/_formula_engine/_formula_evaluator.py
@@ -4,9 +4,10 @@
 """A post-fix formula evaluator that operates on `Sample` receivers."""
 
 import asyncio
+from collections.abc import Callable
 from datetime import datetime
 from math import isinf, isnan
-from typing import Callable, Dict, Generic, List, Optional, Set
+from typing import Dict, Generic, List, Optional, Set
 
 from .. import Sample
 from .._quantities import QuantityT
@@ -19,8 +20,8 @@ class FormulaEvaluator(Generic[QuantityT]):
     def __init__(
         self,
         name: str,
-        steps: List[FormulaStep],
-        metric_fetchers: Dict[str, MetricFetcher[QuantityT]],
+        steps: list[FormulaStep],
+        metric_fetchers: dict[str, MetricFetcher[QuantityT]],
         create_method: Callable[[float], QuantityT],
     ) -> None:
         """Create a `FormulaEngine` instance.
@@ -35,12 +36,12 @@ class FormulaEvaluator(Generic[QuantityT]):
         """
         self._name = name
         self._steps = steps
-        self._metric_fetchers: Dict[str, MetricFetcher[QuantityT]] = metric_fetchers
+        self._metric_fetchers: dict[str, MetricFetcher[QuantityT]] = metric_fetchers
         self._first_run = True
         self._create_method: Callable[[float], QuantityT] = create_method
 
     async def _synchronize_metric_timestamps(
-        self, metrics: Set[asyncio.Task[Optional[Sample[QuantityT]]]]
+        self, metrics: set[asyncio.Task[Sample[QuantityT] | None]]
     ) -> datetime:
         """Synchronize the metric streams.
 
@@ -59,7 +60,7 @@ class FormulaEvaluator(Generic[QuantityT]):
             RuntimeError: when some streams have no value, or when the synchronization
                 of timestamps fails.
         """
-        metrics_by_ts: Dict[datetime, list[str]] = {}
+        metrics_by_ts: dict[datetime, list[str]] = {}
         for metric in metrics:
             result = metric.result()
             name = metric.get_name()
@@ -97,7 +98,7 @@ class FormulaEvaluator(Generic[QuantityT]):
             RuntimeError: if some samples didn't arrive, or if formula application
                 failed.
         """
-        eval_stack: List[float] = []
+        eval_stack: list[float] = []
         ready_metrics, pending = await asyncio.wait(
             [
                 asyncio.create_task(fetcher.fetch_next(), name=name)

--- a/src/frequenz/sdk/timeseries/_formula_engine/_formula_generators/_chp_power_formula.py
+++ b/src/frequenz/sdk/timeseries/_formula_engine/_formula_generators/_chp_power_formula.py
@@ -3,7 +3,6 @@
 
 """Formula generator from component graph for CHP Power."""
 
-from __future__ import annotations
 
 import logging
 from collections import abc

--- a/src/frequenz/sdk/timeseries/_formula_engine/_formula_generators/_ev_charger_current_formula.py
+++ b/src/frequenz/sdk/timeseries/_formula_engine/_formula_generators/_ev_charger_current_formula.py
@@ -3,7 +3,6 @@
 
 """Formula generator from component graph for 3-phase Grid Current."""
 
-from __future__ import annotations
 
 import logging
 from collections import abc

--- a/src/frequenz/sdk/timeseries/_formula_engine/_formula_generators/_formula_generator.py
+++ b/src/frequenz/sdk/timeseries/_formula_engine/_formula_generators/_formula_generator.py
@@ -8,9 +8,10 @@ from __future__ import annotations
 import sys
 from abc import ABC, abstractmethod
 from collections import abc
+from collections.abc import Callable
 from dataclasses import dataclass
 from enum import Enum
-from typing import Callable, Generic
+from typing import Generic
 
 from frequenz.channels import Sender
 

--- a/src/frequenz/sdk/timeseries/_formula_engine/_formula_generators/_formula_generator.py
+++ b/src/frequenz/sdk/timeseries/_formula_engine/_formula_generators/_formula_generator.py
@@ -3,7 +3,6 @@
 
 """Base class for formula generators that use the component graphs."""
 
-from __future__ import annotations
 
 import sys
 from abc import ABC, abstractmethod

--- a/src/frequenz/sdk/timeseries/_formula_engine/_formula_generators/_grid_current_formula.py
+++ b/src/frequenz/sdk/timeseries/_formula_engine/_formula_generators/_grid_current_formula.py
@@ -3,8 +3,6 @@
 
 """Formula generator from component graph for 3-phase Grid Current."""
 
-from typing import Set
-
 from ....microgrid.component import Component, ComponentCategory, ComponentMetricId
 from ..._quantities import Current
 from .._formula_engine import FormulaEngine, FormulaEngine3Phase

--- a/src/frequenz/sdk/timeseries/_formula_engine/_formula_generators/_grid_current_formula.py
+++ b/src/frequenz/sdk/timeseries/_formula_engine/_formula_generators/_grid_current_formula.py
@@ -46,7 +46,7 @@ class GridCurrentFormula(FormulaGenerator[Current]):
 
     def _gen_phase_formula(
         self,
-        grid_successors: Set[Component],
+        grid_successors: set[Component],
         metric_id: ComponentMetricId,
     ) -> FormulaEngine[Current]:
         builder = self._get_builder("grid-current", metric_id, Current.from_amperes)

--- a/src/frequenz/sdk/timeseries/_formula_engine/_formula_steps.py
+++ b/src/frequenz/sdk/timeseries/_formula_engine/_formula_steps.py
@@ -32,7 +32,7 @@ class FormulaStep(ABC):
         """
 
     @abstractmethod
-    def apply(self, eval_stack: List[float]) -> None:
+    def apply(self, eval_stack: list[float]) -> None:
         """Apply a formula operation on the eval_stack.
 
         Args:
@@ -51,7 +51,7 @@ class Adder(FormulaStep):
         """
         return "+"
 
-    def apply(self, eval_stack: List[float]) -> None:
+    def apply(self, eval_stack: list[float]) -> None:
         """Extract two values from the stack, add them, push the result back in.
 
         Args:
@@ -74,7 +74,7 @@ class Subtractor(FormulaStep):
         """
         return "-"
 
-    def apply(self, eval_stack: List[float]) -> None:
+    def apply(self, eval_stack: list[float]) -> None:
         """Extract two values from the stack, subtract them, push the result back in.
 
         Args:
@@ -97,7 +97,7 @@ class Multiplier(FormulaStep):
         """
         return "*"
 
-    def apply(self, eval_stack: List[float]) -> None:
+    def apply(self, eval_stack: list[float]) -> None:
         """Extract two values from the stack, multiply them, push the result back in.
 
         Args:
@@ -120,7 +120,7 @@ class Divider(FormulaStep):
         """
         return "/"
 
-    def apply(self, eval_stack: List[float]) -> None:
+    def apply(self, eval_stack: list[float]) -> None:
         """Extract two values from the stack, divide them, push the result back in.
 
         Args:
@@ -143,7 +143,7 @@ class Maximizer(FormulaStep):
         """
         return "max"
 
-    def apply(self, eval_stack: List[float]) -> None:
+    def apply(self, eval_stack: list[float]) -> None:
         """Extract two values from the stack and pushes back the maximum.
 
         Args:
@@ -166,7 +166,7 @@ class Minimizer(FormulaStep):
         """
         return "min"
 
-    def apply(self, eval_stack: List[float]) -> None:
+    def apply(self, eval_stack: list[float]) -> None:
         """Extract two values from the stack and pushes back the minimum.
 
         Args:
@@ -192,14 +192,14 @@ class OpenParen(FormulaStep):
         """
         return "("
 
-    def apply(self, _: List[float]) -> None:
+    def apply(self, _: list[float]) -> None:
         """No-op."""
 
 
 class Averager(Generic[QuantityT], FormulaStep):
     """A formula step for calculating average."""
 
-    def __init__(self, fetchers: List[MetricFetcher[QuantityT]]) -> None:
+    def __init__(self, fetchers: list[MetricFetcher[QuantityT]]) -> None:
         """Create an `Averager` instance.
 
         Args:
@@ -215,7 +215,7 @@ class Averager(Generic[QuantityT], FormulaStep):
         """
         return f"avg({', '.join(repr(f) for f in self._fetchers)})"
 
-    def apply(self, eval_stack: List[float]) -> None:
+    def apply(self, eval_stack: list[float]) -> None:
         """Calculate average of given metrics, push the average to the eval_stack.
 
         Args:
@@ -263,7 +263,7 @@ class ConstantValue(FormulaStep):
         """
         return str(self._value)
 
-    def apply(self, eval_stack: List[float]) -> None:
+    def apply(self, eval_stack: list[float]) -> None:
         """Push the constant value to the eval_stack.
 
         Args:
@@ -293,7 +293,7 @@ class Clipper(FormulaStep):
         """
         return f"clip({self._min_val}, {self._max_val})"
 
-    def apply(self, eval_stack: List[float]) -> None:
+    def apply(self, eval_stack: list[float]) -> None:
         """Clip the value at the top of the eval_stack.
 
         Args:
@@ -326,10 +326,10 @@ class MetricFetcher(Generic[QuantityT], FormulaStep):
         """
         self._name = name
         self._stream: Receiver[Sample[QuantityT]] = stream
-        self._next_value: Optional[Sample[QuantityT]] = None
+        self._next_value: Sample[QuantityT] | None = None
         self._nones_are_zeros = nones_are_zeros
 
-    async def fetch_next(self) -> Optional[Sample[QuantityT]]:
+    async def fetch_next(self) -> Sample[QuantityT] | None:
         """Fetch the next value from the stream.
 
         To be called before each call to `apply`.
@@ -341,7 +341,7 @@ class MetricFetcher(Generic[QuantityT], FormulaStep):
         return self._next_value
 
     @property
-    def value(self) -> Optional[Sample[QuantityT]]:
+    def value(self) -> Sample[QuantityT] | None:
         """Get the next value in the stream.
 
         Returns:
@@ -357,7 +357,7 @@ class MetricFetcher(Generic[QuantityT], FormulaStep):
         """
         return self._name
 
-    def apply(self, eval_stack: List[float]) -> None:
+    def apply(self, eval_stack: list[float]) -> None:
         """Push the latest value from the stream into the evaluation stack.
 
         Args:

--- a/src/frequenz/sdk/timeseries/_formula_engine/_formula_steps.py
+++ b/src/frequenz/sdk/timeseries/_formula_engine/_formula_steps.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import math
 from abc import ABC, abstractmethod
-from typing import Generic, List, Optional
+from typing import Generic
 
 from frequenz.channels import Receiver
 

--- a/src/frequenz/sdk/timeseries/_formula_engine/_resampled_formula_builder.py
+++ b/src/frequenz/sdk/timeseries/_formula_engine/_resampled_formula_builder.py
@@ -4,8 +4,6 @@
 """A builder for creating formula engines that operate on resampled component metrics."""
 
 
-from __future__ import annotations
-
 from collections.abc import Callable
 from typing import Generic
 

--- a/src/frequenz/sdk/timeseries/_formula_engine/_resampled_formula_builder.py
+++ b/src/frequenz/sdk/timeseries/_formula_engine/_resampled_formula_builder.py
@@ -6,7 +6,8 @@
 
 from __future__ import annotations
 
-from typing import Callable, Generic
+from collections.abc import Callable
+from typing import Generic
 
 from frequenz.channels import Receiver, Sender
 

--- a/src/frequenz/sdk/timeseries/_formula_engine/_tokenizer.py
+++ b/src/frequenz/sdk/timeseries/_formula_engine/_tokenizer.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import Enum
-from typing import Optional
 
 
 class StringIter:

--- a/src/frequenz/sdk/timeseries/_formula_engine/_tokenizer.py
+++ b/src/frequenz/sdk/timeseries/_formula_engine/_tokenizer.py
@@ -64,7 +64,7 @@ class StringIter:
             return char
         raise StopIteration()
 
-    def peek(self) -> Optional[str]:
+    def peek(self) -> str | None:
         """Return the next character in the raw string, without consuming it.
 
         Returns:

--- a/src/frequenz/sdk/timeseries/_moving_window.py
+++ b/src/frequenz/sdk/timeseries/_moving_window.py
@@ -3,7 +3,6 @@
 
 """A data window that moves with the latest datapoints of a data stream."""
 
-from __future__ import annotations
 
 import asyncio
 import logging

--- a/src/frequenz/sdk/timeseries/_periodic_feature_extractor.py
+++ b/src/frequenz/sdk/timeseries/_periodic_feature_extractor.py
@@ -12,7 +12,6 @@ underlying buffer, e.g. the moving window, with the same start and end time
 modulo a fixed period.
 """
 
-from __future__ import annotations
 
 import logging
 from dataclasses import dataclass

--- a/src/frequenz/sdk/timeseries/_periodic_feature_extractor.py
+++ b/src/frequenz/sdk/timeseries/_periodic_feature_extractor.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 from datetime import datetime, timedelta
-from typing import List, Tuple
 
 import numpy as np
 from numpy.typing import NDArray

--- a/src/frequenz/sdk/timeseries/_periodic_feature_extractor.py
+++ b/src/frequenz/sdk/timeseries/_periodic_feature_extractor.py
@@ -291,7 +291,7 @@ class PeriodicFeatureExtractor:
 
     def _get_buffer_bounds(
         self, start: datetime, end: datetime
-    ) -> Tuple[int, int, int]:
+    ) -> tuple[int, int, int]:
         """
         Get the bounds of the ringbuffer used for further operations.
 
@@ -363,7 +363,7 @@ class PeriodicFeatureExtractor:
 
     def _get_reshaped_np_array(
         self, start: datetime, end: datetime
-    ) -> Tuple[NDArray[np.float_], int]:
+    ) -> tuple[NDArray[np.float_], int]:
         """
         Create a reshaped numpy array from the MovingWindow.
 
@@ -393,7 +393,7 @@ class PeriodicFeatureExtractor:
         return (self._reshape_np_array(window_array, window_size), window_size)
 
     def avg(
-        self, start: datetime, end: datetime, weights: List[float] | None = None
+        self, start: datetime, end: datetime, weights: list[float] | None = None
     ) -> NDArray[np.float_]:
         """
         Create the average window out of the window defined by `start` and `end`.

--- a/src/frequenz/sdk/timeseries/_resampling.py
+++ b/src/frequenz/sdk/timeseries/_resampling.py
@@ -11,9 +11,10 @@ import logging
 import math
 from bisect import bisect
 from collections import deque
+from collections.abc import AsyncIterator, Callable, Coroutine, Sequence
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
-from typing import AsyncIterator, Callable, Coroutine, Optional, Sequence
+from typing import Optional
 
 from frequenz.channels.util import Timer
 from frequenz.channels.util._timer import _to_microseconds
@@ -324,7 +325,7 @@ class ResamplingError(RuntimeError):
 class SourceProperties:
     """Properties of a resampling source."""
 
-    sampling_start: Optional[datetime] = None
+    sampling_start: datetime | None = None
     """The time when resampling started for this source.
 
     `None` means it didn't started yet.
@@ -333,7 +334,7 @@ class SourceProperties:
     received_samples: int = 0
     """Total samples received by this source so far."""
 
-    sampling_period: Optional[timedelta] = None
+    sampling_period: timedelta | None = None
     """The sampling period of this source.
 
     This means we receive (on average) one sample for this source every

--- a/src/frequenz/sdk/timeseries/_resampling.py
+++ b/src/frequenz/sdk/timeseries/_resampling.py
@@ -14,7 +14,6 @@ from collections import deque
 from collections.abc import AsyncIterator, Callable, Coroutine, Sequence
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
-from typing import Optional
 
 from frequenz.channels.util import Timer
 from frequenz.channels.util._timer import _to_microseconds

--- a/src/frequenz/sdk/timeseries/_ringbuffer/buffer.py
+++ b/src/frequenz/sdk/timeseries/_ringbuffer/buffer.py
@@ -3,7 +3,6 @@
 
 """Ringbuffer implementation with focus on time & memory efficiency."""
 
-from __future__ import annotations
 
 from collections.abc import Iterable
 from copy import deepcopy

--- a/src/frequenz/sdk/timeseries/_ringbuffer/buffer.py
+++ b/src/frequenz/sdk/timeseries/_ringbuffer/buffer.py
@@ -9,7 +9,7 @@ from collections.abc import Iterable
 from copy import deepcopy
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
-from typing import Generic, List, SupportsFloat, SupportsIndex, TypeVar, overload
+from typing import Generic, SupportsFloat, SupportsIndex, TypeVar, overload
 
 import numpy as np
 import numpy.typing as npt

--- a/src/frequenz/sdk/timeseries/_ringbuffer/buffer.py
+++ b/src/frequenz/sdk/timeseries/_ringbuffer/buffer.py
@@ -17,7 +17,7 @@ import numpy.typing as npt
 from .._base_types import UNIX_EPOCH, Sample
 from .._quantities import QuantityT
 
-FloatArray = TypeVar("FloatArray", List[float], npt.NDArray[np.float64])
+FloatArray = TypeVar("FloatArray", list[float], npt.NDArray[np.float64])
 """Type variable of the buffer container."""
 
 
@@ -98,7 +98,7 @@ class OrderedRingBuffer(Generic[FloatArray]):
         return self._sampling_period
 
     @property
-    def gaps(self) -> List[Gap]:
+    def gaps(self) -> list[Gap]:
         """Get the list of ranges for which no values were provided.
 
         See definition of dataclass @Gaps for more info.

--- a/src/frequenz/sdk/timeseries/_ringbuffer/serialization.py
+++ b/src/frequenz/sdk/timeseries/_ringbuffer/serialization.py
@@ -4,7 +4,7 @@
 """Ringbuffer dumping & loading functions."""
 
 # For use of the class type hint inside the class itself.
-from __future__ import annotations
+
 
 import pickle
 from os.path import exists

--- a/src/frequenz/sdk/timeseries/battery_pool/_component_metric_fetcher.py
+++ b/src/frequenz/sdk/timeseries/battery_pool/_component_metric_fetcher.py
@@ -9,8 +9,9 @@ import asyncio
 import logging
 import math
 from abc import ABC, abstractmethod
+from collections.abc import Iterable
 from datetime import datetime, timezone
-from typing import Any, Generic, Iterable, Optional, Self, Set, TypeVar
+from typing import Any, Generic, Optional, Self, Set, TypeVar
 
 from frequenz.channels import ChannelClosedError, Receiver
 
@@ -64,7 +65,7 @@ class ComponentMetricFetcher(AsyncConstructible, ABC):
         return self
 
     @abstractmethod
-    async def fetch_next(self) -> Optional[ComponentMetricsData]:
+    async def fetch_next(self) -> ComponentMetricsData | None:
         """Fetch metrics for this component."""
 
 
@@ -108,7 +109,7 @@ class LatestMetricsFetcher(ComponentMetricFetcher, Generic[T], ABC):
         self._max_waiting_time = MAX_BATTERY_DATA_AGE_SEC
         return self
 
-    async def fetch_next(self) -> Optional[ComponentMetricsData]:
+    async def fetch_next(self) -> ComponentMetricsData | None:
         """Fetch the latest component metrics.
 
         Returns:
@@ -147,7 +148,7 @@ class LatestMetricsFetcher(ComponentMetricFetcher, Generic[T], ABC):
         ...
 
     @abstractmethod
-    def _supported_metrics(self) -> Set[ComponentMetricId]:
+    def _supported_metrics(self) -> set[ComponentMetricId]:
         ...
 
     @abstractmethod
@@ -195,7 +196,7 @@ class LatestBatteryMetricsFetcher(LatestMetricsFetcher[BatteryData]):
         )
         return self
 
-    def _supported_metrics(self) -> Set[ComponentMetricId]:
+    def _supported_metrics(self) -> set[ComponentMetricId]:
         return set(_BatteryDataMethods.keys())
 
     def _extract_metric(self, data: BatteryData, mid: ComponentMetricId) -> float:
@@ -246,7 +247,7 @@ class LatestInverterMetricsFetcher(LatestMetricsFetcher[InverterData]):
         )
         return self
 
-    def _supported_metrics(self) -> Set[ComponentMetricId]:
+    def _supported_metrics(self) -> set[ComponentMetricId]:
         return set(_InverterDataMethods.keys())
 
     def _extract_metric(self, data: InverterData, mid: ComponentMetricId) -> float:

--- a/src/frequenz/sdk/timeseries/battery_pool/_component_metric_fetcher.py
+++ b/src/frequenz/sdk/timeseries/battery_pool/_component_metric_fetcher.py
@@ -11,7 +11,7 @@ import math
 from abc import ABC, abstractmethod
 from collections.abc import Iterable
 from datetime import datetime, timezone
-from typing import Any, Generic, Optional, Self, Set, TypeVar
+from typing import Any, Generic, Self, TypeVar
 
 from frequenz.channels import ChannelClosedError, Receiver
 

--- a/src/frequenz/sdk/timeseries/battery_pool/_component_metrics.py
+++ b/src/frequenz/sdk/timeseries/battery_pool/_component_metrics.py
@@ -3,7 +3,6 @@
 
 """Class that stores values of the component metrics."""
 
-from __future__ import annotations
 
 from collections.abc import Mapping
 from datetime import datetime

--- a/src/frequenz/sdk/timeseries/battery_pool/_methods.py
+++ b/src/frequenz/sdk/timeseries/battery_pool/_methods.py
@@ -8,7 +8,7 @@ import asyncio
 import logging
 from abc import ABC, abstractmethod
 from datetime import datetime, timedelta, timezone
-from typing import Generic, Optional
+from typing import Generic
 
 from frequenz.channels import Broadcast, Receiver
 

--- a/src/frequenz/sdk/timeseries/battery_pool/_methods.py
+++ b/src/frequenz/sdk/timeseries/battery_pool/_methods.py
@@ -89,7 +89,7 @@ class SendOnUpdate(MetricAggregator[T]):
         self._working_batteries: set[int] = working_batteries.intersection(
             metric_calculator.batteries
         )
-        self._result_channel: Broadcast[T | None] = Broadcast[Optional[T]](
+        self._result_channel: Broadcast[T | None] = Broadcast[T | None](
             name=SendOnUpdate.name() + "_" + metric_calculator.name(),
             resend_latest=True,
         )

--- a/src/frequenz/sdk/timeseries/battery_pool/_methods.py
+++ b/src/frequenz/sdk/timeseries/battery_pool/_methods.py
@@ -89,7 +89,7 @@ class SendOnUpdate(MetricAggregator[T]):
         self._working_batteries: set[int] = working_batteries.intersection(
             metric_calculator.batteries
         )
-        self._result_channel: Broadcast[Optional[T]] = Broadcast[Optional[T]](
+        self._result_channel: Broadcast[T | None] = Broadcast[Optional[T]](
             name=SendOnUpdate.name() + "_" + metric_calculator.name(),
             resend_latest=True,
         )

--- a/src/frequenz/sdk/timeseries/battery_pool/_methods.py
+++ b/src/frequenz/sdk/timeseries/battery_pool/_methods.py
@@ -2,7 +2,7 @@
 # Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """Methods for processing battery-inverter data."""
-from __future__ import annotations
+
 
 import asyncio
 import logging

--- a/src/frequenz/sdk/timeseries/battery_pool/_metric_calculator.py
+++ b/src/frequenz/sdk/timeseries/battery_pool/_metric_calculator.py
@@ -2,7 +2,7 @@
 # Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """Module that defines how to aggregate metrics from battery-inverter components."""
-from __future__ import annotations
+
 
 import logging
 from abc import ABC, abstractmethod

--- a/src/frequenz/sdk/timeseries/battery_pool/_metric_calculator.py
+++ b/src/frequenz/sdk/timeseries/battery_pool/_metric_calculator.py
@@ -6,9 +6,9 @@ from __future__ import annotations
 
 import logging
 from abc import ABC, abstractmethod
-from collections.abc import Mapping, Set
+from collections.abc import Iterable, Mapping, Set
 from datetime import datetime, timezone
-from typing import Generic, Iterable, TypeVar
+from typing import Generic, TypeVar
 
 from ...microgrid import connection_manager
 from ...microgrid.component import ComponentCategory, ComponentMetricId, InverterType

--- a/src/frequenz/sdk/timeseries/battery_pool/battery_pool.py
+++ b/src/frequenz/sdk/timeseries/battery_pool/battery_pool.py
@@ -3,7 +3,6 @@
 
 """User interface for requesting aggregated battery-inverter data."""
 
-from __future__ import annotations
 
 import asyncio
 import uuid

--- a/src/frequenz/sdk/timeseries/battery_pool/battery_pool.py
+++ b/src/frequenz/sdk/timeseries/battery_pool/battery_pool.py
@@ -7,9 +7,9 @@ from __future__ import annotations
 
 import asyncio
 import uuid
-from collections.abc import Set
+from collections.abc import Awaitable, Set
 from datetime import timedelta
-from typing import Any, Awaitable
+from typing import Any
 
 from frequenz.channels import Receiver, Sender
 

--- a/src/frequenz/sdk/timeseries/ev_charger_pool/_ev_charger_pool.py
+++ b/src/frequenz/sdk/timeseries/ev_charger_pool/_ev_charger_pool.py
@@ -3,7 +3,6 @@
 
 """Interactions with pools of EV Chargers."""
 
-from __future__ import annotations
 
 import asyncio
 import logging

--- a/src/frequenz/sdk/timeseries/ev_charger_pool/_set_current_bounds.py
+++ b/src/frequenz/sdk/timeseries/ev_charger_pool/_set_current_bounds.py
@@ -7,7 +7,6 @@ import asyncio
 import logging
 from dataclasses import dataclass
 from datetime import timedelta
-from typing import Dict
 
 from frequenz.channels import Broadcast, Sender
 from frequenz.channels.util import Timer, select, selected_from

--- a/src/frequenz/sdk/timeseries/ev_charger_pool/_set_current_bounds.py
+++ b/src/frequenz/sdk/timeseries/ev_charger_pool/_set_current_bounds.py
@@ -97,7 +97,7 @@ class BoundsSetter:
         meter_data = (
             await api_client.meter_data(next(iter(meters)).component_id)
         ).into_peekable()
-        latest_bound: Dict[int, ComponentCurrentLimit] = {}
+        latest_bound: dict[int, ComponentCurrentLimit] = {}
 
         bound_chan = self._bounds_rx
         timer = Timer.timeout(timedelta(self._repeat_interval.total_seconds()))

--- a/src/frequenz/sdk/timeseries/ev_charger_pool/_state_tracker.py
+++ b/src/frequenz/sdk/timeseries/ev_charger_pool/_state_tracker.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 
 import asyncio
 from enum import Enum
-from typing import Optional
 
 from frequenz.channels import Receiver
 from frequenz.channels.util import Merge

--- a/src/frequenz/sdk/timeseries/ev_charger_pool/_state_tracker.py
+++ b/src/frequenz/sdk/timeseries/ev_charger_pool/_state_tracker.py
@@ -88,7 +88,7 @@ class StateTracker:
         """
         self._component_ids = component_ids
         self._task: asyncio.Task[None] = asyncio.create_task(self._run())
-        self._merged_stream: Optional[Merge[EVChargerData]] = None
+        self._merged_stream: Merge[EVChargerData] | None = None
 
         # Initialize all components to the `MISSING` state.  This will change as data
         # starts arriving from the individual components.

--- a/src/frequenz/sdk/timeseries/logical_meter/_logical_meter.py
+++ b/src/frequenz/sdk/timeseries/logical_meter/_logical_meter.py
@@ -3,7 +3,6 @@
 
 """A logical meter for calculating high level metrics for a microgrid."""
 
-from __future__ import annotations
 
 import uuid
 

--- a/tests/actor/power_distributing/test_distribution_algorithm.py
+++ b/tests/actor/power_distributing/test_distribution_algorithm.py
@@ -6,7 +6,6 @@
 import math
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import Dict, List, Optional
 
 from pytest import approx, raises
 

--- a/tests/actor/power_distributing/test_distribution_algorithm.py
+++ b/tests/actor/power_distributing/test_distribution_algorithm.py
@@ -33,8 +33,8 @@ class Bound:
 class Metric:
     """Class to create protobuf Metric."""
 
-    now: Optional[float]
-    bound: Optional[Bound] = None
+    now: float | None
+    bound: Bound | None = None
 
 
 def battery_msg(  # pylint: disable=too-many-arguments
@@ -97,10 +97,10 @@ def inverter_msg(
 
 def create_components(
     num: int,
-    capacity: List[Metric],
-    soc: List[Metric],
-    power: List[PowerBounds],
-) -> List[InvBatPair]:
+    capacity: list[Metric],
+    soc: list[Metric],
+    power: list[PowerBounds],
+) -> list[InvBatPair]:
     """Create components with given arguments.
 
     Args:
@@ -112,7 +112,7 @@ def create_components(
     Returns:
         List of the components
     """
-    components: List[InvBatPair] = []
+    components: list[InvBatPair] = []
     for i in range(0, num):
         battery = battery_msg(2 * i, capacity[i], soc[i], power[2 * i])
         inverter = inverter_msg(2 * i + 1, power[2 * i + 1])
@@ -126,10 +126,10 @@ class TestDistributionAlgorithm:  # pylint: disable=too-many-public-methods
     # pylint: disable=protected-access
 
     def create_components_with_capacity(
-        self, num: int, capacity: List[float]
-    ) -> List[InvBatPair]:
+        self, num: int, capacity: list[float]
+    ) -> list[InvBatPair]:
         """Create components with given capacity."""
-        components: List[InvBatPair] = []
+        components: list[InvBatPair] = []
         for i in range(0, num):
             battery_data = BatteryDataWrapper(
                 component_id=2 * i,
@@ -153,7 +153,7 @@ class TestDistributionAlgorithm:  # pylint: disable=too-many-public-methods
 
     def test_total_capacity(self) -> None:
         """Test if capacity is computed properly."""
-        capacity: List[float] = list(range(4))
+        capacity: list[float] = list(range(4))
         components = self.create_components_with_capacity(4, capacity)
 
         algorithm = DistributionAlgorithm(distributor_exponent=1)
@@ -162,12 +162,12 @@ class TestDistributionAlgorithm:  # pylint: disable=too-many-public-methods
 
     def test_distribute_power_one_battery(self) -> None:
         """Distribute power between one battery."""
-        capacity: List[float] = [98000]
+        capacity: list[float] = [98000]
         components = self.create_components_with_capacity(1, capacity)
 
-        available_soc: Dict[int, float] = {0: 40}
-        incl_bounds: Dict[int, float] = {1: 500}
-        excl_bounds: Dict[int, float] = {1: 0}
+        available_soc: dict[int, float] = {0: 40}
+        incl_bounds: dict[int, float] = {1: 500}
+        excl_bounds: dict[int, float] = {1: 0}
 
         algorithm = DistributionAlgorithm(distributor_exponent=1)
         result = algorithm._distribute_power(  # pylint: disable=protected-access
@@ -183,12 +183,12 @@ class TestDistributionAlgorithm:  # pylint: disable=too-many-public-methods
         First battery has two times more SoC to use, so first battery should have more
         power assigned.
         """
-        capacity: List[float] = [98000, 98000]
+        capacity: list[float] = [98000, 98000]
         components = self.create_components_with_capacity(2, capacity)
 
-        available_soc: Dict[int, float] = {0: 40, 2: 20}
-        incl_bounds: Dict[int, float] = {1: 500, 3: 500}
-        excl_bounds: Dict[int, float] = {1: 0, 3: 0}
+        available_soc: dict[int, float] = {0: 40, 2: 20}
+        incl_bounds: dict[int, float] = {1: 500, 3: 500}
+        excl_bounds: dict[int, float] = {1: 0, 3: 0}
 
         algorithm = DistributionAlgorithm(distributor_exponent=1)
         result = algorithm._distribute_power(  # pylint: disable=protected-access
@@ -204,12 +204,12 @@ class TestDistributionAlgorithm:  # pylint: disable=too-many-public-methods
         First battery has two times less capacity to use, so first
         battery should be have two times less power.
         """
-        capacity: List[float] = [49000, 98000]
+        capacity: list[float] = [49000, 98000]
         components = self.create_components_with_capacity(2, capacity)
 
-        available_soc: Dict[int, float] = {0: 20, 2: 20}
-        incl_bounds: Dict[int, float] = {1: 500, 3: 500}
-        excl_bounds: Dict[int, float] = {1: 0, 3: 0}
+        available_soc: dict[int, float] = {0: 20, 2: 20}
+        incl_bounds: dict[int, float] = {1: 500, 3: 500}
+        excl_bounds: dict[int, float] = {1: 0, 3: 0}
 
         algorithm = DistributionAlgorithm(distributor_exponent=1)
         result = algorithm._distribute_power(  # pylint: disable=protected-access
@@ -226,12 +226,12 @@ class TestDistributionAlgorithm:  # pylint: disable=too-many-public-methods
         two times more SoC. So the distributed power should be equal
         for each battery.
         """
-        capacity: List[float] = [49000, 98000]
+        capacity: list[float] = [49000, 98000]
         components = self.create_components_with_capacity(2, capacity)
 
-        available_soc: Dict[int, float] = {0: 40, 2: 20}
-        incl_bounds: Dict[int, float] = {1: 250, 3: 330}
-        excl_bounds: Dict[int, float] = {1: 0, 3: 0}
+        available_soc: dict[int, float] = {0: 40, 2: 20}
+        incl_bounds: dict[int, float] = {1: 250, 3: 330}
+        excl_bounds: dict[int, float] = {1: 0, 3: 0}
 
         algorithm = DistributionAlgorithm(distributor_exponent=1)
         result = algorithm._distribute_power(  # pylint: disable=protected-access
@@ -243,12 +243,12 @@ class TestDistributionAlgorithm:  # pylint: disable=too-many-public-methods
 
     def test_distribute_power_three_batteries(self) -> None:
         """Test whether the distribution works ok for more batteries."""
-        capacity: List[float] = [49000, 98000, 49000]
+        capacity: list[float] = [49000, 98000, 49000]
         components = self.create_components_with_capacity(3, capacity)
 
-        available_soc: Dict[int, float] = {0: 40, 2: 20, 4: 20}
-        incl_bounds: Dict[int, float] = {1: 1000, 3: 3400, 5: 3550}
-        excl_bounds: Dict[int, float] = {1: 0, 3: 0, 5: 0}
+        available_soc: dict[int, float] = {0: 40, 2: 20, 4: 20}
+        incl_bounds: dict[int, float] = {1: 1000, 3: 3400, 5: 3550}
+        excl_bounds: dict[int, float] = {1: 0, 3: 0, 5: 0}
 
         algorithm = DistributionAlgorithm(distributor_exponent=1)
         result = algorithm._distribute_power(  # pylint: disable=protected-access
@@ -260,12 +260,12 @@ class TestDistributionAlgorithm:  # pylint: disable=too-many-public-methods
 
     def test_distribute_power_three_batteries_2(self) -> None:
         """Test whether the power which couldn't be distributed is correct."""
-        capacity: List[float] = [98000, 49000, 49000]
+        capacity: list[float] = [98000, 49000, 49000]
         components = self.create_components_with_capacity(3, capacity)
 
-        available_soc: Dict[int, float] = {0: 80, 2: 10, 4: 20}
-        incl_bounds: Dict[int, float] = {1: 400, 3: 3400, 5: 300}
-        excl_bounds: Dict[int, float] = {1: 0, 3: 0, 5: 0}
+        available_soc: dict[int, float] = {0: 80, 2: 10, 4: 20}
+        incl_bounds: dict[int, float] = {1: 400, 3: 3400, 5: 300}
+        excl_bounds: dict[int, float] = {1: 0, 3: 0, 5: 0}
 
         algorithm = DistributionAlgorithm(distributor_exponent=1)
         result = algorithm._distribute_power(  # pylint: disable=protected-access
@@ -277,12 +277,12 @@ class TestDistributionAlgorithm:  # pylint: disable=too-many-public-methods
 
     def test_distribute_power_three_batteries_3(self) -> None:
         """Test with batteries with no capacity."""
-        capacity: List[float] = [0, 49000, 0]
+        capacity: list[float] = [0, 49000, 0]
         components = self.create_components_with_capacity(3, capacity)
 
-        available_soc: Dict[int, float] = {0: 80, 2: 10, 4: 20}
-        incl_bounds: Dict[int, float] = {1: 500, 3: 300, 5: 300}
-        excl_bounds: Dict[int, float] = {1: 0, 3: 0, 5: 0}
+        available_soc: dict[int, float] = {0: 80, 2: 10, 4: 20}
+        incl_bounds: dict[int, float] = {1: 500, 3: 300, 5: 300}
+        excl_bounds: dict[int, float] = {1: 0, 3: 0, 5: 0}
 
         algorithm = DistributionAlgorithm(distributor_exponent=1)
         result = algorithm._distribute_power(  # pylint: disable=protected-access
@@ -295,9 +295,9 @@ class TestDistributionAlgorithm:  # pylint: disable=too-many-public-methods
     # Test distribute supply power
     def test_supply_three_batteries_1(self) -> None:
         """Test distribute supply power for batteries with different SoC."""
-        capacity: List[Metric] = [Metric(49000), Metric(49000), Metric(49000)]
+        capacity: list[Metric] = [Metric(49000), Metric(49000), Metric(49000)]
 
-        soc: List[Metric] = [
+        soc: list[Metric] = [
             Metric(20.0, Bound(0, 60)),
             Metric(60.0, Bound(20, 80)),
             Metric(80.0, Bound(20, 80)),
@@ -322,8 +322,8 @@ class TestDistributionAlgorithm:  # pylint: disable=too-many-public-methods
 
     def test_supply_three_batteries_2(self) -> None:
         """Test distribute supply power."""
-        capacity: List[Metric] = [Metric(98000), Metric(49000), Metric(49000)]
-        soc: List[Metric] = [
+        capacity: list[Metric] = [Metric(98000), Metric(49000), Metric(49000)]
+        soc: list[Metric] = [
             Metric(20.0, Bound(0, 50)),
             Metric(60.0, Bound(20, 80)),
             Metric(80.0, Bound(20, 80)),
@@ -347,8 +347,8 @@ class TestDistributionAlgorithm:  # pylint: disable=too-many-public-methods
 
     def test_supply_three_batteries_3(self) -> None:
         """Distribute supply power with small upper bounds."""
-        capacity: List[Metric] = [Metric(98000), Metric(49000), Metric(49000)]
-        soc: List[Metric] = [
+        capacity: list[Metric] = [Metric(98000), Metric(49000), Metric(49000)]
+        soc: list[Metric] = [
             Metric(20.0, Bound(0, 50)),
             Metric(60.0, Bound(20, 80)),
             Metric(80.0, Bound(20, 80)),
@@ -372,8 +372,8 @@ class TestDistributionAlgorithm:  # pylint: disable=too-many-public-methods
 
     def test_supply_three_batteries_4(self) -> None:
         """Distribute supply power with small upper bounds."""
-        capacity: List[Metric] = [Metric(98000), Metric(49000), Metric(49000)]
-        soc: List[Metric] = [
+        capacity: list[Metric] = [Metric(98000), Metric(49000), Metric(49000)]
+        soc: list[Metric] = [
             Metric(20.0, Bound(0, 50)),
             Metric(60.0, Bound(20, 80)),
             Metric(80.0, Bound(20, 80)),
@@ -397,8 +397,8 @@ class TestDistributionAlgorithm:  # pylint: disable=too-many-public-methods
 
     def test_supply_three_batteries_5(self) -> None:
         """Test no capacity."""
-        capacity: List[Metric] = [Metric(98000), Metric(49000), Metric(0.0)]
-        soc: List[Metric] = [
+        capacity: list[Metric] = [Metric(98000), Metric(49000), Metric(0.0)]
+        soc: list[Metric] = [
             Metric(20.0, Bound(40, 90)),
             Metric(60.0, Bound(20, 80)),
             Metric(80.0, Bound(20, 80)),
@@ -422,8 +422,8 @@ class TestDistributionAlgorithm:  # pylint: disable=too-many-public-methods
 
     def test_supply_two_batteries_1(self) -> None:
         """Distribute supply power between two batteries."""
-        capacity: List[Metric] = [Metric(98000), Metric(98000)]
-        soc: List[Metric] = [
+        capacity: list[Metric] = [Metric(98000), Metric(98000)]
+        soc: list[Metric] = [
             Metric(25.0, Bound(0, 80)),
             Metric(25.0, Bound(20, 80)),
         ]
@@ -445,8 +445,8 @@ class TestDistributionAlgorithm:  # pylint: disable=too-many-public-methods
 
     def test_supply_two_batteries_2(self) -> None:
         """Distribute supply power between two batteries."""
-        capacity: List[Metric] = [Metric(98000), Metric(98000)]
-        soc: List[Metric] = [
+        capacity: list[Metric] = [Metric(98000), Metric(98000)]
+        soc: list[Metric] = [
             Metric(75.0, Bound(0, 80)),
             Metric(75.0, Bound(20, 80)),
         ]
@@ -468,8 +468,8 @@ class TestDistributionAlgorithm:  # pylint: disable=too-many-public-methods
     # Test consumption power distribution
     def test_consumption_three_batteries_1(self) -> None:
         """Distribute consume power."""
-        capacity: List[Metric] = [Metric(49000), Metric(49000), Metric(49000)]
-        soc: List[Metric] = [
+        capacity: list[Metric] = [Metric(49000), Metric(49000), Metric(49000)]
+        soc: list[Metric] = [
             Metric(80.0, Bound(0, 100)),
             Metric(40.0, Bound(20, 80)),
             Metric(20.0, Bound(20, 80)),
@@ -493,8 +493,8 @@ class TestDistributionAlgorithm:  # pylint: disable=too-many-public-methods
 
     def test_consumption_three_batteries_2(self) -> None:
         """Distribute consume power."""
-        capacity: List[Metric] = [Metric(98000), Metric(49000), Metric(49000)]
-        soc: List[Metric] = [
+        capacity: list[Metric] = [Metric(98000), Metric(49000), Metric(49000)]
+        soc: list[Metric] = [
             Metric(80.0, Bound(0, 100)),
             Metric(40.0, Bound(20, 80)),
             Metric(20.0, Bound(20, 80)),
@@ -518,8 +518,8 @@ class TestDistributionAlgorithm:  # pylint: disable=too-many-public-methods
 
     def test_consumption_three_batteries_3(self) -> None:
         """Distribute consume power with small bounds."""
-        capacity: List[Metric] = [Metric(98000), Metric(49000), Metric(49000)]
-        soc: List[Metric] = [
+        capacity: list[Metric] = [Metric(98000), Metric(49000), Metric(49000)]
+        soc: list[Metric] = [
             Metric(80.0, Bound(0, 100)),
             Metric(40.0, Bound(20, 80)),
             Metric(20.0, Bound(20, 80)),
@@ -543,8 +543,8 @@ class TestDistributionAlgorithm:  # pylint: disable=too-many-public-methods
 
     def test_consumption_three_batteries_4(self) -> None:
         """Distribute consume power with small upper bounds."""
-        capacity: List[Metric] = [Metric(98000), Metric(49000), Metric(49000)]
-        soc: List[Metric] = [
+        capacity: list[Metric] = [Metric(98000), Metric(49000), Metric(49000)]
+        soc: list[Metric] = [
             Metric(80.0, Bound(0, 100)),
             Metric(40.0, Bound(20, 80)),
             Metric(20.0, Bound(20, 80)),
@@ -568,8 +568,8 @@ class TestDistributionAlgorithm:  # pylint: disable=too-many-public-methods
 
     def test_consumption_three_batteries_5(self) -> None:
         """Test what if some batteries has invalid SoC and capacity."""
-        capacity: List[Metric] = [Metric(98000), Metric(49000), Metric(0.0)]
-        soc: List[Metric] = [
+        capacity: list[Metric] = [Metric(98000), Metric(49000), Metric(0.0)]
+        soc: list[Metric] = [
             Metric(80.0, Bound(0, 50)),
             Metric(40.0, Bound(20, 80)),
             Metric(20.0, Bound(20, 80)),
@@ -593,8 +593,8 @@ class TestDistributionAlgorithm:  # pylint: disable=too-many-public-methods
 
     def test_consumption_three_batteries_6(self) -> None:
         """Distribute consume power."""
-        capacity: List[Metric] = [Metric(98000), Metric(49000), Metric(49000)]
-        soc: List[Metric] = [
+        capacity: list[Metric] = [Metric(98000), Metric(49000), Metric(49000)]
+        soc: list[Metric] = [
             Metric(50.0, Bound(0, 50)),
             Metric(40.0, Bound(20, 80)),
             Metric(20.0, Bound(20, 80)),
@@ -618,8 +618,8 @@ class TestDistributionAlgorithm:  # pylint: disable=too-many-public-methods
 
     def test_consumption_three_batteries_7(self) -> None:
         """Distribute consume power."""
-        capacity: List[Metric] = [Metric(98000), Metric(49000), Metric(49000)]
-        soc: List[Metric] = [
+        capacity: list[Metric] = [Metric(98000), Metric(49000), Metric(49000)]
+        soc: list[Metric] = [
             Metric(20.0, Bound(0, 80)),
             Metric(79.6, Bound(20, 80)),
             Metric(80.0, Bound(20, 80)),
@@ -643,8 +643,8 @@ class TestDistributionAlgorithm:  # pylint: disable=too-many-public-methods
 
     def test_consumption_two_batteries_1(self) -> None:
         """Distribute consume power."""
-        capacity: List[Metric] = [Metric(98000), Metric(98000)]
-        soc: List[Metric] = [
+        capacity: list[Metric] = [Metric(98000), Metric(98000)]
+        soc: list[Metric] = [
             Metric(75.0, Bound(20, 80)),
             Metric(75.0, Bound(0, 100)),
         ]
@@ -665,8 +665,8 @@ class TestDistributionAlgorithm:  # pylint: disable=too-many-public-methods
 
     def test_consumption_two_batteries_distribution_exponent(self) -> None:
         """Distribute consume power."""
-        capacity: List[Metric] = [Metric(98000), Metric(98000)]
-        soc: List[Metric] = [
+        capacity: list[Metric] = [Metric(98000), Metric(98000)]
+        soc: list[Metric] = [
             Metric(70.0, Bound(20, 80)),
             Metric(50.0, Bound(20, 80)),
         ]
@@ -699,8 +699,8 @@ class TestDistributionAlgorithm:  # pylint: disable=too-many-public-methods
 
     def test_consumption_two_batteries_distribution_exponent_1(self) -> None:
         """Distribute consume power."""
-        capacity: List[Metric] = [Metric(98000), Metric(98000)]
-        soc: List[Metric] = [
+        capacity: list[Metric] = [Metric(98000), Metric(98000)]
+        soc: list[Metric] = [
             Metric(50.0, Bound(20, 80)),
             Metric(20.0, Bound(20, 80)),
         ]
@@ -751,8 +751,8 @@ class TestDistributionAlgorithm:  # pylint: disable=too-many-public-methods
 
     def test_supply_two_batteries_distribution_exponent(self) -> None:
         """Distribute power."""
-        capacity: List[Metric] = [Metric(98000), Metric(98000)]
-        soc: List[Metric] = [
+        capacity: list[Metric] = [Metric(98000), Metric(98000)]
+        soc: list[Metric] = [
             Metric(30.0, Bound(20, 80)),
             Metric(50.0, Bound(20, 80)),
         ]
@@ -785,8 +785,8 @@ class TestDistributionAlgorithm:  # pylint: disable=too-many-public-methods
 
     def test_supply_two_batteries_distribution_exponent_1(self) -> None:
         """Distribute power."""
-        capacity: List[Metric] = [Metric(98000), Metric(98000)]
-        soc: List[Metric] = [
+        capacity: list[Metric] = [Metric(98000), Metric(98000)]
+        soc: list[Metric] = [
             Metric(50.0, Bound(20, 80)),
             Metric(80.0, Bound(20, 80)),
         ]
@@ -819,8 +819,8 @@ class TestDistributionAlgorithm:  # pylint: disable=too-many-public-methods
 
     def test_supply_three_batteries_distribution_exponent_2(self) -> None:
         """Distribute power."""
-        capacity: List[Metric] = [Metric(98000), Metric(98000), Metric(98000)]
-        soc: List[Metric] = [
+        capacity: list[Metric] = [Metric(98000), Metric(98000), Metric(98000)]
+        soc: list[Metric] = [
             Metric(50.0, Bound(20, 80)),
             Metric(65.0, Bound(20, 80)),
             Metric(80.0, Bound(20, 80)),
@@ -862,8 +862,8 @@ class TestDistributionAlgorithm:  # pylint: disable=too-many-public-methods
 
     def test_supply_three_batteries_distribution_exponent_3(self) -> None:
         """Distribute power."""
-        capacity: List[Metric] = [Metric(98000), Metric(98000), Metric(98000)]
-        soc: List[Metric] = [
+        capacity: list[Metric] = [Metric(98000), Metric(98000), Metric(98000)]
+        soc: list[Metric] = [
             Metric(56.0, Bound(20, 80)),  # available SoC 36
             Metric(36.0, Bound(20, 80)),  # available SoC 16
             Metric(29.0, Bound(20, 80)),  # available SoC 9
@@ -893,8 +893,8 @@ class TestDistributionAlgorithm:  # pylint: disable=too-many-public-methods
 
     def test_supply_two_batteries_distribution_exponent_less_then_1(self) -> None:
         """Distribute power."""
-        capacity: List[Metric] = [Metric(98000), Metric(98000)]
-        soc: List[Metric] = [
+        capacity: list[Metric] = [Metric(98000), Metric(98000)]
+        soc: list[Metric] = [
             Metric(44.0, Bound(20, 80)),
             Metric(64.0, Bound(20, 80)),
         ]
@@ -959,8 +959,8 @@ class TestDistWithExclBounds:
         |   -3200 | -1000, -1000, -1000    |      -200 |
 
         """
-        capacities: List[Metric] = [Metric(10000), Metric(10000), Metric(10000)]
-        soc: List[Metric] = [
+        capacities: list[Metric] = [Metric(10000), Metric(10000), Metric(10000)]
+        soc: list[Metric] = [
             Metric(30.0, Bound(10, 90)),
             Metric(50.0, Bound(10, 90)),
             Metric(70.0, Bound(10, 90)),
@@ -1052,8 +1052,8 @@ class TestDistWithExclBounds:
         |    3500 | 1000, 1000, 1000          |       500 |
         |   -3500 | -1000, -1000, -1000       |      -500 |
         """
-        capacities: List[Metric] = [Metric(10000), Metric(10000), Metric(10000)]
-        soc: List[Metric] = [
+        capacities: list[Metric] = [Metric(10000), Metric(10000), Metric(10000)]
+        soc: list[Metric] = [
             Metric(50.0, Bound(10, 90)),
             Metric(50.0, Bound(10, 90)),
             Metric(70.0, Bound(10, 90)),
@@ -1153,8 +1153,8 @@ class TestDistWithExclBounds:
         |   -3500 | -1000, -1000, -1000       |      -500 |
         |    3500 | 1000, 1000, 1000          |       500 |
         """
-        capacities: List[Metric] = [Metric(10000), Metric(10000), Metric(10000)]
-        soc: List[Metric] = [
+        capacities: list[Metric] = [Metric(10000), Metric(10000), Metric(10000)]
+        soc: list[Metric] = [
             Metric(50.0, Bound(10, 90)),
             Metric(50.0, Bound(10, 90)),
             Metric(70.0, Bound(10, 90)),

--- a/tests/actor/power_distributing/test_power_distributing.py
+++ b/tests/actor/power_distributing/test_power_distributing.py
@@ -3,7 +3,6 @@
 
 """Tests power distributor."""
 
-from __future__ import annotations
 
 import asyncio
 import math

--- a/tests/actor/test_battery_pool_status.py
+++ b/tests/actor/test_battery_pool_status.py
@@ -50,7 +50,7 @@ class TestBatteryPoolStatus:
         )
         await asyncio.sleep(0.1)
 
-        expected_working: Set[int] = set()
+        expected_working: set[int] = set()
         assert batteries_status.get_working_batteries(batteries) == expected_working
 
         batteries_list = list(batteries)

--- a/tests/actor/test_battery_pool_status.py
+++ b/tests/actor/test_battery_pool_status.py
@@ -3,7 +3,6 @@
 """Tests for BatteryPoolStatus."""
 
 import asyncio
-from typing import Set
 
 from frequenz.channels import Broadcast
 from pytest_mock import MockerFixture

--- a/tests/actor/test_battery_status.py
+++ b/tests/actor/test_battery_status.py
@@ -4,9 +4,10 @@
 
 import asyncio
 import math
+from collections.abc import AsyncIterator, Iterable
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
-from typing import AsyncIterator, Generic, Iterable, List, Optional, TypeVar
+from typing import Generic, List, Optional, TypeVar
 
 import pytest
 import time_machine
@@ -38,10 +39,10 @@ from ..utils.component_data_wrapper import BatteryDataWrapper, InverterDataWrapp
 
 def battery_data(  # pylint: disable=too-many-arguments
     component_id: int,
-    timestamp: Optional[datetime] = None,
+    timestamp: datetime | None = None,
     relay_state: BatteryRelayState.ValueType = BatteryRelayState.RELAY_STATE_CLOSED,
     component_state: BatteryState.ValueType = BatteryState.COMPONENT_STATE_CHARGING,
-    errors: Optional[Iterable[BatteryError]] = None,
+    errors: Iterable[BatteryError] | None = None,
     capacity: float = 0,
 ) -> BatteryData:
     """Create BatteryData with given arguments.
@@ -76,9 +77,9 @@ def battery_data(  # pylint: disable=too-many-arguments
 
 def inverter_data(
     component_id: int,
-    timestamp: Optional[datetime] = None,
+    timestamp: datetime | None = None,
     component_state: InverterState.ValueType = InverterState.COMPONENT_STATE_CHARGING,
-    errors: Optional[List[InverterError]] = None,
+    errors: list[InverterError] | None = None,
 ) -> InverterData:
     """Create InverterData with given arguments.
 

--- a/tests/actor/test_battery_status.py
+++ b/tests/actor/test_battery_status.py
@@ -7,7 +7,7 @@ import math
 from collections.abc import AsyncIterator, Iterable
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
-from typing import Generic, List, Optional, TypeVar
+from typing import Generic, TypeVar
 
 import pytest
 import time_machine

--- a/tests/actor/test_resampling.py
+++ b/tests/actor/test_resampling.py
@@ -4,8 +4,8 @@
 """Frequenz Python SDK resampling example."""
 import asyncio
 import dataclasses
+from collections.abc import Iterator
 from datetime import datetime, timedelta, timezone
-from typing import Iterator
 
 import async_solipsism
 import pytest

--- a/tests/actor/test_run_utils.py
+++ b/tests/actor/test_run_utils.py
@@ -5,7 +5,7 @@
 
 import asyncio
 import time
-from typing import Iterator
+from collections.abc import Iterator
 
 import async_solipsism
 import pytest

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -101,15 +101,15 @@ class TestConfig:
             ("var_bool", bool, True),
             ("var1", bool, 1),
             ("var_bool", StrictBool, True),
-            ("list_int", List[int], [1, 2, 3]),
-            ("list_int", List[StrictInt], [1, 2, 3]),
-            ("list_float", List[int], [1, 2, 3]),
-            ("list_int", List[float], [1.0, 2.0, 3.0]),
-            ("list_float", List[float], [1, 2.0, 3.5]),
-            ("list_non_strict_bool", List[bool], 2 * [False] + 2 * [True]),
-            ("list_non_strict_bool", List[str], ["false", "0", "true", "1"]),
-            ("item_data", List[Item], [Item(item_id=1, name="My Item")]),
-            ("dict_str_int", Dict[str, int], {"a": 1, "b": 2, "c": 3}),
+            ("list_int", list[int], [1, 2, 3]),
+            ("list_int", list[StrictInt], [1, 2, 3]),
+            ("list_float", list[int], [1, 2, 3]),
+            ("list_int", list[float], [1.0, 2.0, 3.0]),
+            ("list_float", list[float], [1, 2.0, 3.5]),
+            ("list_non_strict_bool", list[bool], 2 * [False] + 2 * [True]),
+            ("list_non_strict_bool", list[str], ["false", "0", "true", "1"]),
+            ("item_data", list[Item], [Item(item_id=1, name="My Item")]),
+            ("dict_str_int", dict[str, int], {"a": 1, "b": 2, "c": 3}),
             ("var_none", Optional[float], None),
         ],
     )
@@ -127,9 +127,9 @@ class TestConfig:
             ("var_float", StrictInt),
             ("var_int", StrictFloat),
             ("var1", StrictBool),
-            ("list_float", List[StrictInt]),
-            ("list_int", List[StrictFloat]),
-            ("list_non_strict_bool", List[int]),
+            ("list_float", list[StrictInt]),
+            ("list_int", list[StrictFloat]),
+            ("list_non_strict_bool", list[int]),
         ],
     )
     def test_get_as_validation_error(
@@ -150,7 +150,7 @@ class TestConfig:
         "key_prefix, expected_values_type, value",
         [
             ("my_dict_", str, {"key1": "value1"}),
-            ("my_dict2_", Set[int], {"key1": {1, 2, 3}, "key2": {3}}),
+            ("my_dict2_", set[int], {"key1": {1, 2, 3}, "key2": {3}}),
         ],
     )
     def test_get_dict_values_success(
@@ -170,7 +170,7 @@ class TestConfig:
         [
             ("my_dict_", int),
             ("my_dict2_", int),
-            ("my_dict3_", Set[int]),
+            ("my_dict3_", set[int]),
         ],
     )
     def test_get_dict_success(

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -110,7 +110,7 @@ class TestConfig:
             ("list_non_strict_bool", list[str], ["false", "0", "true", "1"]),
             ("item_data", list[Item], [Item(item_id=1, name="My Item")]),
             ("dict_str_int", dict[str, int], {"a": 1, "b": 2, "c": 3}),
-            ("var_none", Optional[float], None),
+            ("var_none", float | None, None),
         ],
     )
     def test_get_as_success(

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -7,7 +7,7 @@ import re
 
 # pylint: disable = no-name-in-module
 import tomllib
-from typing import Any, Dict, List, Optional, Set
+from typing import Any
 
 import pytest
 from pydantic import BaseModel, StrictBool, StrictFloat, StrictInt

--- a/tests/microgrid/mock_api.py
+++ b/tests/microgrid/mock_api.py
@@ -15,7 +15,6 @@ from collections.abc import Iterable, Iterator
 
 # pylint: disable=invalid-name,no-name-in-module,unused-import
 from concurrent import futures
-from typing import List, Optional, Tuple
 
 import grpc
 from frequenz.api.common.components_pb2 import (

--- a/tests/microgrid/mock_api.py
+++ b/tests/microgrid/mock_api.py
@@ -11,10 +11,11 @@ all framework code, as API integration should be highly encapsulated.
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Iterable, Iterator
 
 # pylint: disable=invalid-name,no-name-in-module,unused-import
 from concurrent import futures
-from typing import Iterable, Iterator, List, Optional, Tuple
+from typing import List, Optional, Tuple
 
 import grpc
 from frequenz.api.common.components_pb2 import (
@@ -72,26 +73,26 @@ class MockMicrogridServicer(  # pylint: disable=too-many-public-methods
 
     def __init__(
         self,
-        components: Optional[List[Tuple[int, ComponentCategory.V]]] = None,
-        connections: Optional[List[Tuple[int, int]]] = None,
+        components: list[tuple[int, ComponentCategory.V]] | None = None,
+        connections: list[tuple[int, int]] | None = None,
     ) -> None:
         """Create a MockMicrogridServicer instance."""
-        self._components: List[Component] = []
-        self._connections: List[Connection] = []
-        self._bounds: List[SetBoundsParam] = []
+        self._components: list[Component] = []
+        self._connections: list[Connection] = []
+        self._bounds: list[SetBoundsParam] = []
 
         if components is not None:
             self.set_components(components)
         if connections is not None:
             self.set_connections(connections)
 
-        self._latest_power: Optional[SetPowerActiveParam] = None
+        self._latest_power: SetPowerActiveParam | None = None
 
     def add_component(
         self,
         component_id: int,
         component_category: ComponentCategory.V,
-        max_current: Optional[Current] = None,
+        max_current: Current | None = None,
         inverter_type: InverterType.V = InverterType.INVERTER_TYPE_UNSPECIFIED,
     ) -> None:
         """Add a component to the mock service."""
@@ -123,14 +124,14 @@ class MockMicrogridServicer(  # pylint: disable=too-many-public-methods
         """Add a connection to the mock service."""
         self._connections.append(Connection(start=start, end=end))
 
-    def set_components(self, components: List[Tuple[int, ComponentCategory.V]]) -> None:
+    def set_components(self, components: list[tuple[int, ComponentCategory.V]]) -> None:
         """Set components to mock service, dropping existing."""
         self._components.clear()
         self._components.extend(
             map(lambda c: Component(id=c[0], category=c[1]), components)
         )
 
-    def set_connections(self, connections: List[Tuple[int, int]]) -> None:
+    def set_connections(self, connections: list[tuple[int, int]]) -> None:
         """Set connections to mock service, dropping existing."""
         self._connections.clear()
         self._connections.extend(
@@ -142,7 +143,7 @@ class MockMicrogridServicer(  # pylint: disable=too-many-public-methods
         """Get argumetns of the latest charge request."""
         return self._latest_power
 
-    def get_bounds(self) -> List[SetBoundsParam]:
+    def get_bounds(self) -> list[SetBoundsParam]:
         """Return the list of received bounds."""
         return self._bounds
 
@@ -299,11 +300,11 @@ class MockGrpcServer:
         """Start the server."""
         await self._server.start()
 
-    async def _stop(self, grace: Optional[float]) -> None:
+    async def _stop(self, grace: float | None) -> None:
         """Stop the server."""
         await self._server.stop(grace)
 
-    async def _wait_for_termination(self, timeout: Optional[float] = None) -> None:
+    async def _wait_for_termination(self, timeout: float | None = None) -> None:
         """Wait for termination."""
         await self._server.wait_for_termination(timeout)
 

--- a/tests/microgrid/test_client.py
+++ b/tests/microgrid/test_client.py
@@ -252,7 +252,7 @@ class TestMicrogridGrpcClient:
 
             # passing empty sets is the same as passing `None`,
             # filter is ignored
-            assert set(await microgrid.connections(starts=set([]), ends=set([]))) == {
+            assert set(await microgrid.connections(starts=set(), ends=set())) == {
                 Connection(1, 2),
                 Connection(2, 3),
                 Connection(2, 4),

--- a/tests/microgrid/test_datapipeline.py
+++ b/tests/microgrid/test_datapipeline.py
@@ -4,8 +4,8 @@
 """Basic tests for the DataPipeline."""
 
 import asyncio
+from collections.abc import Iterator
 from datetime import timedelta
-from typing import Iterator
 
 import async_solipsism
 import pytest
@@ -54,14 +54,12 @@ async def test_actors_started(mocker: MockerFixture) -> None:
     assert datapipeline._power_distributing_actor is None
 
     mock_client = MockMicrogridClient(
-        set(
-            [
-                Component(1, ComponentCategory.GRID),
-                Component(4, ComponentCategory.INVERTER, InverterType.BATTERY),
-                Component(15, ComponentCategory.BATTERY),
-            ]
-        ),
-        connections=set([Connection(1, 4), Connection(4, 15)]),
+        {
+            Component(1, ComponentCategory.GRID),
+            Component(4, ComponentCategory.INVERTER, InverterType.BATTERY),
+            Component(15, ComponentCategory.BATTERY),
+        },
+        connections={Connection(1, 4), Connection(4, 15)},
     )
     mock_client.initialize(mocker)
 

--- a/tests/microgrid/test_graph.py
+++ b/tests/microgrid/test_graph.py
@@ -29,10 +29,10 @@ from .mock_api import MockGrpcServer, MockMicrogridServicer
 
 
 def _check_predecessors_and_successors(graph: gr.ComponentGraph) -> None:
-    expected_predecessors: Dict[int, Set[Component]] = {}
-    expected_successors: Dict[int, Set[Component]] = {}
+    expected_predecessors: dict[int, set[Component]] = {}
+    expected_successors: dict[int, set[Component]] = {}
 
-    components: Dict[int, Component] = {
+    components: dict[int, Component] = {
         component.component_id: component for component in graph.components()
     }
 
@@ -63,7 +63,7 @@ class TestComponentGraph:
     """
 
     @pytest.fixture()
-    def sample_input_components(self) -> Set[Component]:
+    def sample_input_components(self) -> set[Component]:
         """Create a sample set of components for testing purposes."""
         return {
             Component(11, ComponentCategory.GRID),
@@ -74,7 +74,7 @@ class TestComponentGraph:
         }
 
     @pytest.fixture()
-    def sample_input_connections(self) -> Set[Connection]:
+    def sample_input_connections(self) -> set[Connection]:
         """Create a sample set of connections for testing purposes."""
         return {
             Connection(11, 21),
@@ -86,8 +86,8 @@ class TestComponentGraph:
     @pytest.fixture()
     def sample_graph(
         self,
-        sample_input_components: Set[Component],
-        sample_input_connections: Set[Connection],
+        sample_input_components: set[Component],
+        sample_input_connections: set[Connection],
     ) -> gr.ComponentGraph:
         """Create a sample graph for testing purposes."""
         _graph_implementation = gr._MicrogridComponentGraph(
@@ -211,7 +211,7 @@ class TestComponentGraph:
         ],
     )
     def test_filter_graph_components_by_id(
-        self, sample_graph: gr.ComponentGraph, ids: Set[int], expected: Set[Component]
+        self, sample_graph: gr.ComponentGraph, ids: set[int], expected: set[Component]
     ) -> None:
         """Test the graph component query with component ID filter."""
         # with component_id filter specified, we get back only components whose ID
@@ -261,8 +261,8 @@ class TestComponentGraph:
     def test_filter_graph_components_by_type(
         self,
         sample_graph: gr.ComponentGraph,
-        types: Set[ComponentCategory],
-        expected: Set[Component],
+        types: set[ComponentCategory],
+        expected: set[Component],
     ) -> None:
         """Test the graph component query with component category filter."""
         # with component_id filter specified, we get back only components whose ID
@@ -293,9 +293,9 @@ class TestComponentGraph:
     def test_filter_graph_components_with_composite_filter(
         self,
         sample_graph: gr.ComponentGraph,
-        ids: Set[int],
-        types: Set[ComponentCategory],
-        expected: Set[Component],
+        ids: set[int],
+        types: set[ComponentCategory],
+        expected: set[Component],
     ) -> None:
         """Test the graph component query with composite filter."""
         # when both filters are applied, they are combined via AND logic, i.e.
@@ -310,7 +310,7 @@ class TestComponentGraph:
         )
 
     def test_components_without_filters(
-        self, sample_input_components: Set[Component], sample_graph: gr.ComponentGraph
+        self, sample_input_components: set[Component], sample_graph: gr.ComponentGraph
     ) -> None:
         """Test the graph component query without filters."""
         # without any filter applied, we get back all the components in the graph

--- a/tests/microgrid/test_graph.py
+++ b/tests/microgrid/test_graph.py
@@ -8,7 +8,6 @@
 # pylint: disable=too-many-lines,protected-access,no-member
 
 from dataclasses import asdict
-from typing import Dict, Set
 
 import frequenz.api.common.components_pb2 as components_pb
 import grpc

--- a/tests/microgrid/test_microgrid_api.py
+++ b/tests/microgrid/test_microgrid_api.py
@@ -5,7 +5,6 @@
 
 import asyncio
 from asyncio.tasks import ALL_COMPLETED
-from typing import List
 from unittest import mock
 from unittest.mock import AsyncMock, MagicMock
 

--- a/tests/microgrid/test_microgrid_api.py
+++ b/tests/microgrid/test_microgrid_api.py
@@ -21,7 +21,7 @@ class TestMicrogridApi:
 
     # ignore mypy: Untyped decorator makes function "components" untyped
     @pytest.fixture
-    def components(self) -> List[List[Component]]:
+    def components(self) -> list[list[Component]]:
         """Get components in the graph.
 
         Override this method to create a graph with different components.
@@ -54,7 +54,7 @@ class TestMicrogridApi:
 
     # ignore mypy: Untyped decorator makes function "components" untyped
     @pytest.fixture
-    def connections(self) -> List[List[Connection]]:
+    def connections(self) -> list[list[Connection]]:
         """Get connections between components in the graph.
 
         Override this method to create a graph with different connections.
@@ -87,8 +87,8 @@ class TestMicrogridApi:
     async def test_connection_manager(
         self,
         _: MagicMock,
-        components: List[List[Component]],
-        connections: List[List[Connection]],
+        components: list[list[Component]],
+        connections: list[list[Connection]],
     ) -> None:
         """Test microgrid api.
 
@@ -153,8 +153,8 @@ class TestMicrogridApi:
     async def test_connection_manager_another_method(
         self,
         _: MagicMock,
-        components: List[List[Component]],
-        connections: List[List[Connection]],
+        components: list[list[Component]],
+        connections: list[list[Connection]],
     ) -> None:
         """Test if the api was not deallocated.
 

--- a/tests/timeseries/_battery_pool/test_battery_pool.py
+++ b/tests/timeseries/_battery_pool/test_battery_pool.py
@@ -5,7 +5,6 @@
 
 # pylint: disable=too-many-lines
 
-from __future__ import annotations
 
 import asyncio
 import dataclasses

--- a/tests/timeseries/_battery_pool/test_battery_pool.py
+++ b/tests/timeseries/_battery_pool/test_battery_pool.py
@@ -11,9 +11,10 @@ import asyncio
 import dataclasses
 import logging
 import math
+from collections.abc import AsyncIterator, Iterator
 from dataclasses import dataclass, is_dataclass, replace
 from datetime import datetime, timedelta, timezone
-from typing import Any, AsyncIterator, Generic, Iterator, TypeVar
+from typing import Any, Generic, TypeVar
 
 import async_solipsism
 import pytest

--- a/tests/timeseries/_formula_engine/utils.py
+++ b/tests/timeseries/_formula_engine/utils.py
@@ -3,7 +3,6 @@
 
 """Utils for testing formula engines."""
 
-from __future__ import annotations
 
 from collections.abc import Callable
 from math import isclose

--- a/tests/timeseries/_formula_engine/utils.py
+++ b/tests/timeseries/_formula_engine/utils.py
@@ -5,8 +5,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from math import isclose
-from typing import Callable
 
 from frequenz.channels import Receiver
 

--- a/tests/timeseries/mock_microgrid.py
+++ b/tests/timeseries/mock_microgrid.py
@@ -7,8 +7,9 @@ from __future__ import annotations
 
 import asyncio
 import typing
+from collections.abc import Callable
 from datetime import datetime, timedelta, timezone
-from typing import Callable, Set
+from typing import Set
 
 from pytest_mock import MockerFixture
 
@@ -82,17 +83,15 @@ class MockMicrogrid:  # pylint: disable=too-many-instance-attributes
         if grid_meter is not None and graph is not None:
             raise ValueError("grid_meter and graph are mutually exclusive")
 
-        self._components: Set[Component] = (
-            set(
-                [
-                    Component(1, ComponentCategory.GRID),
-                ]
-            )
+        self._components: set[Component] = (
+            {
+                Component(1, ComponentCategory.GRID),
+            }
             if graph is None
             else graph.components()
         )
 
-        self._connections: Set[Connection] = (
+        self._connections: set[Connection] = (
             set() if graph is None else graph.connections()
         )
 
@@ -110,7 +109,7 @@ class MockMicrogrid:  # pylint: disable=too-many-instance-attributes
             return list(
                 map(
                     lambda c: c.component_id,
-                    graph.components(component_category=set([category])),
+                    graph.components(component_category={category}),
                 )
             )
 
@@ -121,7 +120,7 @@ class MockMicrogrid:  # pylint: disable=too-many-instance-attributes
             return [
                 c.component_id
                 for c in graph.components(
-                    component_category=set([ComponentCategory.INVERTER])
+                    component_category={ComponentCategory.INVERTER}
                 )
                 if c.type == comp_type
             ]
@@ -141,7 +140,7 @@ class MockMicrogrid:  # pylint: disable=too-many-instance-attributes
                 # Hacky, ignores multiple batteries behind one inverter
                 list(graph.successors(c.component_id))[0].component_id: c.component_id
                 for c in graph.components(
-                    component_category=set([ComponentCategory.INVERTER])
+                    component_category={ComponentCategory.INVERTER}
                 )
                 if c.type == InverterType.BATTERY
             }

--- a/tests/timeseries/mock_microgrid.py
+++ b/tests/timeseries/mock_microgrid.py
@@ -9,7 +9,6 @@ import asyncio
 import typing
 from collections.abc import Callable
 from datetime import datetime, timedelta, timezone
-from typing import Set
 
 from pytest_mock import MockerFixture
 

--- a/tests/timeseries/mock_microgrid.py
+++ b/tests/timeseries/mock_microgrid.py
@@ -3,7 +3,6 @@
 
 """A configurable mock microgrid for testing logical meter formulas."""
 
-from __future__ import annotations
 
 import asyncio
 import typing

--- a/tests/timeseries/mock_resampler.py
+++ b/tests/timeseries/mock_resampler.py
@@ -3,7 +3,6 @@
 
 """Mock data_pipeline."""
 
-from __future__ import annotations
 
 import asyncio
 from datetime import datetime

--- a/tests/timeseries/test_ev_charger_pool.py
+++ b/tests/timeseries/test_ev_charger_pool.py
@@ -3,7 +3,6 @@
 
 """Tests for the `EVChargerPool`."""
 
-from __future__ import annotations
 
 import asyncio
 

--- a/tests/timeseries/test_formula_engine.py
+++ b/tests/timeseries/test_formula_engine.py
@@ -4,8 +4,9 @@
 """Tests for the FormulaEngine and the Tokenizer."""
 
 import asyncio
+from collections.abc import Callable
 from datetime import datetime
-from typing import Callable, Dict, List, Optional, Tuple, Union
+from typing import Dict, List, Optional, Tuple, Union
 
 from frequenz.channels import Broadcast, Receiver
 
@@ -52,11 +53,11 @@ class TestFormulaEngine:
         self,
         formula: str,
         postfix: str,
-        io_pairs: List[Tuple[List[Optional[float]], Optional[float]]],
+        io_pairs: list[tuple[list[float | None], float | None]],
         nones_are_zeros: bool = False,
     ) -> None:
         """Run a formula test."""
-        channels: Dict[str, Broadcast[Sample[Quantity]]] = {}
+        channels: dict[str, Broadcast[Sample[Quantity]]] = {}
         builder = FormulaBuilder("test_formula", Quantity)
         for token in Tokenizer(formula):
             if token.type == TokenType.COMPONENT_METRIC:
@@ -316,7 +317,7 @@ class TestFormulaEngineComposition:
     async def run_test(  # pylint: disable=too-many-locals
         self,
         num_items: int,
-        make_builder: Union[
+        make_builder: (
             Callable[
                 [
                     FormulaEngine[Quantity],
@@ -324,8 +325,8 @@ class TestFormulaEngineComposition:
                     FormulaEngine[Quantity],
                 ],
                 HigherOrderFormulaBuilder[Quantity],
-            ],
-            Callable[
+            ]
+            | Callable[
                 [
                     FormulaEngine[Quantity],
                     FormulaEngine[Quantity],
@@ -333,9 +334,9 @@ class TestFormulaEngineComposition:
                     FormulaEngine[Quantity],
                 ],
                 HigherOrderFormulaBuilder[Quantity],
-            ],
-        ],
-        io_pairs: List[Tuple[List[Optional[float]], Optional[float]]],
+            ]
+        ),
+        io_pairs: list[tuple[list[float | None], float | None]],
         nones_are_zeros: bool = False,
     ) -> None:
         """Run a test with the specs provided."""
@@ -576,12 +577,12 @@ class TestFormulaAverager:
 
     async def run_test(
         self,
-        components: List[str],
-        io_pairs: List[Tuple[List[Optional[float]], Optional[float]]],
+        components: list[str],
+        io_pairs: list[tuple[list[float | None], float | None]],
     ) -> None:
         """Run a formula test."""
-        channels: Dict[str, Broadcast[Sample[Quantity]]] = {}
-        streams: List[Tuple[str, Receiver[Sample[Quantity]], bool]] = []
+        channels: dict[str, Broadcast[Sample[Quantity]]] = {}
+        streams: list[tuple[str, Receiver[Sample[Quantity]], bool]] = []
         builder = FormulaBuilder("test_averager", create_method=Quantity)
         for comp_id in components:
             if comp_id not in channels:

--- a/tests/timeseries/test_formula_engine.py
+++ b/tests/timeseries/test_formula_engine.py
@@ -6,7 +6,6 @@
 import asyncio
 from collections.abc import Callable
 from datetime import datetime
-from typing import Dict, List, Optional, Tuple, Union
 
 from frequenz.channels import Broadcast, Receiver
 

--- a/tests/timeseries/test_logical_meter.py
+++ b/tests/timeseries/test_logical_meter.py
@@ -3,7 +3,6 @@
 
 """Tests for the logical meter."""
 
-from __future__ import annotations
 
 import asyncio
 from datetime import datetime, timezone

--- a/tests/timeseries/test_moving_window.py
+++ b/tests/timeseries/test_moving_window.py
@@ -4,8 +4,9 @@
 """Tests for the moving window."""
 
 import asyncio
+from collections.abc import Iterator, Sequence
 from datetime import datetime, timedelta, timezone
-from typing import Iterator, Sequence, Tuple
+from typing import Tuple
 
 import async_solipsism
 import numpy as np
@@ -56,7 +57,7 @@ async def push_logical_meter_data(
 
 def init_moving_window(
     size: timedelta,
-) -> Tuple[MovingWindow, Sender[Sample[Quantity]]]:
+) -> tuple[MovingWindow, Sender[Sample[Quantity]]]:
     """Initialize the moving window with given shape.
 
     Args:

--- a/tests/timeseries/test_moving_window.py
+++ b/tests/timeseries/test_moving_window.py
@@ -6,7 +6,6 @@
 import asyncio
 from collections.abc import Iterator, Sequence
 from datetime import datetime, timedelta, timezone
-from typing import Tuple
 
 import async_solipsism
 import numpy as np

--- a/tests/timeseries/test_periodic_feature_extractor.py
+++ b/tests/timeseries/test_periodic_feature_extractor.py
@@ -6,7 +6,6 @@
 import contextlib
 from collections.abc import AsyncIterator
 from datetime import datetime, timedelta, timezone
-from typing import List
 
 import numpy as np
 import pytest

--- a/tests/timeseries/test_periodic_feature_extractor.py
+++ b/tests/timeseries/test_periodic_feature_extractor.py
@@ -27,7 +27,7 @@ from tests.timeseries.test_moving_window import (
 
 @contextlib.asynccontextmanager
 async def init_feature_extractor(
-    data: List[float], period: timedelta
+    data: list[float], period: timedelta
 ) -> AsyncIterator[PeriodicFeatureExtractor]:
     """
     Initialize a PeriodicFeatureExtractor with a `MovingWindow` that contains the data.
@@ -114,7 +114,7 @@ async def test_feature_extractor() -> None:  # pylint: disable=too-many-statemen
     start = UNIX_EPOCH + timedelta(seconds=1)
     end = start + timedelta(seconds=2)
 
-    data: List[float] = [1, 2, 2.5, 1, 1, 1, 2, 2, 1, 1, 2, 2]
+    data: list[float] = [1, 2, 2.5, 1, 1, 1, 2, 2, 1, 1, 2, 2]
 
     async with init_feature_extractor(data, timedelta(seconds=3)) as feature_extractor:
         assert np.allclose(feature_extractor.avg(start, end), [5 / 3, 4 / 3])
@@ -122,18 +122,18 @@ async def test_feature_extractor() -> None:  # pylint: disable=too-many-statemen
     async with init_feature_extractor(data, timedelta(seconds=4)) as feature_extractor:
         assert np.allclose(feature_extractor.avg(start, end), [1, 2])
 
-    data: List[float] = [1, 2, 2.5, 1, 1, 1, 2, 2, 1, 1, 1, 1, 1, 1, 1]  # type: ignore[no-redef]
+    data: list[float] = [1, 2, 2.5, 1, 1, 1, 2, 2, 1, 1, 1, 1, 1, 1, 1]  # type: ignore[no-redef]
 
     async with init_feature_extractor(data, timedelta(seconds=5)) as feature_extractor:
         assert np.allclose(feature_extractor.avg(start, end), [1.5, 1.5])
 
     async def _test_fun(  # pylint: disable=too-many-arguments
-        data: List[float],
+        data: list[float],
         period: int,
         start: int,
         end: int,
-        expected: List[float],
-        weights: List[float] | None = None,
+        expected: list[float],
+        weights: list[float] | None = None,
     ) -> None:
         async with init_feature_extractor(
             data, timedelta(seconds=period)
@@ -149,20 +149,20 @@ async def test_feature_extractor() -> None:  # pylint: disable=too-many-statemen
         period: int,
         start: int,
         end: int,
-        expected: List[float],
-        weights: List[float] | None = None,
+        expected: list[float],
+        weights: list[float] | None = None,
     ) -> None:
-        data: List[float] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        data: list[float] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
         await _test_fun(data, period, start, end, expected, weights)
 
     async def test_011(
         period: int,
         start: int,
         end: int,
-        expected: List[float],
-        weights: List[float] | None = None,
+        expected: list[float],
+        weights: list[float] | None = None,
     ) -> None:
-        data: List[float] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
+        data: list[float] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
         await _test_fun(data, period, start, end, expected, weights)
 
     # empty time period

--- a/tests/timeseries/test_resampling.py
+++ b/tests/timeseries/test_resampling.py
@@ -3,7 +3,6 @@
 
 """Tests for the `TimeSeriesResampler` class."""
 
-from __future__ import annotations
 
 import asyncio
 import logging

--- a/tests/timeseries/test_resampling.py
+++ b/tests/timeseries/test_resampling.py
@@ -7,8 +7,8 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from collections.abc import AsyncIterator, Iterator
 from datetime import datetime, timedelta, timezone
-from typing import AsyncIterator, Iterator
 from unittest.mock import AsyncMock, MagicMock
 
 import async_solipsism

--- a/tests/timeseries/test_ringbuffer.py
+++ b/tests/timeseries/test_ringbuffer.py
@@ -3,7 +3,6 @@
 
 """Tests for the `OrderedRingbuffer` class."""
 
-from __future__ import annotations
 
 import random
 from datetime import datetime, timedelta, timezone

--- a/tests/timeseries/test_ringbuffer_serialization.py
+++ b/tests/timeseries/test_ringbuffer_serialization.py
@@ -3,7 +3,6 @@
 
 """Tests for the `SerializableRingBuffer` class."""
 
-from __future__ import annotations
 
 import random
 from datetime import datetime, timedelta, timezone

--- a/tests/utils/_a_sequence.py
+++ b/tests/utils/_a_sequence.py
@@ -3,7 +3,6 @@
 
 """Helper class to compare two sequences without caring about the underlying type."""
 
-from __future__ import annotations
 
 from collections.abc import Sequence
 from typing import Any

--- a/tests/utils/component_data_streamer.py
+++ b/tests/utils/component_data_streamer.py
@@ -2,7 +2,7 @@
 # Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """Tool for mocking streams of component data."""
-from __future__ import annotations
+
 
 import asyncio
 from dataclasses import replace

--- a/tests/utils/component_data_wrapper.py
+++ b/tests/utils/component_data_wrapper.py
@@ -154,8 +154,8 @@ class EvChargerDataWrapper(EVChargerData):
         component_id: int,
         timestamp: datetime,
         active_power: float = math.nan,
-        current_per_phase: Tuple[float, float, float] | None = None,
-        voltage_per_phase: Tuple[float, float, float] | None = None,
+        current_per_phase: tuple[float, float, float] | None = None,
+        voltage_per_phase: tuple[float, float, float] | None = None,
         frequency: float = 50.0,
         cable_state: EVChargerCableState = EVChargerCableState.UNSPECIFIED,
         component_state: EVChargerComponentState = EVChargerComponentState.UNSPECIFIED,
@@ -208,8 +208,8 @@ class MeterDataWrapper(MeterData):
         component_id: int,
         timestamp: datetime,
         active_power: float = math.nan,
-        current_per_phase: Tuple[float, float, float] | None = None,
-        voltage_per_phase: Tuple[float, float, float] | None = None,
+        current_per_phase: tuple[float, float, float] | None = None,
+        voltage_per_phase: tuple[float, float, float] | None = None,
         frequency: float = math.nan,
     ) -> None:
         """Initialize the MeterDataWrapper.

--- a/tests/utils/component_data_wrapper.py
+++ b/tests/utils/component_data_wrapper.py
@@ -15,7 +15,6 @@ from __future__ import annotations
 import math
 from dataclasses import dataclass, replace
 from datetime import datetime
-from typing import Tuple
 
 import frequenz.api.microgrid.battery_pb2 as battery_pb
 import frequenz.api.microgrid.inverter_pb2 as inverter_pb

--- a/tests/utils/component_graph_utils.py
+++ b/tests/utils/component_graph_utils.py
@@ -2,7 +2,7 @@
 # Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """Utils for tests that uses component graph."""
-from __future__ import annotations
+
 
 from dataclasses import dataclass
 

--- a/tests/utils/mock_microgrid_client.py
+++ b/tests/utils/mock_microgrid_client.py
@@ -3,7 +3,7 @@
 
 """Mock microgrid definition."""
 from functools import partial
-from typing import Any, Dict, Set
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 from frequenz.channels import Broadcast, Receiver

--- a/tests/utils/mock_microgrid_client.py
+++ b/tests/utils/mock_microgrid_client.py
@@ -28,7 +28,7 @@ from frequenz.sdk.microgrid.connection_manager import ConnectionManager
 class MockMicrogridClient:
     """Class that mocks MicrogridClient behavior."""
 
-    def __init__(self, components: Set[Component], connections: Set[Connection]):
+    def __init__(self, components: set[Component], connections: set[Connection]):
         """Create mock microgrid with given components and connections.
 
         This simulates microgrid.
@@ -50,7 +50,7 @@ class MockMicrogridClient:
         meter_channels = self._create_meter_channels()
         ev_charger_channels = self._create_ev_charger_channels()
 
-        self._all_channels: Dict[int, Broadcast[Any]] = {
+        self._all_channels: dict[int, Broadcast[Any]] = {
             **bat_channels,
             **inv_channels,
             **meter_channels,
@@ -60,7 +60,7 @@ class MockMicrogridClient:
         mock_api = self._create_mock_api(
             bat_channels, inv_channels, meter_channels, ev_charger_channels
         )
-        kwargs: Dict[str, Any] = {
+        kwargs: dict[str, Any] = {
             "api_client": mock_api,
             "component_graph": self._component_graph,
         }
@@ -148,7 +148,7 @@ class MockMicrogridClient:
         if cid in self._all_channels:
             await self._all_channels[cid].close()
 
-    def _create_battery_channels(self) -> Dict[int, Broadcast[BatteryData]]:
+    def _create_battery_channels(self) -> dict[int, Broadcast[BatteryData]]:
         """Create channels for the batteries.
 
         Returns:
@@ -166,7 +166,7 @@ class MockMicrogridClient:
             bid: Broadcast[BatteryData]("battery_data_" + str(bid)) for bid in batteries
         }
 
-    def _create_meter_channels(self) -> Dict[int, Broadcast[MeterData]]:
+    def _create_meter_channels(self) -> dict[int, Broadcast[MeterData]]:
         """Create channels for the meters.
 
         Returns:
@@ -182,7 +182,7 @@ class MockMicrogridClient:
 
         return {cid: Broadcast[MeterData]("meter_data_" + str(cid)) for cid in meters}
 
-    def _create_inverter_channels(self) -> Dict[int, Broadcast[InverterData]]:
+    def _create_inverter_channels(self) -> dict[int, Broadcast[InverterData]]:
         """Create channels for the inverters.
 
         Returns:
@@ -201,7 +201,7 @@ class MockMicrogridClient:
             for cid in inverters
         }
 
-    def _create_ev_charger_channels(self) -> Dict[int, Broadcast[EVChargerData]]:
+    def _create_ev_charger_channels(self) -> dict[int, Broadcast[EVChargerData]]:
         """Create channels for the ev chargers.
 
         Returns:
@@ -221,10 +221,10 @@ class MockMicrogridClient:
 
     def _create_mock_api(
         self,
-        bat_channels: Dict[int, Broadcast[BatteryData]],
-        inv_channels: Dict[int, Broadcast[InverterData]],
-        meter_channels: Dict[int, Broadcast[MeterData]],
-        ev_charger_channels: Dict[int, Broadcast[EVChargerData]],
+        bat_channels: dict[int, Broadcast[BatteryData]],
+        inv_channels: dict[int, Broadcast[InverterData]],
+        meter_channels: dict[int, Broadcast[MeterData]],
+        ev_charger_channels: dict[int, Broadcast[EVChargerData]],
     ) -> MagicMock:
         """Create mock of MicrogridApiClient.
 
@@ -270,7 +270,7 @@ class MockMicrogridClient:
     def _get_battery_receiver(
         self,
         component_id: int,
-        channels: Dict[int, Broadcast[BatteryData]],
+        channels: dict[int, Broadcast[BatteryData]],
         maxsize: int = RECEIVER_MAX_SIZE,
     ) -> Receiver[BatteryData]:
         """Return receiver of the broadcast channel for given component_id.
@@ -290,7 +290,7 @@ class MockMicrogridClient:
     def _get_meter_receiver(
         self,
         component_id: int,
-        channels: Dict[int, Broadcast[MeterData]],
+        channels: dict[int, Broadcast[MeterData]],
         maxsize: int = RECEIVER_MAX_SIZE,
     ) -> Receiver[MeterData]:
         """Return receiver of the broadcast channel for given component_id.
@@ -310,7 +310,7 @@ class MockMicrogridClient:
     def _get_ev_charger_receiver(
         self,
         component_id: int,
-        channels: Dict[int, Broadcast[EVChargerData]],
+        channels: dict[int, Broadcast[EVChargerData]],
         maxsize: int = RECEIVER_MAX_SIZE,
     ) -> Receiver[EVChargerData]:
         """Return receiver of the broadcast channel for given component_id.
@@ -330,7 +330,7 @@ class MockMicrogridClient:
     def _get_inverter_receiver(
         self,
         component_id: int,
-        channels: Dict[int, Broadcast[InverterData]],
+        channels: dict[int, Broadcast[InverterData]],
         maxsize: int = RECEIVER_MAX_SIZE,
     ) -> Receiver[InverterData]:
         """Return receiver of the broadcast channel for given component_id.


### PR DESCRIPTION
The tool `pyupgrade` was used to modernize the code base given that frequenz-SDK is already using python 3.11 as minimum version. The tool was mainly used to replace obsolete types.

Just as a reference the tool was run with the following shell command:

```sh
find ./src ./benchmarks ./docs ./examples ./tests -name '*.py' -exec pyupgrade --py311-plus {} \;
```

Also `black` and `isort` were both run to format the code base after running `pyupgrade`.

Fixes #433 