### PR TITLE
ci: Fix publishing of documentation on push

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -81,7 +81,7 @@ jobs:
 
   nox-cross-arch:
     name: Cross-arch tests with nox
-    if: github.event_name == 'merge_group'
+    if: github.event_name != 'pull_request'
     strategy:
       fail-fast: false
       # Before adding new items to this matrix, make sure that a dockerfile

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -185,7 +185,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Return true
-        run: true
+        run: "true"
 
 
   build:


### PR DESCRIPTION
Enable `nox-cross-arch` test for push events because if we don't do this, the `publish-docs` will not run on pushes, so the in-development documentation will not be published.

While cross-arch tests are generally executed in the merge queue on the identical commit, activating them for push events provides an added layer of security. This is especially important in scenarios where emergency pushes might bypass the merge queue.
