### PR TITLE
PowerDistributing: Add support for n:m relations in invs:bats

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -32,6 +32,11 @@
 
 
 
+- The PowerDistributingActor now supports n:m relations between inverters and
+  batteries.
+  This means that one or more inverters can be connected to one or more batteries.
+
+
 ## Bug Fixes
 
 - Fix rendering of diagrams in the documentation.

--- a/src/frequenz/sdk/actor/power_distributing/_distribution_algorithm/__init__.py
+++ b/src/frequenz/sdk/actor/power_distributing/_distribution_algorithm/__init__.py
@@ -4,6 +4,7 @@
 """Utilities to manage power in a microgrid."""
 
 from ._distribution_algorithm import (
+    AggregatedBatteryData,
     DistributionAlgorithm,
     DistributionResult,
     InvBatPair,
@@ -13,4 +14,5 @@ __all__ = [
     "DistributionAlgorithm",
     "DistributionResult",
     "InvBatPair",
+    "AggregatedBatteryData",
 ]

--- a/src/frequenz/sdk/actor/power_distributing/power_distributing.py
+++ b/src/frequenz/sdk/actor/power_distributing/power_distributing.py
@@ -225,19 +225,21 @@ class PowerDistributingActor(Actor):
                 )
                 for battery, inverters in pairs_data
             ),
-            exclusion_lower=sum(
-                min(
-                    battery.power_exclusion_lower_bound,
-                    inverter.active_power_exclusion_lower_bound,
-                )
-                for battery, inverter in pairs_data
+            exclusion_lower=min(
+                sum(battery.power_exclusion_lower_bound for battery, _ in pairs_data),
+                sum(
+                    inverter.active_power_exclusion_lower_bound
+                    for _, inverters in pairs_data
+                    for inverter in inverters
+                ),
             ),
-            exclusion_upper=sum(
-                max(
-                    battery.power_exclusion_upper_bound,
-                    inverter.active_power_exclusion_upper_bound,
-                )
-                for battery, inverter in pairs_data
+            exclusion_upper=max(
+                sum(battery.power_exclusion_upper_bound for battery, _ in pairs_data),
+                sum(
+                    inverter.active_power_exclusion_upper_bound
+                    for _, inverters in pairs_data
+                    for inverter in inverters
+                ),
             ),
         )
 

--- a/src/frequenz/sdk/microgrid/_graph.py
+++ b/src/frequenz/sdk/microgrid/_graph.py
@@ -761,7 +761,7 @@ class _MicrogridComponentGraph(ComponentGraph):
         if self._graph.number_of_edges() == 0:
             raise InvalidGraphError("No connections in component graph!")
 
-        if not nx.is_tree(self._graph):
+        if not nx.is_directed_acyclic_graph(self._graph):
             raise InvalidGraphError("Component graph is not a tree!")
 
         # node[0] is required by the graph definition

--- a/tests/actor/power_distributing/test_power_distributing.py
+++ b/tests/actor/power_distributing/test_power_distributing.py
@@ -100,7 +100,7 @@ class TestPowerDistributingActor:
             )
 
     async def test_power_distributor_one_user(self, mocker: MockerFixture) -> None:
-        """Test if power distribution works with single user works."""
+        """Test if power distribution works with a single user."""
         mockgrid = MockMicrogrid(grid_meter=False)
         mockgrid.add_batteries(3)
         await mockgrid.start(mocker)
@@ -374,7 +374,7 @@ class TestPowerDistributingActor:
             )
         )
 
-        # Battery 106 should not work because both battery and inverter sends NaN
+        # Battery 9 should not work because both battery and inverter sends NaN
         await mockgrid.mock_client.send(
             inverter_msg(
                 8,

--- a/tests/actor/power_distributing/test_power_distributing.py
+++ b/tests/actor/power_distributing/test_power_distributing.py
@@ -366,11 +366,10 @@ class TestPowerDistributingActor:
         await mockgrid.start(mocker)
         await self.init_component_data(mockgrid)
 
-        # Battery 19 should work even if his inverter sends NaN
         await mockgrid.mock_client.send(
             inverter_msg(
                 18,
-                power=PowerBounds(math.nan, 0, 0, math.nan),
+                power=PowerBounds(-1000, 0, 0, 1000),
             )
         )
 

--- a/tests/utils/graph_generator.py
+++ b/tests/utils/graph_generator.py
@@ -106,6 +106,17 @@ class GraphGenerator:
 
         return Component(self.new_id()[category], category, comp_type)
 
+    def components(self, *component_categories: ComponentCategory) -> list[Component]:
+        """Create a list of components with the next available id for each category.
+
+        Args:
+            *component_categories: the component categories
+
+        Returns:
+            the given components.
+        """
+        return [self.component(category) for category in component_categories]
+
     @staticmethod
     def grid() -> Component:
         """Get a new grid component with default id.


### PR DESCRIPTION
- Allow component graph to be a DAG instead of a tree
- Fix comments in tests
- Don't guess missing power bounds from adjacent components
- GraphGenerator: Add function to generate list of components
- PowerDistributing: Add n:m support for inverters:batteries

refs #501 

