### PR TITLE
Add a job to join the `nox` matrix jobs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -185,14 +185,18 @@ jobs:
         if: always()
         run: sudo chown -R $USER:$USER /tmp/pip-cache
 
-  # This job runs if `nox-cross-arch` ran and succeeded.
-  # This is required because, when the `nox-cross-arch` job is skipped, its
-  # inner matrix is not expanded, and branch protection rules on the
-  # inner-matrix jobs get stuck. So instead of `nox-cross-arch`, this job can be
-  # used in the branch protection rules.
-  # At the time of writing this, there is an ongoing discussion about this here:
+  # This job runs if all the `nox-cross-arch` matrix jobs ran and succeeded.
+  # As the `nox-all` job, its main purpose is to provide a single point of
+  # reference in branch protection rules, similar to how `nox-all` operates.
+  # However, there's a crucial difference: the `nox-cross-arch` job is omitted
+  # in PRs. Without the `nox-cross-arch-all` job, the inner matrix wouldn't be
+  # expanded in such scenarios. This would lead to the CI indefinitely waiting
+  # for these jobs to complete due to the branch protection rules, essentially
+  # causing it to hang. This behavior is tied to a recognized GitHub matrices
+  # issue when certain jobs are skipped. For a deeper understanding, refer to:
   # https://github.com/orgs/community/discussions/9141
   nox-cross-arch-all:
+    # The job name should match the name of the `nox-cross-arch` job.
     name: Cross-arch tests with nox
     needs: ["nox-cross-arch"]
     runs-on: ubuntu-20.04

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -187,7 +187,6 @@ jobs:
       - name: Return true
         run: "true"
 
-
   build:
     name: Build distribution packages
     runs-on: ubuntu-20.04

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -79,6 +79,19 @@ jobs:
         run: nox -R -e "$NOX_SESSION"
         timeout-minutes: 10
 
+  # This job runs if all the `nox` matrix jobs ran and succeeded.
+  # It is only used to have a single job that we can require in branch
+  # protection rules, so we don't have to update the protection rules each time
+  # we add or remove a job from the matrix.
+  nox-all:
+    # The job name should match the name of the `nox` job.
+    name: Test with nox
+    needs: ["nox"]
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Return true
+        run: "true"
+
   nox-cross-arch:
     name: Cross-arch tests with nox
     if: github.event_name != 'pull_request'


### PR DESCRIPTION
This job is only used to have a single job we can require in branch protection rules, so we don't have to update the protection rules each time we add or remove a job from the matrix.
