### PR TITLE
Support int indices and slice index behavior in ring buffer and moving window

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -13,8 +13,16 @@
 - A tutorial section and a getting started tutorial
 - In `OrderedRingBuffer`:
   - Rename `datetime_to_index` to `to_internal_index` to avoid confusion between the internal index and the external index.
+  - Add `index_to_datetime` method to convert external index to corresponding datetime.
   - Remove `__setitem__` method to enforce usage of dedicated `update` method only.
+- In `OrderedRingBuffer` and `MovingWindow`:
+  - Support for integer indices is added.
+  - Add `count_covered` method to count the number of elements covered by the used time range.
+
+
+
 
 ## Bug Fixes
 
 - Fix rendering of diagrams in the documentation.
+- The `__getitem__` magic of the `MovingWindow` is fixed to support the same functionality that the `window` method provides.

--- a/src/frequenz/sdk/timeseries/_moving_window.py
+++ b/src/frequenz/sdk/timeseries/_moving_window.py
@@ -243,8 +243,8 @@ class MovingWindow(BackgroundService):
 
     def window(
         self,
-        start: datetime,
-        end: datetime,
+        start: datetime | int | None,
+        end: datetime | int | None,
         *,
         force_copy: bool = True,
     ) -> ArrayLike:
@@ -252,21 +252,17 @@ class MovingWindow(BackgroundService):
         Return an array containing the samples in the given time interval.
 
         Args:
-            start: The start of the time interval. Only datetime objects are supported.
-            end: The end of the time interval. Only datetime objects are supported.
+            start: The start of the time interval. If `None`, the start of the
+                window is used.
+            end: The end of the time interval. If `None`, the end of the window
+                is used.
             force_copy: If `True`, the returned array is a copy of the underlying
                 data. Otherwise, if possible, a view of the underlying data is
                 returned.
 
         Returns:
             An array containing the samples in the given time interval.
-
-        Raises:
-            IndexError: if `start` or `end` are not datetime objects.
         """
-        if not isinstance(start, datetime) or not isinstance(end, datetime):
-            raise IndexError("Only datetime objects are supported as start and end.")
-
         return self._buffer.window(start, end, force_copy=force_copy)
 
     async def _run_impl(self) -> None:

--- a/src/frequenz/sdk/timeseries/_moving_window.py
+++ b/src/frequenz/sdk/timeseries/_moving_window.py
@@ -315,6 +315,15 @@ class MovingWindow(BackgroundService):
         """
         return self._buffer.count_valid()
 
+    def count_covered(self) -> int:
+        """Count the number of samples that are covered by the oldest and newest valid samples.
+
+        Returns:
+            The count of samples between the oldest and newest (inclusive) valid samples
+                or 0 if there are is no time range covered.
+        """
+        return self._buffer.count_covered()
+
     @overload
     def __getitem__(self, key: SupportsIndex) -> float:
         """See the main __getitem__ method.

--- a/src/frequenz/sdk/timeseries/_ringbuffer/buffer.py
+++ b/src/frequenz/sdk/timeseries/_ringbuffer/buffer.py
@@ -566,6 +566,33 @@ class OrderedRingBuffer(Generic[FloatArray]):
         """
         return self._buffer.__getitem__(index_or_slice)
 
+    def _covered_time_range(self) -> timedelta:
+        """Return the time range that is covered by the oldest and newest valid samples.
+
+        Returns:
+            The time range between the oldest and newest valid samples or 0 if
+                there are is no time range covered.
+        """
+        if not self.oldest_timestamp:
+            return timedelta(0)
+
+        assert (
+            self.newest_timestamp is not None
+        ), "Newest timestamp cannot be None here."
+        return self.newest_timestamp - self.oldest_timestamp + self._sampling_period
+
+    def count_covered(self) -> int:
+        """Count the number of samples that are covered by the oldest and newest valid samples.
+
+        Returns:
+            The count of samples between the oldest and newest (inclusive) valid samples
+                or 0 if there are is no time range covered.
+        """
+        return int(
+            self._covered_time_range().total_seconds()
+            // self._sampling_period.total_seconds()
+        )
+
     def count_valid(self) -> int:
         """Count the number of valid items that this buffer currently holds.
 

--- a/src/frequenz/sdk/timeseries/_ringbuffer/buffer.py
+++ b/src/frequenz/sdk/timeseries/_ringbuffer/buffer.py
@@ -257,6 +257,33 @@ class OrderedRingBuffer(Generic[FloatArray]):
             )
         )
 
+    def get_timestamp(self, index: int) -> datetime | None:
+        """Convert the given index to the underlying timestamp.
+
+        Index 0 corresponds to the oldest timestamp in the buffer.
+        If negative indices are used, the newest timestamp is used as reference.
+
+        !!!warning
+
+            The resulting timestamp can be outside the range of the buffer.
+
+        Args:
+            index: Index to convert.
+
+        Returns:
+            Datetime index where the value for the given index can be found.
+                Or None if the buffer is empty.
+        """
+        if self.oldest_timestamp is None:
+            return None
+        assert self.newest_timestamp is not None
+        ref_ts = (
+            self.oldest_timestamp
+            if index >= 0
+            else self.newest_timestamp + self._sampling_period
+        )
+        return ref_ts + index * self._sampling_period
+
     def window(
         self, start: datetime, end: datetime, *, force_copy: bool = True
     ) -> FloatArray:

--- a/tests/timeseries/test_moving_window.py
+++ b/tests/timeseries/test_moving_window.py
@@ -111,12 +111,21 @@ async def test_access_window_by_int_slice() -> None:
         assert np.array_equal(window[5:14], np.array(data[5:14]))
         assert np.array_equal(window.window(5, 14), np.array(data[5:14]))
 
+        # Test with step size (other than 1 not supported)
+        assert np.array_equal(window[5:14:1], np.array(data[5:14]))
+        assert np.array_equal(window[5:14:None], np.array(data[5:14]))
+        with pytest.raises(ValueError):
+            _ = window[5:14:2]
+        with pytest.raises(ValueError):
+            _ = window[14:5:-1]
+
     window, sender = init_moving_window(timedelta(seconds=5))
 
     def test_eq(expected: list[float], start: int | None, end: int | None) -> None:
         assert np.allclose(
             window.window(start, end), np.array(expected), equal_nan=True
         )
+        assert np.allclose(window[start:end], np.array(expected), equal_nan=True)
 
     async with window:
         test_eq([], 0, 1)

--- a/tests/timeseries/test_moving_window.py
+++ b/tests/timeseries/test_moving_window.py
@@ -121,13 +121,10 @@ async def test_access_window_by_ts_slice() -> None:
         assert np.array_equal(window[time_start:time_end], np.array([3.0, 4.0]))  # type: ignore
         assert np.array_equal(window.window(dt(3), dt(5)), np.array([3.0, 4.0]))
         assert np.array_equal(window.window(dt(3), dt(3)), np.array([]))
-        # Window only supports slicing with ascending indices within allowed range
-        with pytest.raises(IndexError):
-            window.window(dt(3), dt(1))
-        with pytest.raises(IndexError):
-            window.window(dt(3), dt(6))
-        with pytest.raises(IndexError):
-            window.window(dt(-1), dt(5))
+        # Window also supports slicing with indices outside allowed range
+        assert np.array_equal(window.window(dt(3), dt(1)), np.array([]))
+        assert np.array_equal(window.window(dt(3), dt(6)), np.array([3, 4]))
+        assert np.array_equal(window.window(dt(-1), dt(5)), np.array([0, 1, 2, 3, 4]))
 
 
 async def test_access_empty_window() -> None:

--- a/tests/timeseries/test_moving_window.py
+++ b/tests/timeseries/test_moving_window.py
@@ -144,12 +144,15 @@ async def test_window_size() -> None:
     async with window:
         assert window.capacity == 5, "Wrong window capacity"
         assert window.count_valid() == 0, "Window should be empty"
+        assert window.count_covered() == 0, "Window should be empty"
         await push_logical_meter_data(sender, range(0, 2))
         assert window.capacity == 5, "Wrong window capacity"
         assert window.count_valid() == 2, "Window should be partially full"
+        assert window.count_covered() == 2, "Window should be partially full"
         await push_logical_meter_data(sender, range(2, 20))
         assert window.capacity == 5, "Wrong window capacity"
         assert window.count_valid() == 5, "Window should be full"
+        assert window.count_covered() == 5, "Window should be full"
 
 
 # pylint: disable=redefined-outer-name

--- a/tests/timeseries/test_ringbuffer.py
+++ b/tests/timeseries/test_ringbuffer.py
@@ -590,3 +590,28 @@ def test_wrapped_buffer_window() -> None:
     assert [3, 9] == list(res2_view)
     assert [3, 4] == list(res2_copy)
     assert [4, 0] == list(res3_copy)
+
+
+def test_get_timestamp() -> None:
+    """Test the get_timestamp function."""
+    buffer = OrderedRingBuffer(
+        np.empty(shape=5, dtype=float),
+        sampling_period=timedelta(seconds=1),
+    )
+    for i in range(5):
+        buffer.update(Sample(dt(i), Quantity(i)))
+    assert dt(4) == buffer.get_timestamp(-1)
+    assert dt(0) == buffer.get_timestamp(-5)
+    assert dt(-1) == buffer.get_timestamp(-6)
+    assert dt(0) == buffer.get_timestamp(0)
+    assert dt(5) == buffer.get_timestamp(5)
+    assert dt(6) == buffer.get_timestamp(6)
+
+    for i in range(10, 15):
+        buffer.update(Sample(dt(i), Quantity(i)))
+    assert dt(14) == buffer.get_timestamp(-1)
+    assert dt(10) == buffer.get_timestamp(-5)
+    assert dt(9) == buffer.get_timestamp(-6)
+    assert dt(10) == buffer.get_timestamp(0)
+    assert dt(15) == buffer.get_timestamp(5)
+    assert dt(16) == buffer.get_timestamp(6)

--- a/tests/timeseries/test_ringbuffer.py
+++ b/tests/timeseries/test_ringbuffer.py
@@ -210,18 +210,21 @@ def test_gaps() -> None:  # pylint: disable=too-many-statements
     assert buffer.oldest_timestamp is None
     assert buffer.newest_timestamp is None
     assert buffer.count_valid() == 0
+    assert buffer.count_covered() == 0
     assert len(buffer.gaps) == 0
 
     buffer.update(Sample(dt(0), Quantity(0)))
     assert buffer.oldest_timestamp == dt(0)
     assert buffer.newest_timestamp == dt(0)
     assert buffer.count_valid() == 1
+    assert buffer.count_covered() == 1
     assert len(buffer.gaps) == 1
 
     buffer.update(Sample(dt(6), Quantity(0)))
     assert buffer.oldest_timestamp == dt(6)
     assert buffer.newest_timestamp == dt(6)
     assert buffer.count_valid() == 1
+    assert buffer.count_covered() == 1
     assert len(buffer.gaps) == 1
 
     buffer.update(Sample(dt(2), Quantity(2)))
@@ -230,48 +233,57 @@ def test_gaps() -> None:  # pylint: disable=too-many-statements
     assert buffer.oldest_timestamp == dt(2)
     assert buffer.newest_timestamp == dt(6)
     assert buffer.count_valid() == 4
+    assert buffer.count_covered() == 5
     assert len(buffer.gaps) == 1
 
     buffer.update(Sample(dt(3), None))
     assert buffer.oldest_timestamp == dt(2)
     assert buffer.newest_timestamp == dt(6)
     assert buffer.count_valid() == 3
+    assert buffer.count_covered() == 5
     assert len(buffer.gaps) == 2
 
     buffer.update(Sample(dt(3), Quantity(np.nan)))
     assert buffer.oldest_timestamp == dt(2)
     assert buffer.newest_timestamp == dt(6)
     assert buffer.count_valid() == 3
+    assert buffer.count_covered() == 5
     assert len(buffer.gaps) == 2
 
     buffer.update(Sample(dt(2), Quantity(np.nan)))
     assert buffer.oldest_timestamp == dt(4)
     assert buffer.newest_timestamp == dt(6)
     assert buffer.count_valid() == 2
+    assert buffer.count_covered() == 3
     assert len(buffer.gaps) == 2
 
     buffer.update(Sample(dt(3), Quantity(3)))
     assert buffer.oldest_timestamp == dt(3)
     assert buffer.newest_timestamp == dt(6)
     assert buffer.count_valid() == 3
+    assert buffer.count_covered() == 4
     assert len(buffer.gaps) == 2
 
     buffer.update(Sample(dt(2), Quantity(2)))
     assert buffer.oldest_timestamp == dt(2)
     assert buffer.newest_timestamp == dt(6)
     assert buffer.count_valid() == 4
+    assert buffer.count_covered() == 5
     assert len(buffer.gaps) == 1
 
     buffer.update(Sample(dt(5), Quantity(5)))
     assert buffer.oldest_timestamp == dt(2)
     assert buffer.newest_timestamp == dt(6)
     assert buffer.count_valid() == 5
+    assert buffer.count_covered() == 5
     assert len(buffer.gaps) == 0
 
+    # whole range gap suffers from sdk#646
     buffer.update(Sample(dt(99), None))
     assert buffer.oldest_timestamp == dt(95)  # bug: should be None
     assert buffer.newest_timestamp == dt(99)  # bug: should be None
     assert buffer.count_valid() == 4  # bug: should be 0 (whole range gap)
+    assert buffer.count_covered() == 5  # bug: should be 0
     assert len(buffer.gaps) == 1
 
 


### PR DESCRIPTION
To support int indices and slice index behavior in the moving window and the ring buffer, the following changes are made:
* Support for int indices in addition to datetime indices is added to moving window and ring buffer.
* Indices behave like usual slices (gracefully accept start >= end or index out of range).
* A method to count the number of possible elements in the range between oldest and newest timestamp is added to ring buffer and the moving window.
* `get_timestamp` is added to convert an int index passed by the user to the corresponding timestamp.

