### PR TITLE
Add option to impute missing values in window method for moving window

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -28,6 +28,7 @@
 - In `OrderedRingBuffer` and `MovingWindow`:
   - Support for integer indices is added.
   - Add `count_covered` method to count the number of elements covered by the used time range.
+  - Add `fill_value` option to window method to impute missing values. By default missing values are imputed with `NaN`.
 - Add `at` method to `MovingWindow` to access a single element and use it in `__getitem__` magic to fully support single element access.
 
 

--- a/src/frequenz/sdk/timeseries/_moving_window.py
+++ b/src/frequenz/sdk/timeseries/_moving_window.py
@@ -289,6 +289,7 @@ class MovingWindow(BackgroundService):
         end: datetime | int | None,
         *,
         force_copy: bool = True,
+        fill_value: float | None = np.nan,
     ) -> ArrayLike:
         """
         Return an array containing the samples in the given time interval.
@@ -305,11 +306,16 @@ class MovingWindow(BackgroundService):
             force_copy: If `True`, the returned array is a copy of the underlying
                 data. Otherwise, if possible, a view of the underlying data is
                 returned.
+            fill_value: If not None, will use this value to fill missing values.
+                If missing values should be set, force_copy must be True.
+                Defaults to NaN to avoid returning outdated data unexpectedly.
 
         Returns:
             An array containing the samples in the given time interval.
         """
-        return self._buffer.window(start, end, force_copy=force_copy)
+        return self._buffer.window(
+            start, end, force_copy=force_copy, fill_value=fill_value
+        )
 
     async def _run_impl(self) -> None:
         """Awaits samples from the receiver and updates the underlying ring buffer.

--- a/tests/timeseries/test_moving_window.py
+++ b/tests/timeseries/test_moving_window.py
@@ -163,10 +163,16 @@ async def test_access_window_by_int_slice() -> None:
             sender, [3.0], start_ts=UNIX_EPOCH + timedelta(seconds=3)
         )
         test_eq([0.0, 1.0], 0, 2)
-        # gap fill not supported yet:
-        # test_eq([0.0, 1.0, np.nan, 3.0], 0, None)
-        # test_eq([0.0, 1.0, np.nan, 3.0], -9, None)
-        # test_eq([np.nan, 3.0], -2, None)
+        # test gaps to be NaN
+        test_eq([0.0, 1.0, np.nan, 3.0], 0, None)
+        test_eq([np.nan, 3.0], -2, None)
+
+        # Test fill_value
+        assert np.allclose(
+            np.array([0.0, 1.0, 2.0, 3.0]),
+            window.window(0, None, fill_value=2.0),
+            equal_nan=True,
+        )
 
         # Complete window
         await push_logical_meter_data(sender, [0.0, 1.0, 2.0, 3.0, 4.0])


### PR DESCRIPTION
The `fill_value` option imputes missing values `NaN` or `None` in the ring buffer and the moving window with the corresponding value. If `None` is passed, no imputation is done. By default, missing values are imputed with `NaN`. This prevents returning outdated return values accidentally.

If missing values should be filled, the force_copy argument has to be true to avoid overwriting the underlying data.