### PR TITLE
Update obsolete comment about networkx-stubs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -177,8 +177,8 @@ module = [
   "grpc.aio",
   "grpc.aio.*",
   "mkdocs_macros.*",
-  # There is a stubs package available, but it's not working:
-  # https://github.com/eggplants/networkx-stubs/issues/1
+  # The available stubs packages are outdated or incomplete (WIP/experimental):
+  # https://github.com/frequenz-floss/frequenz-sdk-python/issues/430
   "networkx",
   "sybil",
   "sybil.*",


### PR DESCRIPTION
The networkx-stubs package was already working as the issue mentioned in the comment was fixed. However, the package networkx-stubs was removed a while ago from Frequenz-SDK as it was no longer maintained and it has been archived.
At the moment of writing, there are only outdated and incomplete alternatives to networkx-stubs.
Besides that, the Frequenz-SDK is not heavily using networkx, so it is not worth it to maintain our own networkx-stubs package or to contribute to a third-party package to fix errors.

Fixes #430 