### PR TITLE
Rename datetime_to_index to to_internal_index

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -11,8 +11,9 @@
 ## New Features
 
 - A tutorial section and a getting started tutorial
-
-- Remove `__setitem__` method from `OrderedRingBuffer` to enforce usage of the dedicated `update` method only.
+- In `OrderedRingBuffer`:
+  - Rename `datetime_to_index` to `to_internal_index` to avoid confusion between the internal index and the external index.
+  - Remove `__setitem__` method to enforce usage of dedicated `update` method only.
 
 ## Bug Fixes
 

--- a/src/frequenz/sdk/timeseries/_moving_window.py
+++ b/src/frequenz/sdk/timeseries/_moving_window.py
@@ -384,7 +384,7 @@ class MovingWindow(BackgroundService):
                 return self._buffer[key]
         elif isinstance(key, datetime):
             _logger.debug("Returning value at time %s ", key)
-            return self._buffer[self._buffer.datetime_to_index(key)]
+            return self._buffer[self._buffer.to_internal_index(key)]
         elif isinstance(key, SupportsIndex):
             _logger.debug("Returning value at index %s ", key)
             return self._buffer[key]

--- a/src/frequenz/sdk/timeseries/_periodic_feature_extractor.py
+++ b/src/frequenz/sdk/timeseries/_periodic_feature_extractor.py
@@ -350,7 +350,7 @@ class PeriodicFeatureExtractor:
 
         # add the offset to the oldest sample in the ringbuffer and wrap around
         # to get the start and end positions in the ringbuffer
-        rb_offset = self._buffer.datetime_to_index(self._buffer.time_bound_oldest)
+        rb_offset = self._buffer.to_internal_index(self._buffer.time_bound_oldest)
         start_pos = self._buffer.wrap(end_pos + self._period + rb_offset)
         end_pos = self._buffer.wrap(end_pos + rb_offset)
 

--- a/tests/timeseries/test_ringbuffer.py
+++ b/tests/timeseries/test_ringbuffer.py
@@ -182,9 +182,9 @@ def test_timestamp_ringbuffer_missing_parameter(
     ) == datetime(2, 2, 2, 0, 10, tzinfo=timezone.utc)
     buffer.update(Sample(datetime(2, 2, 2, 0, 7, 31, tzinfo=timezone.utc), Quantity(0)))
 
-    assert buffer.datetime_to_index(
+    assert buffer.to_internal_index(
         datetime(2, 2, 2, 0, 7, 31, tzinfo=timezone.utc)
-    ) == buffer.datetime_to_index(datetime(2, 2, 2, 0, 10, tzinfo=timezone.utc))
+    ) == buffer.to_internal_index(datetime(2, 2, 2, 0, 10, tzinfo=timezone.utc))
     assert len(buffer.gaps) == 2
 
     # import pdb; pdb.set_trace()


### PR DESCRIPTION
The method is renamed to avoid confusion between indices in a window, which are passed by the user, and the internal indices that point to the actual position in the internal buffer.