### PR TITLE
Allow using macros in docstrings

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -88,10 +88,6 @@ plugins:
         - docs/_scripts/mkdocstrings_autoapi.py
   - literate-nav:
       nav_file: SUMMARY.md
-  - macros:
-      module_name: docs/_scripts/macros
-      on_undefined: strict
-      on_error_fail: true
   - mike:
       canonical_version: latest
   - mkdocstrings:
@@ -119,6 +115,13 @@ plugins:
             - https://protobuf.readthedocs.io/en/latest/objects.inv
             - https://typing-extensions.readthedocs.io/en/stable/objects.inv
             - https://watchfiles.helpmanual.io/objects.inv
+  # Note this plugin must be loaded after mkdocstrings to be able to use macros
+  # inside docstrings. See the comment in `docs/_scripts/macros.py` for more
+  # details
+  - macros:
+      module_name: docs/_scripts/macros
+      on_undefined: strict
+      on_error_fail: true
   - search
 
 # Preview controls


### PR DESCRIPTION
According to @pawamoy:

> `mkdocs-macros` and `mkdocstrings` work at different levels: `mkdocs-macros` at the plugin level (in something like the `on_page_markdown` hook) while `mkdocstrings` renders docstrings at the Markdown conversion level, so in-between `on_page_markdown` and `on_page_content`. That means `mkdocs-macros` never sees the docstrings.

To fix this, we can implement a hack to plug both together in the `define_env()` function for `mkdocs-macros`.

Eventually a `mkdocs-macros` *pluglet* might be implemented so that this hack is not necessary anymore.

For more context see:

* https://github.com/mkdocstrings/mkdocstrings/issues/615
