### PR TITLE
Remove the consumption and production power formulas

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -64,6 +64,8 @@ This version ships an experimental version of the **Power Manager**, adds prelim
 
 - Add consumption and production operators that will replace the logical meters production and consumption function variants.
 
+- Consumption and production power formulas have been removed.
+
 ## Bug Fixes
 
 - Fix rendering of diagrams in the documentation.

--- a/src/frequenz/sdk/timeseries/battery_pool/_battery_pool.py
+++ b/src/frequenz/sdk/timeseries/battery_pool/_battery_pool.py
@@ -262,60 +262,6 @@ class BatteryPool:
         return engine
 
     @property
-    def production_power(self) -> FormulaEngine[Power]:
-        """Fetch the total production power of the batteries in the pool.
-
-        This formula produces positive values when producing power and 0 otherwise.
-
-        If a formula engine to calculate this metric is not already running, it will be
-        started.
-
-        A receiver from the formula engine can be obtained by calling the `new_receiver`
-        method.
-
-        Returns:
-            A FormulaEngine that will calculate and stream the total production power of
-                all batteries in the pool.
-        """
-        engine = self._battery_pool._formula_pool.from_power_formula_generator(
-            "battery_pool_production_power",
-            BatteryPowerFormula,
-            FormulaGeneratorConfig(
-                component_ids=self._battery_pool._batteries,
-                formula_type=FormulaType.PRODUCTION,
-            ),
-        )
-        assert isinstance(engine, FormulaEngine)
-        return engine
-
-    @property
-    def consumption_power(self) -> FormulaEngine[Power]:
-        """Fetch the total consumption power of the batteries in the pool.
-
-        This formula produces positive values when consuming power and 0 otherwise.
-
-        If a formula engine to calculate this metric is not already running, it will be
-        started.
-
-        A receiver from the formula engine can be obtained by calling the `new_receiver`
-        method.
-
-        Returns:
-            A FormulaEngine that will calculate and stream the total consumption
-                power of all batteries in the pool.
-        """
-        engine = self._battery_pool._formula_pool.from_power_formula_generator(
-            "battery_pool_consumption_power",
-            BatteryPowerFormula,
-            FormulaGeneratorConfig(
-                component_ids=self._battery_pool._batteries,
-                formula_type=FormulaType.CONSUMPTION,
-            ),
-        )
-        assert isinstance(engine, FormulaEngine)
-        return engine
-
-    @property
     def soc(self) -> ReceiverFetcher[Sample[Percentage]]:
         """Fetch the normalized average weighted-by-capacity SoC values for the pool.
 

--- a/src/frequenz/sdk/timeseries/battery_pool/_battery_pool.py
+++ b/src/frequenz/sdk/timeseries/battery_pool/_battery_pool.py
@@ -21,7 +21,6 @@ from ..formula_engine import FormulaEngine
 from ..formula_engine._formula_generators import (
     BatteryPowerFormula,
     FormulaGeneratorConfig,
-    FormulaType,
 )
 from ._battery_pool_reference_store import BatteryPoolReferenceStore
 from ._methods import SendOnUpdate
@@ -255,7 +254,6 @@ class BatteryPool:
             BatteryPowerFormula,
             FormulaGeneratorConfig(
                 component_ids=self._battery_pool._batteries,
-                formula_type=FormulaType.PASSIVE_SIGN_CONVENTION,
             ),
         )
         assert isinstance(engine, FormulaEngine)

--- a/src/frequenz/sdk/timeseries/ev_charger_pool/_ev_charger_pool.py
+++ b/src/frequenz/sdk/timeseries/ev_charger_pool/_ev_charger_pool.py
@@ -187,60 +187,6 @@ class EVChargerPool:
         assert isinstance(engine, FormulaEngine)
         return engine
 
-    @property
-    def production_power(self) -> FormulaEngine[Power]:
-        """Fetch the total power produced by the EV Chargers in the pool.
-
-        This formula produces positive values when producing power and 0 otherwise.
-
-        If a formula engine to calculate EV Charger power is not already running, it
-        will be started.
-
-        A receiver from the formula engine can be created using the `new_receiver`
-        method.
-
-        Returns:
-            A FormulaEngine that will calculate and stream the production power of all
-                EV Chargers.
-        """
-        engine = self._formula_pool.from_power_formula_generator(
-            "ev_charger_production_power",
-            EVChargerPowerFormula,
-            FormulaGeneratorConfig(
-                component_ids=self._component_ids,
-                formula_type=FormulaType.PRODUCTION,
-            ),
-        )
-        assert isinstance(engine, FormulaEngine)
-        return engine
-
-    @property
-    def consumption_power(self) -> FormulaEngine[Power]:
-        """Fetch the total power consumed by the EV Chargers in the pool.
-
-        This formula produces positive values when consuming power and 0 otherwise.
-
-        If a formula engine to calculate EV Charger power is not already running, it
-        will be started.
-
-        A receiver from the formula engine can be created using the `new_receiver`
-        method.
-
-        Returns:
-            A FormulaEngine that will calculate and stream the consumption power of all
-                EV Chargers.
-        """
-        engine = self._formula_pool.from_power_formula_generator(
-            "ev_charger_consumption_power",
-            EVChargerPowerFormula,
-            FormulaGeneratorConfig(
-                component_ids=self._component_ids,
-                formula_type=FormulaType.CONSUMPTION,
-            ),
-        )
-        assert isinstance(engine, FormulaEngine)
-        return engine
-
     def component_data(self, component_id: int) -> Receiver[EVChargerData]:
         """Stream 3-phase current values and state of an EV Charger.
 

--- a/src/frequenz/sdk/timeseries/ev_charger_pool/_ev_charger_pool.py
+++ b/src/frequenz/sdk/timeseries/ev_charger_pool/_ev_charger_pool.py
@@ -26,7 +26,6 @@ from ..formula_engine._formula_generators import (
     EVChargerCurrentFormula,
     EVChargerPowerFormula,
     FormulaGeneratorConfig,
-    FormulaType,
 )
 from ._set_current_bounds import BoundsSetter, ComponentCurrentLimit
 from ._state_tracker import EVChargerState, StateTracker
@@ -181,7 +180,6 @@ class EVChargerPool:
             EVChargerPowerFormula,
             FormulaGeneratorConfig(
                 component_ids=self._component_ids,
-                formula_type=FormulaType.PASSIVE_SIGN_CONVENTION,
             ),
         )
         assert isinstance(engine, FormulaEngine)

--- a/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/__init__.py
+++ b/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/__init__.py
@@ -13,7 +13,6 @@ from ._formula_generator import (
     FormulaGenerationError,
     FormulaGenerator,
     FormulaGeneratorConfig,
-    FormulaType,
 )
 from ._grid_current_formula import GridCurrentFormula
 from ._grid_power_formula import GridPowerFormula
@@ -26,7 +25,6 @@ __all__ = [
     #
     "FormulaGenerator",
     "FormulaGeneratorConfig",
-    "FormulaType",
     #
     # Power Formula generators
     #

--- a/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_battery_power_formula.py
+++ b/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_battery_power_formula.py
@@ -13,7 +13,6 @@ from ._formula_generator import (
     NON_EXISTING_COMPONENT_ID,
     ComponentNotFound,
     FormulaGenerator,
-    FormulaType,
 )
 
 _logger = logging.getLogger(__name__)
@@ -78,12 +77,5 @@ class BatteryPowerFormula(FormulaGenerator[Power]):
                 builder.push_oper("+")
             builder.push_component_metric(comp.component_id, nones_are_zeros=True)
         builder.push_oper(")")
-        if self._config.formula_type == FormulaType.PRODUCTION:
-            builder.push_oper("*")
-            builder.push_constant(-1)
-        builder.push_oper(")")
-
-        if self._config.formula_type != FormulaType.PASSIVE_SIGN_CONVENTION:
-            builder.push_clipper(0.0, None)
 
         return builder.build()

--- a/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_chp_power_formula.py
+++ b/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_chp_power_formula.py
@@ -15,7 +15,6 @@ from ._formula_generator import (
     NON_EXISTING_COMPONENT_ID,
     FormulaGenerationError,
     FormulaGenerator,
-    FormulaType,
 )
 
 _logger = logging.getLogger(__name__)
@@ -58,13 +57,6 @@ class CHPPowerFormula(FormulaGenerator[Power]):
                 builder.push_oper("+")
             builder.push_component_metric(chp_meter_id, nones_are_zeros=False)
         builder.push_oper(")")
-        if self._config.formula_type == FormulaType.PRODUCTION:
-            builder.push_oper("*")
-            builder.push_constant(-1)
-        builder.push_oper(")")
-
-        if self._config.formula_type != FormulaType.PASSIVE_SIGN_CONVENTION:
-            builder.push_clipper(0.0, None)
 
         return builder.build()
 

--- a/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_ev_charger_power_formula.py
+++ b/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_ev_charger_power_formula.py
@@ -8,7 +8,7 @@ import logging
 from ....microgrid.component import ComponentMetricId
 from ..._quantities import Power
 from .._formula_engine import FormulaEngine
-from ._formula_generator import NON_EXISTING_COMPONENT_ID, FormulaGenerator, FormulaType
+from ._formula_generator import NON_EXISTING_COMPONENT_ID, FormulaGenerator
 
 _logger = logging.getLogger(__name__)
 
@@ -48,12 +48,5 @@ class EVChargerPowerFormula(FormulaGenerator[Power]):
                 builder.push_oper("+")
             builder.push_component_metric(component_id, nones_are_zeros=True)
         builder.push_oper(")")
-        if self._config.formula_type == FormulaType.PRODUCTION:
-            builder.push_oper("*")
-            builder.push_constant(-1)
-        builder.push_oper(")")
-
-        if self._config.formula_type != FormulaType.PASSIVE_SIGN_CONVENTION:
-            builder.push_clipper(0.0, None)
 
         return builder.build()

--- a/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_formula_generator.py
+++ b/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_formula_generator.py
@@ -9,7 +9,6 @@ from abc import ABC, abstractmethod
 from collections import abc
 from collections.abc import Callable
 from dataclasses import dataclass
-from enum import Enum
 from typing import Generic
 
 from frequenz.channels import Sender
@@ -41,34 +40,12 @@ frequency as the other streams.
 """
 
 
-class FormulaType(Enum):
-    """Enum representing type of formula outputs."""
-
-    PASSIVE_SIGN_CONVENTION = 1
-    """Formula output will be signed values, following the passive sign convention, with
-    consumption from the grid being positive and production to the grid being negative.
-    """
-
-    PRODUCTION = 2
-    """Formula output will be unsigned values representing production to the grid.  When
-    power is being consumed from the grid instead, this formula will output zero.
-    """
-
-    CONSUMPTION = 3
-    """Formula output will be unsigned values representing consumption from the grid.
-    When power is being produced to the grid instead, this formula will output zero.
-    """
-
-
 @dataclass(frozen=True)
 class FormulaGeneratorConfig:
     """Config for formula generators."""
 
     component_ids: abc.Set[int] | None = None
     """The component IDs to use for generating the formula."""
-
-    formula_type: FormulaType = FormulaType.PASSIVE_SIGN_CONVENTION
-    """The type of formula output."""
 
 
 class FormulaGenerator(ABC, Generic[QuantityT]):

--- a/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_grid_power_formula.py
+++ b/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_grid_power_formula.py
@@ -6,7 +6,7 @@
 from ....microgrid.component import ComponentCategory, ComponentMetricId
 from ..._quantities import Power
 from .._formula_engine import FormulaEngine
-from ._formula_generator import FormulaGenerator, FormulaType
+from ._formula_generator import FormulaGenerator
 
 
 class GridPowerFormula(FormulaGenerator[Power]):
@@ -66,13 +66,5 @@ class GridPowerFormula(FormulaGenerator[Power]):
                 comp.component_id, nones_are_zeros=nones_are_zeros
             )
         builder.push_oper(")")
-
-        if self._config.formula_type == FormulaType.PRODUCTION:
-            builder.push_oper("*")
-            builder.push_constant(-1)
-        builder.push_oper(")")
-
-        if self._config.formula_type != FormulaType.PASSIVE_SIGN_CONVENTION:
-            builder.push_clipper(0.0, None)
 
         return builder.build()

--- a/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_pv_power_formula.py
+++ b/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_pv_power_formula.py
@@ -9,7 +9,7 @@ from ....microgrid import connection_manager
 from ....microgrid.component import ComponentCategory, ComponentMetricId
 from ..._quantities import Power
 from .._formula_engine import FormulaEngine
-from ._formula_generator import NON_EXISTING_COMPONENT_ID, FormulaGenerator, FormulaType
+from ._formula_generator import NON_EXISTING_COMPONENT_ID, FormulaGenerator
 
 _logger = logging.getLogger(__name__)
 
@@ -69,12 +69,5 @@ class PVPowerFormula(FormulaGenerator[Power]):
                 nones_are_zeros=component.category != ComponentCategory.METER,
             )
         builder.push_oper(")")
-        if self._config.formula_type == FormulaType.PRODUCTION:
-            builder.push_oper("*")
-            builder.push_constant(-1)
-        builder.push_oper(")")
-
-        if self._config.formula_type != FormulaType.PASSIVE_SIGN_CONVENTION:
-            builder.push_clipper(0.0, None)
 
         return builder.build()

--- a/src/frequenz/sdk/timeseries/logical_meter/_logical_meter.py
+++ b/src/frequenz/sdk/timeseries/logical_meter/_logical_meter.py
@@ -153,52 +153,6 @@ class LogicalMeter:
         return engine
 
     @property
-    def grid_consumption_power(self) -> FormulaEngine[Power]:
-        """Fetch the grid consumption power for the microgrid.
-
-        This formula produces positive values when consuming power and 0 otherwise.
-
-        If a formula engine to calculate grid consumption power is not already running,
-        it will be started.
-
-        A receiver from the formula engine can be created using the `new_receiver`
-        method.
-
-        Returns:
-            A FormulaEngine that will calculate and stream grid consumption power.
-        """
-        engine = self._formula_pool.from_power_formula_generator(
-            "grid_consumption_power",
-            GridPowerFormula,
-            FormulaGeneratorConfig(formula_type=FormulaType.CONSUMPTION),
-        )
-        assert isinstance(engine, FormulaEngine)
-        return engine
-
-    @property
-    def grid_production_power(self) -> FormulaEngine[Power]:
-        """Fetch the grid production power for the microgrid.
-
-        This formula produces positive values when producing power and 0 otherwise.
-
-        If a formula engine to calculate grid production power is not already running,
-        it will be started.
-
-        A receiver from the formula engine can be created using the `new_receiver`
-        method.
-
-        Returns:
-            A FormulaEngine that will calculate and stream grid production power.
-        """
-        engine = self._formula_pool.from_power_formula_generator(
-            "grid_production_power",
-            GridPowerFormula,
-            FormulaGeneratorConfig(formula_type=FormulaType.PRODUCTION),
-        )
-        assert isinstance(engine, FormulaEngine)
-        return engine
-
-    @property
     def grid_current(self) -> FormulaEngine3Phase[Current]:
         """Fetch the grid power for the microgrid.
 
@@ -294,52 +248,6 @@ class LogicalMeter:
         return engine
 
     @property
-    def pv_production_power(self) -> FormulaEngine[Power]:
-        """Fetch the PV power production in the microgrid.
-
-        This formula produces positive values when producing power and 0 otherwise.
-
-        If a formula engine to calculate PV power production is not already running, it
-        will be started.
-
-        A receiver from the formula engine can be created using the `new_receiver`
-        method.
-
-        Returns:
-            A FormulaEngine that will calculate and stream PV power production.
-        """
-        engine = self._formula_pool.from_power_formula_generator(
-            "pv_production_power",
-            PVPowerFormula,
-            FormulaGeneratorConfig(formula_type=FormulaType.PRODUCTION),
-        )
-        assert isinstance(engine, FormulaEngine)
-        return engine
-
-    @property
-    def pv_consumption_power(self) -> FormulaEngine[Power]:
-        """Fetch the PV power consumption in the microgrid.
-
-        This formula produces positive values when consuming power and 0 otherwise.
-
-        If a formula engine to calculate PV power consumption is not already running, it
-        will be started.
-
-        A receiver from the formula engine can be created using the `new_receiver`
-        method.
-
-        Returns:
-            A FormulaEngine that will calculate and stream PV power consumption.
-        """
-        engine = self._formula_pool.from_power_formula_generator(
-            "pv_consumption_power",
-            PVPowerFormula,
-            FormulaGeneratorConfig(formula_type=FormulaType.CONSUMPTION),
-        )
-        assert isinstance(engine, FormulaEngine)
-        return engine
-
-    @property
     def chp_power(self) -> FormulaEngine[Power]:
         """Fetch the CHP power production in the microgrid.
 
@@ -358,56 +266,6 @@ class LogicalMeter:
             "chp_power",
             CHPPowerFormula,
             FormulaGeneratorConfig(formula_type=FormulaType.PASSIVE_SIGN_CONVENTION),
-        )
-        assert isinstance(engine, FormulaEngine)
-        return engine
-
-    @property
-    def chp_production_power(self) -> FormulaEngine[Power]:
-        """Fetch the CHP power production in the microgrid.
-
-        This formula produces positive values when producing power and 0 otherwise.
-
-        If a formula engine to calculate CHP power production is not already running, it
-        will be started.
-
-        A receiver from the formula engine can be created using the `new_receiver`
-        method.
-
-        Returns:
-            A FormulaEngine that will calculate and stream CHP power production.
-        """
-        engine = self._formula_pool.from_power_formula_generator(
-            "chp_production_power",
-            CHPPowerFormula,
-            FormulaGeneratorConfig(
-                formula_type=FormulaType.PRODUCTION,
-            ),
-        )
-        assert isinstance(engine, FormulaEngine)
-        return engine
-
-    @property
-    def chp_consumption_power(self) -> FormulaEngine[Power]:
-        """Fetch the CHP power consumption in the microgrid.
-
-        This formula produces positive values when consuming power and 0 otherwise.
-
-        If a formula engine to calculate CHP power consumption is not already running,
-        it will be started.
-
-        A receiver from the formula engine can be created using the `new_receiver`
-        method.
-
-        Returns:
-            A FormulaEngine that will calculate and stream CHP power consumption.
-        """
-        engine = self._formula_pool.from_power_formula_generator(
-            "chp_consumption_power",
-            CHPPowerFormula,
-            FormulaGeneratorConfig(
-                formula_type=FormulaType.CONSUMPTION,
-            ),
         )
         assert isinstance(engine, FormulaEngine)
         return engine

--- a/src/frequenz/sdk/timeseries/logical_meter/_logical_meter.py
+++ b/src/frequenz/sdk/timeseries/logical_meter/_logical_meter.py
@@ -16,8 +16,6 @@ from ..formula_engine._formula_engine_pool import FormulaEnginePool
 from ..formula_engine._formula_generators import (
     CHPPowerFormula,
     ConsumerPowerFormula,
-    FormulaGeneratorConfig,
-    FormulaType,
     GridCurrentFormula,
     GridPowerFormula,
     ProducerPowerFormula,
@@ -242,7 +240,6 @@ class LogicalMeter:
         engine = self._formula_pool.from_power_formula_generator(
             "pv_power",
             PVPowerFormula,
-            FormulaGeneratorConfig(formula_type=FormulaType.PASSIVE_SIGN_CONVENTION),
         )
         assert isinstance(engine, FormulaEngine)
         return engine
@@ -265,7 +262,6 @@ class LogicalMeter:
         engine = self._formula_pool.from_power_formula_generator(
             "chp_power",
             CHPPowerFormula,
-            FormulaGeneratorConfig(formula_type=FormulaType.PASSIVE_SIGN_CONVENTION),
         )
         assert isinstance(engine, FormulaEngine)
         return engine

--- a/tests/timeseries/_battery_pool/test_battery_pool.py
+++ b/tests/timeseries/_battery_pool/test_battery_pool.py
@@ -483,23 +483,15 @@ async def test_battery_pool_power(mocker: MockerFixture) -> None:
 
     battery_pool = microgrid.battery_pool()
     power_receiver = battery_pool.power.new_receiver()
-    consumption_receiver = battery_pool.consumption_power.new_receiver()
-    production_receiver = battery_pool.production_power.new_receiver()
 
     await mockgrid.mock_resampler.send_bat_inverter_power([2.0, 3.0])
     assert (await power_receiver.receive()).value == Power.from_watts(5.0)
-    assert (await consumption_receiver.receive()).value == Power.from_watts(5.0)
-    assert (await production_receiver.receive()).value == Power.from_watts(0.0)
 
     await mockgrid.mock_resampler.send_bat_inverter_power([-2.0, -5.0])
     assert (await power_receiver.receive()).value == Power.from_watts(-7.0)
-    assert (await consumption_receiver.receive()).value == Power.from_watts(0.0)
-    assert (await production_receiver.receive()).value == Power.from_watts(7.0)
 
     await mockgrid.mock_resampler.send_bat_inverter_power([2.0, -5.0])
     assert (await power_receiver.receive()).value == Power.from_watts(-3.0)
-    assert (await consumption_receiver.receive()).value == Power.from_watts(0.0)
-    assert (await production_receiver.receive()).value == Power.from_watts(3.0)
 
     await mockgrid.cleanup()
 

--- a/tests/timeseries/test_ev_charger_pool.py
+++ b/tests/timeseries/test_ev_charger_pool.py
@@ -85,18 +85,12 @@ class TestEVChargerPool:
 
         ev_pool = microgrid.ev_charger_pool()
         power_receiver = ev_pool.power.new_receiver()
-        production_receiver = ev_pool.production_power.new_receiver()
-        consumption_receiver = ev_pool.consumption_power.new_receiver()
 
         await mockgrid.mock_resampler.send_evc_power([2.0, 4.0, 10.0])
         assert (await power_receiver.receive()).value == Power.from_watts(16.0)
-        assert (await production_receiver.receive()).value == Power.from_watts(0.0)
-        assert (await consumption_receiver.receive()).value == Power.from_watts(16.0)
 
         await mockgrid.mock_resampler.send_evc_power([2.0, 4.0, -10.0])
         assert (await power_receiver.receive()).value == Power.from_watts(-4.0)
-        assert (await production_receiver.receive()).value == Power.from_watts(4.0)
-        assert (await consumption_receiver.receive()).value == Power.from_watts(0.0)
 
         await mockgrid.cleanup()
 


### PR DESCRIPTION
Users must understand passive sign conventions to utilize these formulas effectively, and therefore they do not provide significant benefits.
