### PR TITLE
Update pydantic to v2.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,9 +37,9 @@ dependencies = [
   "networkx >= 2.8, < 4",
   "numpy >= 1.24.2, < 2",
   "protobuf >= 4.21.6, < 5",
-  "pydantic >= 1.9, < 2",
+  "pydantic >= 2.3, < 3",
   "tqdm >= 4.38.0, < 5",
-  "typing_extensions >= 4.4.0, < 5",
+  "typing_extensions >= 4.6.1, < 5",
   "watchfiles >= 0.15.0",
 ]
 dynamic = ["version"]

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -92,10 +92,10 @@ class TestConfig:
             ("logging_lvl", str, "DEBUG"),
             ("var_int", int, 5),
             ("var_int", StrictInt, 5),
+            ("var_int", StrictFloat, 5.0),
             ("var_int", float, 5.0),
             ("var_float", float, 3.14),
             ("var_float", StrictFloat, 3.14),
-            ("var_float", int, 3),
             ("var_bool", int, 1),
             ("var_bool", float, 1.0),
             ("var_bool", bool, True),
@@ -103,7 +103,7 @@ class TestConfig:
             ("var_bool", StrictBool, True),
             ("list_int", list[int], [1, 2, 3]),
             ("list_int", list[StrictInt], [1, 2, 3]),
-            ("list_float", list[int], [1, 2, 3]),
+            ("list_int", list[StrictFloat], [1.0, 2.0, 3.0]),
             ("list_int", list[float], [1.0, 2.0, 3.0]),
             ("list_float", list[float], [1, 2.0, 3.5]),
             ("list_non_strict_bool", list[bool], 2 * [False] + 2 * [True]),
@@ -124,12 +124,12 @@ class TestConfig:
     @pytest.mark.parametrize(
         "key, expected_type",
         [
+            ("var_float", int),
             ("var_float", StrictInt),
-            ("var_int", StrictFloat),
             ("var1", StrictBool),
             ("list_float", list[StrictInt]),
-            ("list_int", list[StrictFloat]),
             ("list_non_strict_bool", list[int]),
+            ("list_float", list[int]),
         ],
     )
     def test_get_as_validation_error(


### PR DESCRIPTION
This update is necessary to stay current with the latest pydantic version, rather than pinning the library to v1.9.0. However, it's worth noting that this is a temporary solution until Frequenz-SDK is updated to use Marshmallow instead of pydantic, which would require a higher level of effort.

One important consideration is the dependency on
typing-extensions>=4.6.1 introduced in pydantic v2.0.

Additionally, there's a breaking change in pydantic v2, which disallows data type conversion if it results in a loss of precision. This is particularly relevant when converting a float to an int. Consequently, the `test_config.py` file has been updated to accommodate this change.

Fixes #500 