### PR TITLE
Add a restart delay to actors to avoid spam-restarting of buggy actors

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -25,6 +25,8 @@ This version ships an experimental version of the **Power Manager**, adds prelim
 
 - Move `microgrid.ComponentGraph` class to `microgrid.component_graph.ComponentGraph`, exposing only the high level interface functions through the `microgrid` package.
 
+- An actor that is crashing will no longer instantly restart but induce an artificial delay to avoid potential spam-restarting.
+
 ## New Features
 
 - New and improved documentation.

--- a/src/frequenz/sdk/actor/_actor.py
+++ b/src/frequenz/sdk/actor/_actor.py
@@ -6,6 +6,7 @@
 import abc
 import asyncio
 import logging
+from datetime import timedelta
 
 from ._background_service import BackgroundService
 
@@ -26,6 +27,9 @@ class Actor(BackgroundService, abc.ABC):
         Please read the [`actor` module documentation][frequenz.sdk.actor] for more
         comprehensive guide on how to use and implement actors properly.
     """
+
+    RESTART_DELAY: timedelta = timedelta(seconds=2)
+    """The delay to wait between restarts of this actor."""
 
     _restart_limit: int | None = None
     """The number of times actors can be restarted when they are stopped by unhandled exceptions.
@@ -64,7 +68,7 @@ class Actor(BackgroundService, abc.ABC):
         # the longer the actor has been running.
         # Not just for the restart-delay but actually for the n_restarts counter as well.
         if iteration > 0:
-            delay: int = 1 << iteration # delay for 1, 2, 4, 8, ... seconds
+            delay = Actor.RESTART_DELAY.total_seconds()
             _logger.info("Actor %s: Waiting %s seconds...", self, delay)
             await asyncio.sleep(delay)
 

--- a/src/frequenz/sdk/actor/_actor.py
+++ b/src/frequenz/sdk/actor/_actor.py
@@ -68,7 +68,7 @@ class Actor(BackgroundService, abc.ABC):
         # the longer the actor has been running.
         # Not just for the restart-delay but actually for the n_restarts counter as well.
         if iteration > 0:
-            delay = Actor.RESTART_DELAY.total_seconds()
+            delay = self.RESTART_DELAY.total_seconds()
             _logger.info("Actor %s: Waiting %s seconds...", self, delay)
             await asyncio.sleep(delay)
 


### PR DESCRIPTION
Closes #732

I've decided to go for the hard coded 2.0 seconds delay for now. I very much like the idea of (instead of hard-coding an exponential backoff in), allow configuring the actor at construction time, and have it passed a retry strategy (as suggested by @shms), so the dev of that actor can decide what's best for this particular actor. This can then default to a fixed-delay retry strategy.