### PR TITLE
Rename datetime to timestamp variables

### DIFF
--- a/src/frequenz/sdk/timeseries/_moving_window.py
+++ b/src/frequenz/sdk/timeseries/_moving_window.py
@@ -150,7 +150,7 @@ class MovingWindow(BackgroundService):
                 given sampling period.
             input_sampling_period: The time interval between consecutive input samples.
             resampler_config: The resampler configuration in case resampling is required.
-            align_to: A datetime object that defines a point in time to which
+            align_to: A timestamp that defines a point in time to which
                 the window is aligned to modulo window size. For further
                 information, consult the class level documentation.
             name: The name of this moving window. If `None`, `str(id(self))` will be
@@ -299,10 +299,10 @@ class MovingWindow(BackgroundService):
         and returns an array.
 
         Args:
-            start: The start of the time interval. If `None`, the start of the
-                window is used.
-            end: The end of the time interval. If `None`, the end of the window
-                is used.
+            start: The start timestamp of the time interval. If `None`, the
+                start of the window is used.
+            end: The end timestamp of the time interval. If `None`, the end of
+                the window is used.
             force_copy: If `True`, the returned array is a copy of the underlying
                 data. Otherwise, if possible, a view of the underlying data is
                 returned.
@@ -402,7 +402,7 @@ class MovingWindow(BackgroundService):
 
         * If the key is an integer, the float value of that key
           at the given position is returned.
-        * If the key is a datetime object, the float value of that key
+        * If the key is a timestamp, the float value of that key
           that corresponds to the timestamp is returned.
         * If the key is a slice of timestamps or integers, an ndarray is returned,
           where the bounds correspond to the slice bounds.

--- a/src/frequenz/sdk/timeseries/_ringbuffer/buffer.py
+++ b/src/frequenz/sdk/timeseries/_ringbuffer/buffer.py
@@ -24,9 +24,9 @@ class Gap:
     """A gap defines the range for which we haven't received values yet."""
 
     start: datetime
-    """Start of the range, inclusive."""
+    """Start timestamp of the range, inclusive."""
     end: datetime
-    """End of the range, exclusive."""
+    """End timestamp of the range, exclusive."""
 
     def contains(self, timestamp: datetime) -> bool:
         """Check if a given timestamp is inside this gap.
@@ -271,7 +271,7 @@ class OrderedRingBuffer(Generic[FloatArray]):
             index: Index to convert.
 
         Returns:
-            Datetime index where the value for the given index can be found.
+            Timestamp where the value for the given index can be found.
                 Or None if the buffer is empty.
         """
         if self.oldest_timestamp is None:
@@ -323,8 +323,8 @@ class OrderedRingBuffer(Generic[FloatArray]):
         missing entries, they can safely do so.
 
         Args:
-            start: start time of the window.
-            end: end time of the window.
+            start: start timestamp of the window.
+            end: end timestamp of the window.
             force_copy: optional, default True. If True, will always create a
                 copy of the data.
             fill_value: If not None, will use this value to fill missing values.

--- a/tests/timeseries/test_moving_window.py
+++ b/tests/timeseries/test_moving_window.py
@@ -67,13 +67,13 @@ def init_moving_window(
 
 
 def dt(i: int) -> datetime:  # pylint: disable=invalid-name
-    """Create datetime objects from indices.
+    """Create a timestamp from the given index.
 
     Args:
-        i: Index to create datetime from.
+        i: The index to create a timestamp from.
 
     Returns:
-        Datetime object.
+        The timestamp created from the index.
     """
     return datetime.fromtimestamp(i, tz=timezone.utc)
 

--- a/tests/timeseries/test_ringbuffer.py
+++ b/tests/timeseries/test_ringbuffer.py
@@ -192,13 +192,13 @@ def test_timestamp_ringbuffer_missing_parameter(
 
 
 def dt(i: int) -> datetime:  # pylint: disable=invalid-name
-    """Create datetime objects from indices.
+    """Create a timestamp from the given index.
 
     Args:
-        i: Index to create datetime from.
+        i: The index to create a timestamp from.
 
     Returns:
-        Datetime object.
+        The timestamp created from the index.
     """
     return datetime.fromtimestamp(i, tz=timezone.utc)
 

--- a/tests/timeseries/test_ringbuffer_serialization.py
+++ b/tests/timeseries/test_ringbuffer_serialization.py
@@ -52,9 +52,9 @@ def load_dump_test(dumped: rb.OrderedRingBuffer[Any], path: str) -> None:
     np.testing.assert_equal(dumped[:], loaded[:])
 
     # pylint: disable=protected-access
-    assert dumped._datetime_oldest == loaded._datetime_oldest
+    assert dumped._timestamp_oldest == loaded._timestamp_oldest
     # pylint: disable=protected-access
-    assert dumped._datetime_newest == loaded._datetime_newest
+    assert dumped._timestamp_newest == loaded._timestamp_newest
     # pylint: disable=protected-access
     assert len(dumped._gaps) == len(loaded._gaps)
     # pylint: disable=protected-access


### PR DESCRIPTION
.There were internal variables in OrderedRingBuffer and MovingWindow that were named with the prefix `datetime` as a way to refer to the timestamps that are stored, which happened to be represented using a datetime object, but timestamps are actually what it is stored. To avoid confusion when reading the code, these variables were renamed from `_datetime` to `_timestamp`.

Fixes #691