### PR TITLE
Use exclusion bounds while calculating target powers in PowerManager

### DIFF
--- a/src/frequenz/sdk/actor/_power_managing/_matryoshka.py
+++ b/src/frequenz/sdk/actor/_power_managing/_matryoshka.py
@@ -36,6 +36,70 @@ if typing.TYPE_CHECKING:
 _logger = logging.getLogger(__name__)
 
 
+def _check_exclusion_bounds_overlap(
+    lower_bound: Power,
+    upper_bound: Power,
+    exclusion_bounds: timeseries.Bounds[Power] | None,
+) -> tuple[bool, bool]:
+    """Check if the given bounds overlap with the given exclusion bounds.
+
+    Args:
+        lower_bound: The lower bound to check.
+        upper_bound: The upper bound to check.
+        exclusion_bounds: The exclusion bounds to check against.
+
+    Returns:
+        A tuple containing a boolean indicating if the lower bound is bounded by the
+            exclusion bounds, and a boolean indicating if the upper bound is bounded by
+            the exclusion bounds.
+    """
+    if exclusion_bounds is None:
+        return False, False
+
+    bounded_lower = False
+    bounded_upper = False
+
+    if exclusion_bounds.lower < lower_bound < exclusion_bounds.upper:
+        bounded_lower = True
+    if exclusion_bounds.lower < upper_bound < exclusion_bounds.upper:
+        bounded_upper = True
+
+    return bounded_lower, bounded_upper
+
+
+def _adjust_exclusion_bounds(
+    lower_bound: Power,
+    upper_bound: Power,
+    exclusion_bounds: timeseries.Bounds[Power] | None,
+) -> tuple[Power, Power]:
+    """Adjust the given bounds to exclude the given exclusion bounds.
+
+    Args:
+        lower_bound: The lower bound to adjust.
+        upper_bound: The upper bound to adjust.
+        exclusion_bounds: The exclusion bounds to adjust to.
+
+    Returns:
+        The adjusted lower and upper bounds.
+    """
+    if exclusion_bounds is None:
+        return lower_bound, upper_bound
+
+    # If the given bounds are within the exclusion bounds, there's no room to adjust,
+    # so return zero.
+    #
+    # And if the given bounds overlap with the exclusion bounds on one side, then clamp
+    # the given bounds on that side.
+    match _check_exclusion_bounds_overlap(lower_bound, upper_bound, exclusion_bounds):
+        case (True, True):
+            return Power.zero(), Power.zero()
+        case (False, True):
+            return lower_bound, exclusion_bounds.lower
+        case (True, False):
+            return exclusion_bounds.upper, upper_bound
+    return lower_bound, upper_bound
+
+
 class Matryoshka(BaseAlgorithm):
     """The matryoshka algorithm."""
 
@@ -72,6 +136,13 @@ class Matryoshka(BaseAlgorithm):
             else Power.zero()
         )
 
+        exclusion_bounds = None
+        if system_bounds.exclusion_bounds is not None and (
+            system_bounds.exclusion_bounds.lower != Power.zero()
+            or system_bounds.exclusion_bounds.upper != Power.zero()
+        ):
+            exclusion_bounds = system_bounds.exclusion_bounds
+
         target_power = Power.zero()
         for next_proposal in reversed(proposals):
             if upper_bound < lower_bound:
@@ -87,8 +158,19 @@ class Matryoshka(BaseAlgorithm):
                 next_proposal.bounds.lower or lower_bound,
                 next_proposal.bounds.upper or upper_bound,
             )
+            # If the bounds from the current proposal are fully within the exclusion
+            # bounds, then don't use them to narrow the bounds further. This allows
+            # subsequent proposals to not be blocked by the current proposal.
+            match _check_exclusion_bounds_overlap(
+                proposal_lower, proposal_upper, exclusion_bounds
+            ):
+                case (True, True):
+                    continue
             lower_bound = max(lower_bound, proposal_lower)
             upper_bound = min(upper_bound, proposal_upper)
+            lower_bound, upper_bound = _adjust_exclusion_bounds(
+                lower_bound, upper_bound, exclusion_bounds
+            )
 
         return target_power
 
@@ -204,6 +286,13 @@ class Matryoshka(BaseAlgorithm):
         lower_bound = system_bounds.inclusion_bounds.lower
         upper_bound = system_bounds.inclusion_bounds.upper
 
+        exclusion_bounds = None
+        if system_bounds.exclusion_bounds is not None and (
+            system_bounds.exclusion_bounds.lower != Power.zero()
+            or system_bounds.exclusion_bounds.upper != Power.zero()
+        ):
+            exclusion_bounds = system_bounds.exclusion_bounds
+
         for next_proposal in reversed(self._battery_buckets.get(battery_ids, [])):
             if next_proposal.priority <= priority:
                 break
@@ -211,11 +300,19 @@ class Matryoshka(BaseAlgorithm):
                 next_proposal.bounds.lower or lower_bound,
                 next_proposal.bounds.upper or upper_bound,
             )
+            match _check_exclusion_bounds_overlap(
+                proposal_lower, proposal_upper, exclusion_bounds
+            ):
+                case (True, True):
+                    continue
             calc_lower_bound = max(lower_bound, proposal_lower)
             calc_upper_bound = min(upper_bound, proposal_upper)
             if calc_lower_bound <= calc_upper_bound:
                 lower_bound = calc_lower_bound
                 upper_bound = calc_upper_bound
+                lower_bound, upper_bound = _adjust_exclusion_bounds(
+                    lower_bound, upper_bound, exclusion_bounds
+                )
             else:
                 break
         return Report(

--- a/src/frequenz/sdk/actor/_power_managing/_matryoshka.py
+++ b/src/frequenz/sdk/actor/_power_managing/_matryoshka.py
@@ -83,11 +83,12 @@ class Matryoshka(BaseAlgorithm):
                     target_power = lower_bound
                 else:
                     target_power = next_proposal.preferred_power
-            low, high = next_proposal.bounds.lower, next_proposal.bounds.upper
-            if low is not None:
-                lower_bound = max(lower_bound, low)
-            if high is not None:
-                upper_bound = min(upper_bound, high)
+            proposal_lower, proposal_upper = (
+                next_proposal.bounds.lower or lower_bound,
+                next_proposal.bounds.upper or upper_bound,
+            )
+            lower_bound = max(lower_bound, proposal_lower)
+            upper_bound = min(upper_bound, proposal_upper)
 
         return target_power
 
@@ -206,13 +207,12 @@ class Matryoshka(BaseAlgorithm):
         for next_proposal in reversed(self._battery_buckets.get(battery_ids, [])):
             if next_proposal.priority <= priority:
                 break
-            low, high = next_proposal.bounds.lower, next_proposal.bounds.upper
-            calc_lower_bound = lower_bound
-            calc_upper_bound = upper_bound
-            if low is not None:
-                calc_lower_bound = max(calc_lower_bound, low)
-            if high is not None:
-                calc_upper_bound = min(calc_upper_bound, high)
+            proposal_lower, proposal_upper = (
+                next_proposal.bounds.lower or lower_bound,
+                next_proposal.bounds.upper or upper_bound,
+            )
+            calc_lower_bound = max(lower_bound, proposal_lower)
+            calc_upper_bound = min(upper_bound, proposal_upper)
             if calc_lower_bound <= calc_upper_bound:
                 lower_bound = calc_lower_bound
                 upper_bound = calc_upper_bound

--- a/src/frequenz/sdk/actor/_power_managing/_matryoshka.py
+++ b/src/frequenz/sdk/actor/_power_managing/_matryoshka.py
@@ -36,6 +36,60 @@ if typing.TYPE_CHECKING:
 _logger = logging.getLogger(__name__)
 
 
+# Just 20 lines of code in this function, but unfortunately 8 of those are return
+# statements, and that's too many for pylint.
+def _clamp_to_bounds(  # pylint: disable=too-many-return-statements
+    value: Power,
+    lower_bound: Power,
+    upper_bound: Power,
+    exclusion_bounds: timeseries.Bounds[Power] | None,
+) -> Power:
+    """Clamp the given value to the given bounds.
+
+    Args:
+        value: The value to clamp.
+        lower_bound: The lower bound to clamp to.
+        upper_bound: The upper bound to clamp to.
+        exclusion_bounds: The exclusion bounds to clamp outside of.
+
+    Returns:
+        The clamped value.
+    """
+    # If the given bounds are within the exclusion bounds, return zero.
+    #
+    # And if the given bounds overlap with the exclusion bounds on one side, and the
+    # given power is in that overlap region, clamp it to the exclusion bounds on that
+    # side.
+    if exclusion_bounds is not None:
+        match _check_exclusion_bounds_overlap(
+            lower_bound, upper_bound, exclusion_bounds
+        ):
+            case (True, True):
+                return Power.zero()
+            case (True, False):
+                if value < exclusion_bounds.upper:
+                    return exclusion_bounds.upper
+            case (False, True):
+                if value > exclusion_bounds.lower:
+                    return exclusion_bounds.lower
+
+    # If the given value is outside the given bounds, clamp it to the closest bound.
+    if value < lower_bound:
+        return lower_bound
+    if value > upper_bound:
+        return upper_bound
+
+    # If the given value is within the exclusion bounds and the exclusion bounds are
+    # within the given bounds, clamp the given value to the closest exclusion bound.
+    if exclusion_bounds is not None:
+        if exclusion_bounds.lower < value < exclusion_bounds.upper:
+            if value - exclusion_bounds.lower < exclusion_bounds.upper - value:
+                return exclusion_bounds.lower
+            return exclusion_bounds.upper
+
+    return value
+
+
 def _check_exclusion_bounds_overlap(
     lower_bound: Power,
     upper_bound: Power,
@@ -148,12 +202,12 @@ class Matryoshka(BaseAlgorithm):
             if upper_bound < lower_bound:
                 break
             if next_proposal.preferred_power:
-                if next_proposal.preferred_power > upper_bound:
-                    target_power = upper_bound
-                elif next_proposal.preferred_power < lower_bound:
-                    target_power = lower_bound
-                else:
-                    target_power = next_proposal.preferred_power
+                target_power = _clamp_to_bounds(
+                    next_proposal.preferred_power,
+                    lower_bound,
+                    upper_bound,
+                    exclusion_bounds,
+                )
             proposal_lower, proposal_upper = (
                 next_proposal.bounds.lower or lower_bound,
                 next_proposal.bounds.upper or upper_bound,
@@ -308,10 +362,8 @@ class Matryoshka(BaseAlgorithm):
             calc_lower_bound = max(lower_bound, proposal_lower)
             calc_upper_bound = min(upper_bound, proposal_upper)
             if calc_lower_bound <= calc_upper_bound:
-                lower_bound = calc_lower_bound
-                upper_bound = calc_upper_bound
                 lower_bound, upper_bound = _adjust_exclusion_bounds(
-                    lower_bound, upper_bound, exclusion_bounds
+                    calc_lower_bound, calc_upper_bound, exclusion_bounds
                 )
             else:
                 break

--- a/tests/actor/_power_managing/test_matryoshka.py
+++ b/tests/actor/_power_managing/test_matryoshka.py
@@ -78,7 +78,6 @@ async def test_matryoshka_algorithm() -> None:  # pylint: disable=too-many-state
     """Tests for the power managing actor."""
     batteries = frozenset({2, 5})
 
-    algorithm = Matryoshka()
     system_bounds = battery_pool.PowerMetrics(
         timestamp=datetime.now(tz=timezone.utc),
         inclusion_bounds=timeseries.Bounds(
@@ -87,139 +86,96 @@ async def test_matryoshka_algorithm() -> None:  # pylint: disable=too-many-state
         exclusion_bounds=timeseries.Bounds(lower=Power.zero(), upper=Power.zero()),
     )
 
-    call_count = 0
+    tester = StatefulTester(batteries, system_bounds)
 
-    def test_tgt_power(
-        priority: int,
-        power: float | None,
-        bounds: tuple[float | None, float | None],
-        expected: float | None,
-        must_send: bool = False,
-    ) -> None:
-        nonlocal call_count
-        call_count += 1
-        tgt_power = algorithm.calculate_target_power(
-            batteries,
-            Proposal(
-                battery_ids=batteries,
-                source_id=f"actor-{priority}",
-                preferred_power=None if power is None else Power.from_watts(power),
-                bounds=timeseries.Bounds(
-                    None if bounds[0] is None else Power.from_watts(bounds[0]),
-                    None if bounds[1] is None else Power.from_watts(bounds[1]),
-                ),
-                priority=priority,
-            ),
-            system_bounds,
-            must_send,
-        )
-        assert tgt_power == (
-            Power.from_watts(expected) if expected is not None else None
-        )
+    tester.tgt_power(priority=2, power=25.0, bounds=(25.0, 50.0), expected=25.0)
+    tester.bounds(priority=2, expected_power=25.0, expected_bounds=(-200.0, 200.0))
+    tester.bounds(priority=1, expected_power=25.0, expected_bounds=(25.0, 50.0))
 
-    def test_bounds(
-        priority: int,
-        expected_power: float | None,
-        expected_bounds: tuple[float, float],
-    ) -> None:
-        report = algorithm.get_status(batteries, priority, system_bounds, None)
-        if expected_power is None:
-            assert report.target_power is None
-        else:
-            assert report.target_power is not None
-            assert report.target_power.as_watts() == expected_power
-        assert report.inclusion_bounds is not None
-        assert report.inclusion_bounds.lower.as_watts() == expected_bounds[0]
-        assert report.inclusion_bounds.upper.as_watts() == expected_bounds[1]
-
-    test_tgt_power(priority=2, power=25.0, bounds=(25.0, 50.0), expected=25.0)
-    test_bounds(priority=2, expected_power=25.0, expected_bounds=(-200.0, 200.0))
-    test_bounds(priority=1, expected_power=25.0, expected_bounds=(25.0, 50.0))
-
-    test_tgt_power(priority=1, power=20.0, bounds=(20.0, 50.0), expected=None)
-    test_tgt_power(
+    tester.tgt_power(priority=1, power=20.0, bounds=(20.0, 50.0), expected=None)
+    tester.tgt_power(
         priority=1, power=20.0, bounds=(20.0, 50.0), expected=25.0, must_send=True
     )
-    test_bounds(priority=1, expected_power=25.0, expected_bounds=(25.0, 50.0))
+    tester.bounds(priority=1, expected_power=25.0, expected_bounds=(25.0, 50.0))
 
-    test_tgt_power(priority=3, power=10.0, bounds=(10.0, 15.0), expected=15.0)
-    test_bounds(priority=3, expected_power=15.0, expected_bounds=(-200.0, 200.0))
-    test_bounds(priority=2, expected_power=15.0, expected_bounds=(10.0, 15.0))
-    test_bounds(priority=1, expected_power=15.0, expected_bounds=(10.0, 15.0))
+    tester.tgt_power(priority=3, power=10.0, bounds=(10.0, 15.0), expected=15.0)
+    tester.bounds(priority=3, expected_power=15.0, expected_bounds=(-200.0, 200.0))
+    tester.bounds(priority=2, expected_power=15.0, expected_bounds=(10.0, 15.0))
+    tester.bounds(priority=1, expected_power=15.0, expected_bounds=(10.0, 15.0))
 
-    test_tgt_power(priority=3, power=10.0, bounds=(10.0, 22.0), expected=22.0)
-    test_bounds(priority=3, expected_power=22.0, expected_bounds=(-200.0, 200.0))
-    test_bounds(priority=2, expected_power=22.0, expected_bounds=(10.0, 22.0))
-    test_bounds(priority=1, expected_power=22.0, expected_bounds=(10.0, 22.0))
+    tester.tgt_power(priority=3, power=10.0, bounds=(10.0, 22.0), expected=22.0)
+    tester.bounds(priority=3, expected_power=22.0, expected_bounds=(-200.0, 200.0))
+    tester.bounds(priority=2, expected_power=22.0, expected_bounds=(10.0, 22.0))
+    tester.bounds(priority=1, expected_power=22.0, expected_bounds=(10.0, 22.0))
 
-    test_tgt_power(priority=1, power=30.0, bounds=(20.0, 50.0), expected=None)
-    test_bounds(priority=1, expected_power=22.0, expected_bounds=(10.0, 22.0))
+    tester.tgt_power(priority=1, power=30.0, bounds=(20.0, 50.0), expected=None)
+    tester.bounds(priority=1, expected_power=22.0, expected_bounds=(10.0, 22.0))
 
-    test_tgt_power(priority=3, power=10.0, bounds=(10.0, 50.0), expected=30.0)
-    test_bounds(priority=3, expected_power=30.0, expected_bounds=(-200.0, 200.0))
-    test_bounds(priority=2, expected_power=30.0, expected_bounds=(10.0, 50.0))
-    test_bounds(priority=1, expected_power=30.0, expected_bounds=(25.0, 50.0))
+    tester.tgt_power(priority=3, power=10.0, bounds=(10.0, 50.0), expected=30.0)
+    tester.bounds(priority=3, expected_power=30.0, expected_bounds=(-200.0, 200.0))
+    tester.bounds(priority=2, expected_power=30.0, expected_bounds=(10.0, 50.0))
+    tester.bounds(priority=1, expected_power=30.0, expected_bounds=(25.0, 50.0))
 
-    test_tgt_power(priority=2, power=40.0, bounds=(40.0, None), expected=40.0)
-    test_bounds(priority=3, expected_power=40.0, expected_bounds=(-200.0, 200.0))
-    test_bounds(priority=2, expected_power=40.0, expected_bounds=(10.0, 50.0))
-    test_bounds(priority=1, expected_power=40.0, expected_bounds=(40.0, 50.0))
+    tester.tgt_power(priority=2, power=40.0, bounds=(40.0, None), expected=40.0)
+    tester.bounds(priority=3, expected_power=40.0, expected_bounds=(-200.0, 200.0))
+    tester.bounds(priority=2, expected_power=40.0, expected_bounds=(10.0, 50.0))
+    tester.bounds(priority=1, expected_power=40.0, expected_bounds=(40.0, 50.0))
 
-    test_tgt_power(priority=2, power=0.0, bounds=(None, None), expected=30.0)
-    test_bounds(priority=4, expected_power=30.0, expected_bounds=(-200.0, 200.0))
-    test_bounds(priority=3, expected_power=30.0, expected_bounds=(-200.0, 200.0))
-    test_bounds(priority=2, expected_power=30.0, expected_bounds=(10.0, 50.0))
-    test_bounds(priority=1, expected_power=30.0, expected_bounds=(10.0, 50.0))
+    tester.tgt_power(priority=2, power=0.0, bounds=(None, None), expected=30.0)
+    tester.bounds(priority=4, expected_power=30.0, expected_bounds=(-200.0, 200.0))
+    tester.bounds(priority=3, expected_power=30.0, expected_bounds=(-200.0, 200.0))
+    tester.bounds(priority=2, expected_power=30.0, expected_bounds=(10.0, 50.0))
+    tester.bounds(priority=1, expected_power=30.0, expected_bounds=(10.0, 50.0))
 
-    test_tgt_power(priority=4, power=-50.0, bounds=(None, -50.0), expected=-50.0)
-    test_bounds(priority=4, expected_power=-50.0, expected_bounds=(-200.0, 200.0))
-    test_bounds(priority=3, expected_power=-50.0, expected_bounds=(-200.0, -50.0))
-    test_bounds(priority=2, expected_power=-50.0, expected_bounds=(-200.0, -50.0))
-    test_bounds(priority=1, expected_power=-50.0, expected_bounds=(-200.0, -50.0))
+    tester.tgt_power(priority=4, power=-50.0, bounds=(None, -50.0), expected=-50.0)
+    tester.bounds(priority=4, expected_power=-50.0, expected_bounds=(-200.0, 200.0))
+    tester.bounds(priority=3, expected_power=-50.0, expected_bounds=(-200.0, -50.0))
+    tester.bounds(priority=2, expected_power=-50.0, expected_bounds=(-200.0, -50.0))
+    tester.bounds(priority=1, expected_power=-50.0, expected_bounds=(-200.0, -50.0))
 
-    test_tgt_power(priority=3, power=-0.0, bounds=(-200.0, 200.0), expected=None)
-    test_bounds(priority=1, expected_power=-50.0, expected_bounds=(-200.0, -50.0))
+    tester.tgt_power(priority=3, power=-0.0, bounds=(-200.0, 200.0), expected=None)
+    tester.bounds(priority=1, expected_power=-50.0, expected_bounds=(-200.0, -50.0))
 
-    test_tgt_power(priority=1, power=-150.0, bounds=(-200.0, -150.0), expected=-150.0)
-    test_bounds(priority=2, expected_power=-150.0, expected_bounds=(-200.0, -50.0))
-    test_bounds(priority=1, expected_power=-150.0, expected_bounds=(-200.0, -50.0))
+    tester.tgt_power(priority=1, power=-150.0, bounds=(-200.0, -150.0), expected=-150.0)
+    tester.bounds(priority=2, expected_power=-150.0, expected_bounds=(-200.0, -50.0))
+    tester.bounds(priority=1, expected_power=-150.0, expected_bounds=(-200.0, -50.0))
 
-    test_tgt_power(priority=4, power=-180.0, bounds=(-200.0, -50.0), expected=None)
-    test_bounds(priority=1, expected_power=-150.0, expected_bounds=(-200.0, -50.0))
+    tester.tgt_power(priority=4, power=-180.0, bounds=(-200.0, -50.0), expected=None)
+    tester.bounds(priority=1, expected_power=-150.0, expected_bounds=(-200.0, -50.0))
 
-    test_tgt_power(priority=4, power=50.0, bounds=(50.0, None), expected=50.0)
-    test_bounds(priority=4, expected_power=50.0, expected_bounds=(-200.0, 200.0))
-    test_bounds(priority=3, expected_power=50.0, expected_bounds=(50.0, 200.0))
-    test_bounds(priority=2, expected_power=50.0, expected_bounds=(50.0, 200.0))
-    test_bounds(priority=1, expected_power=50.0, expected_bounds=(50.0, 200.0))
+    tester.tgt_power(priority=4, power=50.0, bounds=(50.0, None), expected=50.0)
+    tester.bounds(priority=4, expected_power=50.0, expected_bounds=(-200.0, 200.0))
+    tester.bounds(priority=3, expected_power=50.0, expected_bounds=(50.0, 200.0))
+    tester.bounds(priority=2, expected_power=50.0, expected_bounds=(50.0, 200.0))
+    tester.bounds(priority=1, expected_power=50.0, expected_bounds=(50.0, 200.0))
 
-    test_tgt_power(priority=4, power=0.0, bounds=(-200.0, 200.0), expected=-150.0)
-    test_bounds(priority=4, expected_power=-150.0, expected_bounds=(-200.0, 200.0))
-    test_bounds(priority=3, expected_power=-150.0, expected_bounds=(-200.0, 200.0))
-    test_bounds(priority=2, expected_power=-150.0, expected_bounds=(-200.0, 200.0))
-    test_bounds(priority=1, expected_power=-150.0, expected_bounds=(-200.0, 200.0))
+    tester.tgt_power(priority=4, power=0.0, bounds=(-200.0, 200.0), expected=-150.0)
+    tester.bounds(priority=4, expected_power=-150.0, expected_bounds=(-200.0, 200.0))
+    tester.bounds(priority=3, expected_power=-150.0, expected_bounds=(-200.0, 200.0))
+    tester.bounds(priority=2, expected_power=-150.0, expected_bounds=(-200.0, 200.0))
+    tester.bounds(priority=1, expected_power=-150.0, expected_bounds=(-200.0, 200.0))
 
-    test_tgt_power(priority=3, power=0.0, bounds=(-200.0, 200.0), expected=None)
-    test_bounds(priority=3, expected_power=-150.0, expected_bounds=(-200.0, 200.0))
-    test_bounds(priority=2, expected_power=-150.0, expected_bounds=(-200.0, 200.0))
-    test_bounds(priority=1, expected_power=-150.0, expected_bounds=(-200.0, 200.0))
+    tester.tgt_power(priority=3, power=0.0, bounds=(-200.0, 200.0), expected=None)
+    tester.bounds(priority=3, expected_power=-150.0, expected_bounds=(-200.0, 200.0))
+    tester.bounds(priority=2, expected_power=-150.0, expected_bounds=(-200.0, 200.0))
+    tester.bounds(priority=1, expected_power=-150.0, expected_bounds=(-200.0, 200.0))
 
-    test_tgt_power(priority=2, power=50.0, bounds=(-100, 100), expected=-100.0)
-    test_bounds(priority=3, expected_power=-100.0, expected_bounds=(-200.0, 200.0))
-    test_bounds(priority=2, expected_power=-100.0, expected_bounds=(-200.0, 200.0))
-    test_bounds(priority=1, expected_power=-100.0, expected_bounds=(-100.0, 100.0))
+    tester.tgt_power(priority=2, power=50.0, bounds=(-100, 100), expected=-100.0)
+    tester.bounds(priority=3, expected_power=-100.0, expected_bounds=(-200.0, 200.0))
+    tester.bounds(priority=2, expected_power=-100.0, expected_bounds=(-200.0, 200.0))
+    tester.bounds(priority=1, expected_power=-100.0, expected_bounds=(-100.0, 100.0))
 
-    test_tgt_power(priority=1, power=100.0, bounds=(100, 200), expected=100.0)
-    test_bounds(priority=1, expected_power=100.0, expected_bounds=(-100.0, 100.0))
+    tester.tgt_power(priority=1, power=100.0, bounds=(100, 200), expected=100.0)
+    tester.bounds(priority=1, expected_power=100.0, expected_bounds=(-100.0, 100.0))
 
-    test_tgt_power(priority=1, power=50.0, bounds=(50, 200), expected=50.0)
-    test_bounds(priority=1, expected_power=50.0, expected_bounds=(-100.0, 100.0))
+    tester.tgt_power(priority=1, power=50.0, bounds=(50, 200), expected=50.0)
+    tester.bounds(priority=1, expected_power=50.0, expected_bounds=(-100.0, 100.0))
 
-    test_tgt_power(priority=1, power=200.0, bounds=(50, 200), expected=100.0)
-    test_bounds(priority=1, expected_power=100.0, expected_bounds=(-100.0, 100.0))
+    tester.tgt_power(priority=1, power=200.0, bounds=(50, 200), expected=100.0)
+    tester.bounds(priority=1, expected_power=100.0, expected_bounds=(-100.0, 100.0))
 
-    test_tgt_power(priority=1, power=0.0, bounds=(-200, 200), expected=0.0)
-    test_bounds(priority=1, expected_power=0.0, expected_bounds=(-100.0, 100.0))
+    tester.tgt_power(priority=1, power=0.0, bounds=(-200, 200), expected=0.0)
+    tester.bounds(priority=1, expected_power=0.0, expected_bounds=(-100.0, 100.0))
 
-    test_tgt_power(priority=1, power=None, bounds=(-200, 200), expected=50.0)
-    test_bounds(priority=1, expected_power=50.0, expected_bounds=(-100.0, 100.0))
+    tester.tgt_power(priority=1, power=None, bounds=(-200, 200), expected=50.0)
+    tester.bounds(priority=1, expected_power=50.0, expected_bounds=(-100.0, 100.0))


### PR DESCRIPTION
This also helps with the upcoming bounds-interface update, to hide the exclusion bounds from SDK users, in preparation for its deprecation in the microgrid API in favour of a simpler interface.