### PR TITLE
Make the SDK's representation of bounds data internal

### DIFF
--- a/src/frequenz/sdk/actor/_power_managing/_base_classes.py
+++ b/src/frequenz/sdk/actor/_power_managing/_base_classes.py
@@ -50,14 +50,14 @@ class Report:
     target_power: Power | None
     """The currently set power for the batteries."""
 
-    inclusion_bounds: timeseries.Bounds[Power] | None
+    _inclusion_bounds: timeseries.Bounds[Power] | None
     """The available inclusion bounds for the batteries, for the actor's priority.
 
     These bounds are adjusted to any restrictions placed by actors with higher
     priorities.
     """
 
-    exclusion_bounds: timeseries.Bounds[Power] | None
+    _exclusion_bounds: timeseries.Bounds[Power] | None
     """The exclusion bounds for the batteries.
 
     The power manager doesn't manage exclusion bounds, so these are aggregations of
@@ -72,6 +72,20 @@ class Report:
 
     This is `None` if no power distribution has been performed yet.
     """
+
+    @property
+    def bounds(self) -> timeseries.Bounds[Power] | None:
+        """The bounds for the batteries.
+
+        These bounds are adjusted to any restrictions placed by actors with higher
+        priorities.
+
+        There might be exclusion zones within these bounds. If necessary, the
+        [`adjust_to_bounds`][frequenz.sdk.timeseries.battery_pool.Report.adjust_to_bounds]
+        method may be used to check if a desired power value fits the bounds, or to get
+        the closest possible power values that do fit the bounds.
+        """
+        return self._inclusion_bounds
 
     def adjust_to_bounds(self, power: Power) -> tuple[Power | None, Power | None]:
         """Adjust a power value to the bounds.
@@ -123,14 +137,14 @@ class Report:
             A tuple of the closest power values to the desired power that fall within
                 the available bounds for the actor.
         """
-        if self.inclusion_bounds is None:
+        if self._inclusion_bounds is None:
             return None, None
 
         return _clamp_to_bounds(
             power,
-            self.inclusion_bounds.lower,
-            self.inclusion_bounds.upper,
-            self.exclusion_bounds,
+            self._inclusion_bounds.lower,
+            self._inclusion_bounds.upper,
+            self._exclusion_bounds,
         )
 
 

--- a/src/frequenz/sdk/actor/_power_managing/_base_classes.py
+++ b/src/frequenz/sdk/actor/_power_managing/_base_classes.py
@@ -13,7 +13,7 @@ import typing
 
 from ... import timeseries
 from ...timeseries import Power
-from ._bounds_methods import _clamp_to_bounds
+from . import _bounds
 
 if typing.TYPE_CHECKING:
     from ...timeseries.battery_pool import PowerMetrics
@@ -50,6 +50,12 @@ class Report:
     target_power: Power | None
     """The currently set power for the batteries."""
 
+    distribution_result: power_distributing.Result | None
+    """The result of the last power distribution.
+
+    This is `None` if no power distribution has been performed yet.
+    """
+
     _inclusion_bounds: timeseries.Bounds[Power] | None
     """The available inclusion bounds for the batteries, for the actor's priority.
 
@@ -65,12 +71,6 @@ class Report:
 
     These bounds are adjusted to any restrictions placed by actors with higher
     priorities.
-    """
-
-    distribution_result: power_distributing.Result | None
-    """The result of the last power distribution.
-
-    This is `None` if no power distribution has been performed yet.
     """
 
     @property
@@ -140,7 +140,7 @@ class Report:
         if self._inclusion_bounds is None:
             return None, None
 
-        return _clamp_to_bounds(
+        return _bounds.clamp_to_bounds(
             power,
             self._inclusion_bounds.lower,
             self._inclusion_bounds.upper,

--- a/src/frequenz/sdk/actor/_power_managing/_base_classes.py
+++ b/src/frequenz/sdk/actor/_power_managing/_base_classes.py
@@ -13,6 +13,7 @@ import typing
 
 from ... import timeseries
 from ...timeseries import Power
+from ._bounds_methods import _clamp_to_bounds
 
 if typing.TYPE_CHECKING:
     from ...timeseries.battery_pool import PowerMetrics
@@ -71,6 +72,66 @@ class Report:
 
     This is `None` if no power distribution has been performed yet.
     """
+
+    def adjust_to_bounds(self, power: Power) -> tuple[Power | None, Power | None]:
+        """Adjust a power value to the bounds.
+
+        This method can be used to adjust a desired power value to the power bounds
+        available to the actor.
+
+        If the given power value falls within the usable bounds, it will be returned
+        unchanged.
+
+        If it falls outside the usable bounds, the closest possible value on the
+        corresponding side will be returned.  For example, if the given power is lower
+        than the lowest usable power, only the lowest usable power will be returned, and
+        similarly for the highest usable power.
+
+        If the given power falls within an exclusion zone that's contained within the
+        usable bounds, the closest possible power values on both sides will be returned.
+
+        !!! note
+            It is completely optional to use this method to adjust power values before
+            proposing them through the battery pool, because the battery pool will do
+            this automatically.  This method is provided for convenience, and for
+            granular control when there are two possible power values, both of which
+            fall within the available bounds.
+
+        Example:
+            ```python
+            from frequenz.sdk import microgrid
+
+            power_status_rx = microgrid.battery_pool().power_status.new_receiver()
+            power_status = await power_status_rx.receive()
+            desired_power = Power.from_watts(1000.0)
+
+            match power_status.adjust_to_bounds(desired_power):
+                case (power, _) if power == desired_power:
+                    print("Desired power is available.")
+                case (None, power) | (power, None) if power:
+                    print(f"Closest available power is {power}.")
+                case (lower, upper) if lower and upper:
+                    print(f"Two options {lower}, {upper} to propose to battery pool.")
+                case (None, None):
+                    print("No available power")
+            ```
+
+        Args:
+            power: The power value to adjust.
+
+        Returns:
+            A tuple of the closest power values to the desired power that fall within
+                the available bounds for the actor.
+        """
+        if self.inclusion_bounds is None:
+            return None, None
+
+        return _clamp_to_bounds(
+            power,
+            self.inclusion_bounds.lower,
+            self.inclusion_bounds.upper,
+            self.exclusion_bounds,
+        )
 
 
 @dataclasses.dataclass(frozen=True, kw_only=True)

--- a/src/frequenz/sdk/actor/_power_managing/_bounds.py
+++ b/src/frequenz/sdk/actor/_power_managing/_bounds.py
@@ -15,6 +15,7 @@ def check_exclusion_bounds_overlap(
 
     Example:
 
+        ```
                        lower                        upper
                           .----- exclusion zone -----.
         -----|✓✓✓✓✓✓✓✓✓✓✓✓|xxxxxxxxxxxxxxx|----------|----
@@ -24,6 +25,7 @@ def check_exclusion_bounds_overlap(
            lower                        upper
            bound                        bound
                               (inside the exclusion zone)
+        ```
 
         Resulting in `(False, True)` because only the upper bound is inside the
         exclusion zone.

--- a/src/frequenz/sdk/actor/_power_managing/_bounds_methods.py
+++ b/src/frequenz/sdk/actor/_power_managing/_bounds_methods.py
@@ -1,0 +1,143 @@
+# License: MIT
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
+
+"""Methods for checking and clamping bounds and power values to exclusion bounds."""
+
+from ...timeseries import Bounds, Power
+
+
+def _check_exclusion_bounds_overlap(
+    lower_bound: Power,
+    upper_bound: Power,
+    exclusion_bounds: Bounds[Power] | None,
+) -> tuple[bool, bool]:
+    """Check if the given bounds overlap with the given exclusion bounds.
+
+    When only the upper bound overlaps with exclusion bounds, the usable range is
+    between the lower bound and the lower exclusion bound, like below.
+
+      ===lb+++++++ex----ub-------ex===
+
+    When only the lower bound overlaps with exclusion bounds, the usable range is
+    between the upper exclusion bound and the upper bound.
+
+      ===ex------lb------ex++++++ub===
+
+    Both bounds overlapping with exclusion bounds (or given bounds are fully contained
+    within exclusion bounds).  In this case, there is no usable range.
+
+      ===ex------lb------ub------ex===
+
+    Args:
+        lower_bound: The lower bound to check.
+        upper_bound: The upper bound to check.
+        exclusion_bounds: The exclusion bounds to check against.
+
+    Returns:
+        A tuple containing a boolean indicating if the lower bound is bounded by the
+            exclusion bounds, and a boolean indicating if the upper bound is bounded by
+            the exclusion bounds.
+    """
+    if exclusion_bounds is None:
+        return False, False
+
+    bounded_lower = False
+    bounded_upper = False
+
+    if exclusion_bounds.lower < lower_bound < exclusion_bounds.upper:
+        bounded_lower = True
+    if exclusion_bounds.lower < upper_bound < exclusion_bounds.upper:
+        bounded_upper = True
+
+    return bounded_lower, bounded_upper
+
+
+def _adjust_exclusion_bounds(
+    lower_bound: Power,
+    upper_bound: Power,
+    exclusion_bounds: Bounds[Power] | None,
+) -> tuple[Power, Power]:
+    """Adjust the given bounds to exclude the given exclusion bounds.
+
+    Args:
+        lower_bound: The lower bound to adjust.
+        upper_bound: The upper bound to adjust.
+        exclusion_bounds: The exclusion bounds to adjust to.
+
+    Returns:
+        The adjusted lower and upper bounds.
+    """
+    if exclusion_bounds is None:
+        return lower_bound, upper_bound
+
+    # If the given bounds are within the exclusion bounds, there's no room to adjust,
+    # so return zero.
+    #
+    # And if the given bounds overlap with the exclusion bounds on one side, then clamp
+    # the given bounds on that side.
+    match _check_exclusion_bounds_overlap(lower_bound, upper_bound, exclusion_bounds):
+        case (True, True):
+            return Power.zero(), Power.zero()
+        case (False, True):
+            return lower_bound, exclusion_bounds.lower
+        case (True, False):
+            return exclusion_bounds.upper, upper_bound
+    return lower_bound, upper_bound
+
+
+# Just 20 lines of code in this function, but unfortunately 8 of those are return
+# statements, and that's too many for pylint.
+def _clamp_to_bounds(  # pylint: disable=too-many-return-statements
+    value: Power,
+    lower_bound: Power,
+    upper_bound: Power,
+    exclusion_bounds: Bounds[Power] | None,
+) -> tuple[Power | None, Power | None]:
+    """Clamp the given value to the given bounds.
+
+    When the given value can falls within the exclusion zone, and can be clamped to
+    both sides, both options will be returned.
+
+    When the given value falls outside the usable bounds and can be clamped only to
+    one side, only that option will be returned.
+
+    Args:
+        value: The value to clamp.
+        lower_bound: The lower bound to clamp to.
+        upper_bound: The upper bound to clamp to.
+        exclusion_bounds: The exclusion bounds to clamp outside of.
+
+    Returns:
+        The clamped value.
+    """
+    # If the given bounds are within the exclusion bounds, return zero.
+    #
+    # And if the given bounds overlap with the exclusion bounds on one side, and the
+    # given power is in that overlap region, clamp it to the exclusion bounds on that
+    # side.
+    if exclusion_bounds is not None:
+        match _check_exclusion_bounds_overlap(
+            lower_bound, upper_bound, exclusion_bounds
+        ):
+            case (True, True):
+                return None, None
+            case (True, False):
+                if value < exclusion_bounds.upper:
+                    return None, exclusion_bounds.upper
+            case (False, True):
+                if value > exclusion_bounds.lower:
+                    return exclusion_bounds.lower, None
+
+    # If the given value is outside the given bounds, clamp it to the closest bound.
+    if value < lower_bound:
+        return lower_bound, None
+    if value > upper_bound:
+        return None, upper_bound
+
+    # If the given value is within the exclusion bounds and the exclusion bounds are
+    # within the given bounds, clamp the given value to the closest exclusion bound.
+    if exclusion_bounds is not None:
+        if exclusion_bounds.lower < value < exclusion_bounds.upper:
+            return exclusion_bounds.lower, exclusion_bounds.upper
+
+    return value, value

--- a/src/frequenz/sdk/actor/_power_managing/_matryoshka.py
+++ b/src/frequenz/sdk/actor/_power_managing/_matryoshka.py
@@ -27,6 +27,11 @@ from typing_extensions import override
 from ... import timeseries
 from ...timeseries import Power
 from ._base_classes import BaseAlgorithm, Proposal, Report
+from ._bounds_methods import (
+    _adjust_exclusion_bounds,
+    _check_exclusion_bounds_overlap,
+    _clamp_to_bounds,
+)
 from ._sorted_set import SortedSet
 
 if typing.TYPE_CHECKING:
@@ -34,143 +39,6 @@ if typing.TYPE_CHECKING:
     from .. import power_distributing
 
 _logger = logging.getLogger(__name__)
-
-
-# Just 20 lines of code in this function, but unfortunately 8 of those are return
-# statements, and that's too many for pylint.
-def _clamp_to_bounds(  # pylint: disable=too-many-return-statements
-    value: Power,
-    lower_bound: Power,
-    upper_bound: Power,
-    exclusion_bounds: timeseries.Bounds[Power] | None,
-) -> tuple[Power | None, Power | None]:
-    """Clamp the given value to the given bounds.
-
-    When the given value can falls within the exclusion zone, and can be clamped to
-    both sides, both options will be returned.
-
-    When the given value falls outside the usable bounds and can be clamped only to
-    one side, only that option will be returned.
-
-    Args:
-        value: The value to clamp.
-        lower_bound: The lower bound to clamp to.
-        upper_bound: The upper bound to clamp to.
-        exclusion_bounds: The exclusion bounds to clamp outside of.
-
-    Returns:
-        The clamped value.
-    """
-    # If the given bounds are within the exclusion bounds, return zero.
-    #
-    # And if the given bounds overlap with the exclusion bounds on one side, and the
-    # given power is in that overlap region, clamp it to the exclusion bounds on that
-    # side.
-    if exclusion_bounds is not None:
-        match _check_exclusion_bounds_overlap(
-            lower_bound, upper_bound, exclusion_bounds
-        ):
-            case (True, True):
-                return None, None
-            case (True, False):
-                if value < exclusion_bounds.upper:
-                    return None, exclusion_bounds.upper
-            case (False, True):
-                if value > exclusion_bounds.lower:
-                    return exclusion_bounds.lower, None
-
-    # If the given value is outside the given bounds, clamp it to the closest bound.
-    if value < lower_bound:
-        return lower_bound, None
-    if value > upper_bound:
-        return None, upper_bound
-
-    # If the given value is within the exclusion bounds and the exclusion bounds are
-    # within the given bounds, clamp the given value to the closest exclusion bound.
-    if exclusion_bounds is not None:
-        if exclusion_bounds.lower < value < exclusion_bounds.upper:
-            return exclusion_bounds.lower, exclusion_bounds.upper
-
-    return value, value
-
-
-def _check_exclusion_bounds_overlap(
-    lower_bound: Power,
-    upper_bound: Power,
-    exclusion_bounds: timeseries.Bounds[Power] | None,
-) -> tuple[bool, bool]:
-    """Check if the given bounds overlap with the given exclusion bounds.
-
-    When only the upper bound overlaps with exclusion bounds, the usable range is
-    between the lower bound and the lower exclusion bound, like below.
-
-      ===lb+++++++ex----ub-------ex===
-
-    When only the lower bound overlaps with exclusion bounds, the usable range is
-    between the upper exclusion bound and the upper bound.
-
-      ===ex------lb------ex++++++ub===
-
-    Both bounds overlapping with exclusion bounds (or given bounds are fully contained
-    within exclusion bounds).  In this case, there is no usable range.
-
-      ===ex------lb------ub------ex===
-
-    Args:
-        lower_bound: The lower bound to check.
-        upper_bound: The upper bound to check.
-        exclusion_bounds: The exclusion bounds to check against.
-
-    Returns:
-        A tuple containing a boolean indicating if the lower bound is bounded by the
-            exclusion bounds, and a boolean indicating if the upper bound is bounded by
-            the exclusion bounds.
-    """
-    if exclusion_bounds is None:
-        return False, False
-
-    bounded_lower = False
-    bounded_upper = False
-
-    if exclusion_bounds.lower < lower_bound < exclusion_bounds.upper:
-        bounded_lower = True
-    if exclusion_bounds.lower < upper_bound < exclusion_bounds.upper:
-        bounded_upper = True
-
-    return bounded_lower, bounded_upper
-
-
-def _adjust_exclusion_bounds(
-    lower_bound: Power,
-    upper_bound: Power,
-    exclusion_bounds: timeseries.Bounds[Power] | None,
-) -> tuple[Power, Power]:
-    """Adjust the given bounds to exclude the given exclusion bounds.
-
-    Args:
-        lower_bound: The lower bound to adjust.
-        upper_bound: The upper bound to adjust.
-        exclusion_bounds: The exclusion bounds to adjust to.
-
-    Returns:
-        The adjusted lower and upper bounds.
-    """
-    if exclusion_bounds is None:
-        return lower_bound, upper_bound
-
-    # If the given bounds are within the exclusion bounds, there's no room to adjust,
-    # so return zero.
-    #
-    # And if the given bounds overlap with the exclusion bounds on one side, then clamp
-    # the given bounds on that side.
-    match _check_exclusion_bounds_overlap(lower_bound, upper_bound, exclusion_bounds):
-        case (True, True):
-            return Power.zero(), Power.zero()
-        case (False, True):
-            return lower_bound, exclusion_bounds.lower
-        case (True, False):
-            return exclusion_bounds.upper, upper_bound
-    return lower_bound, upper_bound
 
 
 class Matryoshka(BaseAlgorithm):

--- a/src/frequenz/sdk/actor/_power_managing/_matryoshka.py
+++ b/src/frequenz/sdk/actor/_power_managing/_matryoshka.py
@@ -228,8 +228,8 @@ class Matryoshka(BaseAlgorithm):
         if system_bounds.inclusion_bounds is None:
             return Report(
                 target_power=target_power,
-                inclusion_bounds=None,
-                exclusion_bounds=system_bounds.exclusion_bounds,
+                _inclusion_bounds=None,
+                _exclusion_bounds=system_bounds.exclusion_bounds,
                 distribution_result=distribution_result,
             )
 
@@ -263,9 +263,9 @@ class Matryoshka(BaseAlgorithm):
                 break
         return Report(
             target_power=target_power,
-            inclusion_bounds=timeseries.Bounds[Power](
+            _inclusion_bounds=timeseries.Bounds[Power](
                 lower=lower_bound, upper=upper_bound
             ),
-            exclusion_bounds=system_bounds.exclusion_bounds,
+            _exclusion_bounds=system_bounds.exclusion_bounds,
             distribution_result=distribution_result,
         )

--- a/src/frequenz/sdk/actor/_power_managing/_matryoshka.py
+++ b/src/frequenz/sdk/actor/_power_managing/_matryoshka.py
@@ -97,6 +97,21 @@ def _check_exclusion_bounds_overlap(
 ) -> tuple[bool, bool]:
     """Check if the given bounds overlap with the given exclusion bounds.
 
+    When only the upper bound overlaps with exclusion bounds, the usable range is
+    between the lower bound and the lower exclusion bound, like below.
+
+      ===lb+++++++ex----ub-------ex===
+
+    When only the lower bound overlaps with exclusion bounds, the usable range is
+    between the upper exclusion bound and the upper bound.
+
+      ===ex------lb------ex++++++ub===
+
+    Both bounds overlapping with exclusion bounds (or given bounds are fully contained
+    within exclusion bounds).  In this case, there is no usable range.
+
+      ===ex------lb------ub------ex===
+
     Args:
         lower_bound: The lower bound to check.
         upper_bound: The upper bound to check.

--- a/src/frequenz/sdk/actor/_power_managing/_matryoshka.py
+++ b/src/frequenz/sdk/actor/_power_managing/_matryoshka.py
@@ -208,10 +208,8 @@ class Matryoshka(BaseAlgorithm):
                     upper_bound,
                     exclusion_bounds,
                 )
-            proposal_lower, proposal_upper = (
-                next_proposal.bounds.lower or lower_bound,
-                next_proposal.bounds.upper or upper_bound,
-            )
+            proposal_lower = next_proposal.bounds.lower or lower_bound
+            proposal_upper = next_proposal.bounds.upper or upper_bound
             # If the bounds from the current proposal are fully within the exclusion
             # bounds, then don't use them to narrow the bounds further. This allows
             # subsequent proposals to not be blocked by the current proposal.
@@ -350,10 +348,8 @@ class Matryoshka(BaseAlgorithm):
         for next_proposal in reversed(self._battery_buckets.get(battery_ids, [])):
             if next_proposal.priority <= priority:
                 break
-            proposal_lower, proposal_upper = (
-                next_proposal.bounds.lower or lower_bound,
-                next_proposal.bounds.upper or upper_bound,
-            )
+            proposal_lower = next_proposal.bounds.lower or lower_bound
+            proposal_upper = next_proposal.bounds.upper or upper_bound
             match _check_exclusion_bounds_overlap(
                 proposal_lower, proposal_upper, exclusion_bounds
             ):

--- a/src/frequenz/sdk/actor/_power_managing/_matryoshka.py
+++ b/src/frequenz/sdk/actor/_power_managing/_matryoshka.py
@@ -26,12 +26,8 @@ from typing_extensions import override
 
 from ... import timeseries
 from ...timeseries import Power
+from . import _bounds
 from ._base_classes import BaseAlgorithm, Proposal, Report
-from ._bounds_methods import (
-    _adjust_exclusion_bounds,
-    _check_exclusion_bounds_overlap,
-    _clamp_to_bounds,
-)
 from ._sorted_set import SortedSet
 
 if typing.TYPE_CHECKING:
@@ -89,7 +85,7 @@ class Matryoshka(BaseAlgorithm):
             if upper_bound < lower_bound:
                 break
             if next_proposal.preferred_power:
-                match _clamp_to_bounds(
+                match _bounds.clamp_to_bounds(
                     next_proposal.preferred_power,
                     lower_bound,
                     upper_bound,
@@ -111,14 +107,14 @@ class Matryoshka(BaseAlgorithm):
             # If the bounds from the current proposal are fully within the exclusion
             # bounds, then don't use them to narrow the bounds further. This allows
             # subsequent proposals to not be blocked by the current proposal.
-            match _check_exclusion_bounds_overlap(
+            match _bounds.check_exclusion_bounds_overlap(
                 proposal_lower, proposal_upper, exclusion_bounds
             ):
                 case (True, True):
                     continue
             lower_bound = max(lower_bound, proposal_lower)
             upper_bound = min(upper_bound, proposal_upper)
-            lower_bound, upper_bound = _adjust_exclusion_bounds(
+            lower_bound, upper_bound = _bounds.adjust_exclusion_bounds(
                 lower_bound, upper_bound, exclusion_bounds
             )
 
@@ -248,7 +244,7 @@ class Matryoshka(BaseAlgorithm):
                 break
             proposal_lower = next_proposal.bounds.lower or lower_bound
             proposal_upper = next_proposal.bounds.upper or upper_bound
-            match _check_exclusion_bounds_overlap(
+            match _bounds.check_exclusion_bounds_overlap(
                 proposal_lower, proposal_upper, exclusion_bounds
             ):
                 case (True, True):
@@ -256,7 +252,7 @@ class Matryoshka(BaseAlgorithm):
             calc_lower_bound = max(lower_bound, proposal_lower)
             calc_upper_bound = min(upper_bound, proposal_upper)
             if calc_lower_bound <= calc_upper_bound:
-                lower_bound, upper_bound = _adjust_exclusion_bounds(
+                lower_bound, upper_bound = _bounds.adjust_exclusion_bounds(
                     calc_lower_bound, calc_upper_bound, exclusion_bounds
                 )
             else:

--- a/src/frequenz/sdk/timeseries/battery_pool/__init__.py
+++ b/src/frequenz/sdk/timeseries/battery_pool/__init__.py
@@ -3,10 +3,12 @@
 
 """Manage a pool of batteries."""
 
+from ...actor._power_managing import Report
 from ._battery_pool import BatteryPool
 from ._result_types import PowerMetrics
 
 __all__ = [
     "BatteryPool",
     "PowerMetrics",
+    "Report",
 ]

--- a/tests/actor/_power_managing/test_matryoshka.py
+++ b/tests/actor/_power_managing/test_matryoshka.py
@@ -69,9 +69,11 @@ class StatefulTester:
         else:
             assert report.target_power is not None
             assert report.target_power.as_watts() == expected_power
-        assert report.inclusion_bounds is not None
-        assert report.inclusion_bounds.lower.as_watts() == expected_bounds[0]
-        assert report.inclusion_bounds.upper.as_watts() == expected_bounds[1]
+        # pylint: disable=protected-access
+        assert report._inclusion_bounds is not None
+        assert report._inclusion_bounds.lower.as_watts() == expected_bounds[0]
+        assert report._inclusion_bounds.upper.as_watts() == expected_bounds[1]
+        # pylint: enable=protected-access
 
 
 async def test_matryoshka_no_excl() -> None:  # pylint: disable=too-many-statements

--- a/tests/actor/_power_managing/test_report.py
+++ b/tests/actor/_power_managing/test_report.py
@@ -1,0 +1,119 @@
+# License: MIT
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
+
+"""Tests for methods provided by the PowerManager's reports."""
+
+from frequenz.sdk.actor._power_managing import Report
+from frequenz.sdk.timeseries import Bounds, Power
+
+
+class BoundsTester:
+    """Test the bounds adjustment."""
+
+    def __init__(
+        self,
+        inclusion_bounds: tuple[float, float] | None,
+        exclusion_bounds: tuple[float, float] | None,
+    ) -> None:
+        """Initialize the tester."""
+        self._report = Report(
+            target_power=None,
+            inclusion_bounds=Bounds(
+                Power.from_watts(inclusion_bounds[0]),
+                Power.from_watts(inclusion_bounds[1]),
+            )
+            if inclusion_bounds is not None
+            else None,
+            exclusion_bounds=Bounds(
+                Power.from_watts(exclusion_bounds[0]),
+                Power.from_watts(exclusion_bounds[1]),
+            )
+            if exclusion_bounds is not None
+            else None,
+            distribution_result=None,
+        )
+
+    def case(
+        self,
+        desired_power: float,
+        expected_lower: float | None,
+        expected_upper: float | None,
+    ) -> None:
+        """Test a case."""
+        lower, upper = self._report.adjust_to_bounds(Power.from_watts(desired_power))
+
+        tgt_lower = (
+            Power.from_watts(expected_lower) if expected_lower is not None else None
+        )
+        assert lower == tgt_lower
+        tgt_upper = (
+            Power.from_watts(expected_upper) if expected_upper is not None else None
+        )
+        assert upper == tgt_upper
+
+
+def test_adjust_to_bounds() -> None:
+    """Test that desired powers are adjusted to bounds correctly."""
+    tester = BoundsTester(
+        inclusion_bounds=(-200.0, 200.0),
+        exclusion_bounds=(-30.0, 30.0),
+    )
+    tester.case(0.0, -30.0, 30.0)
+    tester.case(-210.0, -200.0, None)
+    tester.case(220.0, None, 200.0)
+    tester.case(-20.0, -30.0, 30.0)
+    tester.case(-30.0, -30.0, -30.0)
+    tester.case(30.0, 30.0, 30.0)
+    tester.case(50.0, 50.0, 50.0)
+    tester.case(-200.0, -200.0, -200.0)
+    tester.case(200.0, 200.0, 200.0)
+
+    tester = BoundsTester(
+        inclusion_bounds=(-200.0, 200.0),
+        exclusion_bounds=(-210.0, 0.0),
+    )
+    tester.case(0.0, 0.0, 0.0)
+    tester.case(-210.0, None, 0.0)
+    tester.case(220.0, None, 200.0)
+    tester.case(-20.0, None, 0.0)
+    tester.case(20.0, 20.0, 20.0)
+
+    tester = BoundsTester(
+        inclusion_bounds=(-200.0, 200.0),
+        exclusion_bounds=(0.0, 210.0),
+    )
+    tester.case(0.0, 0.0, 0.0)
+    tester.case(-210.0, -200.0, None)
+    tester.case(220.0, 0.0, None)
+    tester.case(-20.0, -20.0, -20.0)
+    tester.case(20.0, 0.0, None)
+
+    tester = BoundsTester(
+        inclusion_bounds=(-200.0, 200.0),
+        exclusion_bounds=None,
+    )
+    tester.case(0.0, 0.0, 0.0)
+    tester.case(-210.0, -200.0, None)
+    tester.case(220.0, None, 200.0)
+    tester.case(-20.0, -20.0, -20.0)
+    tester.case(20.0, 20.0, 20.0)
+
+    tester = BoundsTester(
+        inclusion_bounds=(-200.0, 200.0),
+        exclusion_bounds=(-210.0, 210.0),
+    )
+    tester.case(0.0, None, None)
+    tester.case(-210.0, None, None)
+    tester.case(220.0, None, None)
+    tester.case(-20.0, None, None)
+    tester.case(20.0, None, None)
+
+    tester = BoundsTester(
+        inclusion_bounds=None,
+        exclusion_bounds=(-210.0, 210.0),
+    )
+    tester.case(0.0, None, None)
+    tester.case(-210.0, None, None)
+    tester.case(220.0, None, None)
+    tester.case(-20.0, None, None)
+    tester.case(20.0, None, None)

--- a/tests/actor/_power_managing/test_report.py
+++ b/tests/actor/_power_managing/test_report.py
@@ -18,13 +18,13 @@ class BoundsTester:
         """Initialize the tester."""
         self._report = Report(
             target_power=None,
-            inclusion_bounds=Bounds(
+            _inclusion_bounds=Bounds(  # pylint: disable=protected-access
                 Power.from_watts(inclusion_bounds[0]),
                 Power.from_watts(inclusion_bounds[1]),
             )
             if inclusion_bounds is not None
             else None,
-            exclusion_bounds=Bounds(
+            _exclusion_bounds=Bounds(  # pylint: disable=protected-access
                 Power.from_watts(exclusion_bounds[0]),
                 Power.from_watts(exclusion_bounds[1]),
             )

--- a/tests/timeseries/_battery_pool/test_battery_pool_control_methods.py
+++ b/tests/timeseries/_battery_pool/test_battery_pool_control_methods.py
@@ -149,13 +149,16 @@ class TestBatteryPoolControl:
         assert report.target_power == (
             Power.from_watts(power) if power is not None else None
         )
+        # pylint: disable=protected-access
         assert (
-            report.inclusion_bounds is not None and report.exclusion_bounds is not None
+            report._inclusion_bounds is not None
+            and report._exclusion_bounds is not None
         )
-        assert report.inclusion_bounds.lower == Power.from_watts(lower)
-        assert report.inclusion_bounds.upper == Power.from_watts(upper)
-        assert report.exclusion_bounds.lower == Power.from_watts(0.0)
-        assert report.exclusion_bounds.upper == Power.from_watts(0.0)
+        assert report._inclusion_bounds.lower == Power.from_watts(lower)
+        assert report._inclusion_bounds.upper == Power.from_watts(upper)
+        assert report._exclusion_bounds.lower == Power.from_watts(0.0)
+        assert report._exclusion_bounds.upper == Power.from_watts(0.0)
+        # pylint: enable=protected-access
         if expected_result_pred is not None:
             assert report.distribution_result is not None
             assert expected_result_pred(report.distribution_result)


### PR DESCRIPTION
This make the `inclusion_bounds` and `exclusion_bounds` fields of the
battery pool's `Report` class private, and instead introduces a
`bounds` property as a single set of bounds that users can use.

This PR also introduces the `Report.adjust_to_bounds` method which can
be used in case more granularity is needed on what exact power values
can be proposed to the battery pool.