### PR TITLE
Update DataSourcingActor to accept current requests for inverters

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -71,4 +71,4 @@ This version ships an experimental version of the **Power Manager**, adds prelim
 - Fix rendering of diagrams in the documentation.
 - The `__getitem__` magic of the `MovingWindow` is fixed to support the same functionality that the `window` method provides.
 - Fixes incorrect implementation of single element access in `__getitem__` magic of `MovingWindow`.
-- Fix incorrect grid current calculations in locations where the calculations depeneded on current measurements from an inverter.
+- Fix incorrect grid current calculations in locations where the calculations depended on current measurements from an inverter.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -71,3 +71,4 @@ This version ships an experimental version of the **Power Manager**, adds prelim
 - Fix rendering of diagrams in the documentation.
 - The `__getitem__` magic of the `MovingWindow` is fixed to support the same functionality that the `window` method provides.
 - Fixes incorrect implementation of single element access in `__getitem__` magic of `MovingWindow`.
+- Fix incorrect grid current calculations in locations where the calculations depeneded on current measurements from an inverter.

--- a/src/frequenz/sdk/actor/_data_sourcing/microgrid_api_source.py
+++ b/src/frequenz/sdk/actor/_data_sourcing/microgrid_api_source.py
@@ -155,7 +155,9 @@ class MicrogridApiSource:
         """
         for metric in requests:
             if metric not in _BatteryDataMethods:
-                raise ValueError(f"Unknown metric {metric} for Battery id {comp_id}")
+                err = f"Unknown metric {metric} for Battery id {comp_id}"
+                logging.error(err)
+                raise ValueError(err)
         if comp_id not in self.comp_data_receivers:
             self.comp_data_receivers[
                 comp_id
@@ -178,7 +180,9 @@ class MicrogridApiSource:
         """
         for metric in requests:
             if metric not in _EVChargerDataMethods:
-                raise ValueError(f"Unknown metric {metric} for EvCharger id {comp_id}")
+                err = f"Unknown metric {metric} for EvCharger id {comp_id}"
+                logging.error(err)
+                raise ValueError(err)
         if comp_id not in self.comp_data_receivers:
             self.comp_data_receivers[
                 comp_id
@@ -201,7 +205,9 @@ class MicrogridApiSource:
         """
         for metric in requests:
             if metric not in _InverterDataMethods:
-                raise ValueError(f"Unknown metric {metric} for Inverter id {comp_id}")
+                err = f"Unknown metric {metric} for Inverter id {comp_id}"
+                logging.error(err)
+                raise ValueError(err)
         if comp_id not in self.comp_data_receivers:
             self.comp_data_receivers[
                 comp_id
@@ -224,7 +230,9 @@ class MicrogridApiSource:
         """
         for metric in requests:
             if metric not in _MeterDataMethods:
-                raise ValueError(f"Unknown metric {metric} for Meter id {comp_id}")
+                err = f"Unknown metric {metric} for Meter id {comp_id}"
+                logging.error(err)
+                raise ValueError(err)
         if comp_id not in self.comp_data_receivers:
             self.comp_data_receivers[
                 comp_id
@@ -260,7 +268,9 @@ class MicrogridApiSource:
         elif category == ComponentCategory.METER:
             await self._check_meter_request(comp_id, requests)
         else:
-            raise ValueError(f"Unknown component category {category}")
+            err = f"Unknown component category {category}"
+            logging.error(err)
+            raise ValueError(err)
 
     def _get_data_extraction_method(
         self, category: ComponentCategory, metric: ComponentMetricId
@@ -286,7 +296,9 @@ class MicrogridApiSource:
             return _MeterDataMethods[metric]
         if category == ComponentCategory.EV_CHARGER:
             return _EVChargerDataMethods[metric]
-        raise ValueError(f"Unknown component category {category}")
+        err = f"Unknown component category {category}"
+        logging.error(err)
+        raise ValueError(err)
 
     def _get_metric_senders(
         self,

--- a/src/frequenz/sdk/actor/_data_sourcing/microgrid_api_source.py
+++ b/src/frequenz/sdk/actor/_data_sourcing/microgrid_api_source.py
@@ -69,6 +69,9 @@ _InverterDataMethods: dict[ComponentMetricId, Callable[[InverterData], float]] =
     ComponentMetricId.ACTIVE_POWER_INCLUSION_UPPER_BOUND: lambda msg: (
         msg.active_power_inclusion_upper_bound
     ),
+    ComponentMetricId.CURRENT_PHASE_1: lambda msg: msg.current_per_phase[0],
+    ComponentMetricId.CURRENT_PHASE_2: lambda msg: msg.current_per_phase[1],
+    ComponentMetricId.CURRENT_PHASE_3: lambda msg: msg.current_per_phase[2],
     ComponentMetricId.FREQUENCY: lambda msg: msg.frequency,
 }
 

--- a/src/frequenz/sdk/microgrid/component/_component_data.py
+++ b/src/frequenz/sdk/microgrid/component/_component_data.py
@@ -232,7 +232,7 @@ class InverterData(ComponentData):
     """
 
     current_per_phase: tuple[float, float, float]
-    """AC current in Amperes (A) for phase/line 1,2 and 3 respectively.
+    """AC current in Amperes (A) for phase/line 1, 2 and 3 respectively.
             +ve current means consumption, away from the grid.
             -ve current means supply into the grid.
     """

--- a/src/frequenz/sdk/microgrid/component/_component_data.py
+++ b/src/frequenz/sdk/microgrid/component/_component_data.py
@@ -231,6 +231,12 @@ class InverterData(ComponentData):
             -ve current means supply into the grid.
     """
 
+    current_per_phase: tuple[float, float, float]
+    """AC current in Amperes (A) for phase/line 1,2 and 3 respectively.
+            +ve current means consumption, away from the grid.
+            -ve current means supply into the grid.
+    """
+
     # pylint: disable=line-too-long
     active_power_inclusion_lower_bound: float
     """Lower inclusion bound for inverter power in watts.
@@ -301,6 +307,11 @@ class InverterData(ComponentData):
             component_id=raw.id,
             timestamp=raw.ts.ToDatetime(tzinfo=timezone.utc),
             active_power=raw.inverter.data.ac.power_active.value,
+            current_per_phase=(
+                raw.meter.data.ac.phase_1.current.value,
+                raw.meter.data.ac.phase_2.current.value,
+                raw.meter.data.ac.phase_3.current.value,
+            ),
             active_power_inclusion_lower_bound=raw_power.system_inclusion_bounds.lower,
             active_power_exclusion_lower_bound=raw_power.system_exclusion_bounds.lower,
             active_power_inclusion_upper_bound=raw_power.system_inclusion_bounds.upper,

--- a/tests/utils/component_data_wrapper.py
+++ b/tests/utils/component_data_wrapper.py
@@ -101,6 +101,7 @@ class InverterDataWrapper(InverterData):
         component_id: int,
         timestamp: datetime,
         active_power: float = math.nan,
+        current_per_phase: tuple[float, float, float] | None = None,
         active_power_inclusion_lower_bound: float = math.nan,
         active_power_exclusion_lower_bound: float = math.nan,
         active_power_inclusion_upper_bound: float = math.nan,
@@ -120,6 +121,11 @@ class InverterDataWrapper(InverterData):
             component_id=component_id,
             timestamp=timestamp,
             active_power=active_power,
+            current_per_phase=(
+                current_per_phase
+                if current_per_phase
+                else (math.nan, math.nan, math.nan)
+            ),
             active_power_inclusion_lower_bound=active_power_inclusion_lower_bound,
             active_power_exclusion_lower_bound=active_power_exclusion_lower_bound,
             active_power_inclusion_upper_bound=active_power_inclusion_upper_bound,


### PR DESCRIPTION
In some component configurations, it might be necessary to use current
readings from inverters to calculate grid current.