### PR TITLE
Fix bug in inverter current data extractor

### DIFF
--- a/src/frequenz/sdk/microgrid/component/_component_data.py
+++ b/src/frequenz/sdk/microgrid/component/_component_data.py
@@ -308,9 +308,9 @@ class InverterData(ComponentData):
             timestamp=raw.ts.ToDatetime(tzinfo=timezone.utc),
             active_power=raw.inverter.data.ac.power_active.value,
             current_per_phase=(
-                raw.meter.data.ac.phase_1.current.value,
-                raw.meter.data.ac.phase_2.current.value,
-                raw.meter.data.ac.phase_3.current.value,
+                raw.inverter.data.ac.phase_1.current.value,
+                raw.inverter.data.ac.phase_2.current.value,
+                raw.inverter.data.ac.phase_3.current.value,
             ),
             active_power_inclusion_lower_bound=raw_power.system_inclusion_bounds.lower,
             active_power_exclusion_lower_bound=raw_power.system_exclusion_bounds.lower,

--- a/tests/microgrid/test_component_data.py
+++ b/tests/microgrid/test_component_data.py
@@ -6,8 +6,14 @@
 from datetime import datetime, timezone
 
 import pytest
+from frequenz.api.common import metrics_pb2
+from frequenz.api.common.metrics import electrical_pb2
+from frequenz.api.microgrid import inverter_pb2, microgrid_pb2
+from google.protobuf import timestamp_pb2
 
-from frequenz.sdk.microgrid.component import ComponentData
+from frequenz.sdk.microgrid.component import ComponentData, InverterData
+
+# pylint: disable=no-member
 
 
 def test_component_data_abstract_class() -> None:
@@ -15,3 +21,62 @@ def test_component_data_abstract_class() -> None:
     with pytest.raises(TypeError):
         # pylint: disable=abstract-class-instantiated
         ComponentData(0, datetime.now(timezone.utc))  # type: ignore
+
+
+def test_inverter_data() -> None:
+    """Verify the constructor for the InverterData class."""
+    seconds = 1234567890
+
+    raw = microgrid_pb2.ComponentData(
+        id=5,
+        ts=timestamp_pb2.Timestamp(seconds=seconds),
+        inverter=inverter_pb2.Inverter(
+            state=inverter_pb2.State(
+                component_state=inverter_pb2.COMPONENT_STATE_DISCHARGING
+            ),
+            errors=[inverter_pb2.Error(msg="error message")],
+            data=inverter_pb2.Data(
+                dc_battery=None,
+                dc_solar=None,
+                temperature=None,
+                ac=electrical_pb2.AC(
+                    frequency=metrics_pb2.Metric(value=50.1),
+                    power_active=metrics_pb2.Metric(
+                        value=100.2,
+                        system_exclusion_bounds=metrics_pb2.Bounds(
+                            lower=-501.0, upper=501.0
+                        ),
+                        system_inclusion_bounds=metrics_pb2.Bounds(
+                            lower=-51000.0, upper=51000.0
+                        ),
+                    ),
+                    phase_1=electrical_pb2.AC.ACPhase(
+                        current=metrics_pb2.Metric(value=12.3),
+                    ),
+                    phase_2=electrical_pb2.AC.ACPhase(
+                        current=metrics_pb2.Metric(value=23.4),
+                    ),
+                    phase_3=electrical_pb2.AC.ACPhase(
+                        current=metrics_pb2.Metric(value=34.5),
+                    ),
+                ),
+            ),
+        ),
+    )
+
+    inv_data = InverterData.from_proto(raw)
+    assert inv_data.component_id == 5
+    assert inv_data.timestamp == datetime.fromtimestamp(seconds, timezone.utc)
+    assert (  # pylint: disable=protected-access
+        inv_data._component_state == inverter_pb2.COMPONENT_STATE_DISCHARGING
+    )
+    assert inv_data._errors == [  # pylint: disable=protected-access
+        inverter_pb2.Error(msg="error message")
+    ]
+    assert inv_data.frequency == pytest.approx(50.1)
+    assert inv_data.active_power == pytest.approx(100.2)
+    assert inv_data.current_per_phase == pytest.approx((12.3, 23.4, 34.5))
+    assert inv_data.active_power_inclusion_lower_bound == pytest.approx(-51000.0)
+    assert inv_data.active_power_inclusion_upper_bound == pytest.approx(51000.0)
+    assert inv_data.active_power_exclusion_lower_bound == pytest.approx(-501.0)
+    assert inv_data.active_power_exclusion_upper_bound == pytest.approx(501.0)

--- a/tests/microgrid/test_component_data.py
+++ b/tests/microgrid/test_component_data.py
@@ -47,7 +47,7 @@ def test_inverter_data() -> None:
                             lower=-501.0, upper=501.0
                         ),
                         system_inclusion_bounds=metrics_pb2.Bounds(
-                            lower=-51000.0, upper=51000.0
+                            lower=-51_000.0, upper=51_000.0
                         ),
                     ),
                     phase_1=electrical_pb2.AC.ACPhase(
@@ -76,7 +76,7 @@ def test_inverter_data() -> None:
     assert inv_data.frequency == pytest.approx(50.1)
     assert inv_data.active_power == pytest.approx(100.2)
     assert inv_data.current_per_phase == pytest.approx((12.3, 23.4, 34.5))
-    assert inv_data.active_power_inclusion_lower_bound == pytest.approx(-51000.0)
-    assert inv_data.active_power_inclusion_upper_bound == pytest.approx(51000.0)
+    assert inv_data.active_power_inclusion_lower_bound == pytest.approx(-51_000.0)
+    assert inv_data.active_power_inclusion_upper_bound == pytest.approx(51_000.0)
     assert inv_data.active_power_exclusion_lower_bound == pytest.approx(-501.0)
     assert inv_data.active_power_exclusion_upper_bound == pytest.approx(501.0)


### PR DESCRIPTION
It was supposed to extract data for the inverter, but was doing so for the meter.