### PR TITLE
Fix power failure report

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -72,3 +72,4 @@ This version ships an experimental version of the **Power Manager**, adds prelim
 - The `__getitem__` magic of the `MovingWindow` is fixed to support the same functionality that the `window` method provides.
 - Fixes incorrect implementation of single element access in `__getitem__` magic of `MovingWindow`.
 - Fix incorrect grid current calculations in locations where the calculations depended on current measurements from an inverter.
+- Fix power failure report to exclude any failed power from the succeeded power.

--- a/src/frequenz/sdk/actor/power_distributing/power_distributing.py
+++ b/src/frequenz/sdk/actor/power_distributing/power_distributing.py
@@ -350,7 +350,9 @@ class PowerDistributingActor(Actor):
                 succeed_batteries = set(battery_distribution.keys()) - failed_batteries
                 response = PartialFailure(
                     request=request,
-                    succeeded_power=Power.from_watts(distributed_power_value),
+                    succeeded_power=Power.from_watts(
+                        distributed_power_value - failed_power
+                    ),
                     succeeded_batteries=succeed_batteries,
                     failed_power=Power.from_watts(failed_power),
                     failed_batteries=failed_batteries,


### PR DESCRIPTION
The succeeded power in `PartialFailure`  result should exclude any failed power.

There was no unit tests covering `PartialFailure` results so this patch adds a test to cover the case where the microgrid, for any reason, fails to set power for one of the batteries in the power request.

Fixes #751 