### PR TITLE
Bump frequenz-channels from 0.16 to 1.0.0b2

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -8,6 +8,8 @@
 
 - The `BatteryPool.power_status` method now streams objects of type `BatteryPoolReport`, replacing the previous `Report` objects.
 
+- `Channels` has been upgraded to version 1.0.0b2, for information on how to upgrade please read [Channels release notes](https://github.com/frequenz-floss/frequenz-channels-python/releases/tag/v1.0.0-beta.2).
+
 - In `BatteryPoolReport.distribution_result`,
   * the following fields have been renamed:
     + `Result.succeeded_batteries` → `Result.succeeded_components`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
   # Make sure to update the mkdocs.yml file when
   # changing the version
   # (plugins.mkdocstrings.handlers.python.import)
-  "frequenz-channels >= 0.16.0, < 0.17.0",
+  "frequenz-channels == 1.0.0b2",
   "google-api-python-client >= 2.71, < 3",
   "grpcio >= 1.54.2, < 2",
   "grpcio-tools >= 1.54.2, < 2",

--- a/src/frequenz/sdk/actor/_channel_registry.py
+++ b/src/frequenz/sdk/actor/_channel_registry.py
@@ -47,9 +47,7 @@ class ChannelRegistry:
             self._channels[key] = Broadcast(f"{self._name}-{key}")
         # This attribute is protected in the current version of the channels library,
         # but that will change in the future.
-        self._channels[  # pylint: disable=protected-access
-            key
-        ]._resend_latest = resend_latest
+        self._channels[key].resend_latest = resend_latest
 
     def new_sender(self, key: str) -> Sender[typing.Any]:
         """Get a sender to a dynamically created channel with the given key.

--- a/src/frequenz/sdk/timeseries/battery_pool/_methods.py
+++ b/src/frequenz/sdk/timeseries/battery_pool/_methods.py
@@ -183,7 +183,7 @@ class SendOnUpdate(MetricAggregator[T]):
         _logger.error(
             "Removing component %d from the %s formula.",
             component_id,
-            self._result_channel.name,
+            self._result_channel._name,  # pylint: disable=protected-access
         )
         fetchers.pop(component_id)
 


### PR DESCRIPTION
this is a prerequesite for #556

NB: No changelog entry added, as it seems like it hasen't been done in the past for version changes either (at least I didn't find it)