### PR TITLE
Fix type hint errors in microgrid client

### DIFF
--- a/src/frequenz/sdk/microgrid/client/_client.py
+++ b/src/frequenz/sdk/microgrid/client/_client.py
@@ -239,10 +239,14 @@ class MicrogridGrpcClient(MicrogridApiClient):
         try:
             # grpc.aio is missing types and mypy thinks this is not awaitable,
             # but it is
-            component_list = await self.api.ListComponents(
-                microgrid_pb.ComponentFilter(),
-                timeout=int(DEFAULT_GRPC_CALL_TIMEOUT),
-            )  # type: ignore[misc]
+            component_list = await cast(
+                Awaitable[microgrid_pb.ComponentList],
+                self.api.ListComponents(
+                    microgrid_pb.ComponentFilter(),
+                    timeout=int(DEFAULT_GRPC_CALL_TIMEOUT),
+                ),
+            )
+
         except grpc.aio.AioRpcError as err:
             msg = f"Failed to list components. Microgrid API: {self.target}. Err: {err.details()}"
             raise grpc.aio.AioRpcError(
@@ -280,10 +284,13 @@ class MicrogridGrpcClient(MicrogridApiClient):
         """
         microgrid_metadata: microgrid_pb.MicrogridMetadata | None = None
         try:
-            microgrid_metadata = await self.api.GetMicrogridMetadata(
-                Empty(),
-                timeout=int(DEFAULT_GRPC_CALL_TIMEOUT),
-            )  # type: ignore[misc]
+            microgrid_metadata = await cast(
+                Awaitable[microgrid_pb.MicrogridMetadata],
+                self.api.GetMicrogridMetadata(
+                    Empty(),
+                    timeout=int(DEFAULT_GRPC_CALL_TIMEOUT),
+                ),
+            )
         except grpc.aio.AioRpcError:
             _logger.exception("The microgrid metadata is not available.")
 
@@ -616,12 +623,15 @@ class MicrogridGrpcClient(MicrogridApiClient):
                 when the api call exceeded timeout
         """
         try:
-            await self.api.SetPowerActive(
-                microgrid_pb.SetPowerActiveParam(
-                    component_id=component_id, power=power_w
+            await cast(
+                Awaitable[microgrid_pb.SetPowerActiveParam],
+                self.api.SetPowerActive(
+                    microgrid_pb.SetPowerActiveParam(
+                        component_id=component_id, power=power_w
+                    ),
+                    timeout=int(DEFAULT_GRPC_CALL_TIMEOUT),
                 ),
-                timeout=int(DEFAULT_GRPC_CALL_TIMEOUT),
-            )  # type: ignore[misc]
+            )
         except grpc.aio.AioRpcError as err:
             msg = f"Failed to set power. Microgrid API: {self.target}. Err: {err.details()}"
             raise grpc.aio.AioRpcError(

--- a/src/frequenz/sdk/microgrid/client/_client.py
+++ b/src/frequenz/sdk/microgrid/client/_client.py
@@ -241,7 +241,7 @@ class MicrogridGrpcClient(MicrogridApiClient):
             # but it is
             component_list = await self.api.ListComponents(
                 microgrid_pb.ComponentFilter(),
-                timeout=DEFAULT_GRPC_CALL_TIMEOUT,  # type: ignore[arg-type]
+                timeout=int(DEFAULT_GRPC_CALL_TIMEOUT),
             )  # type: ignore[misc]
         except grpc.aio.AioRpcError as err:
             msg = f"Failed to list components. Microgrid API: {self.target}. Err: {err.details()}"
@@ -329,7 +329,7 @@ class MicrogridGrpcClient(MicrogridApiClient):
                     Awaitable[microgrid_pb.ConnectionList],
                     self.api.ListConnections(
                         connection_filter,
-                        timeout=DEFAULT_GRPC_CALL_TIMEOUT,  # type: ignore[arg-type]
+                        timeout=int(DEFAULT_GRPC_CALL_TIMEOUT),
                     ),
                 ),
             )
@@ -620,7 +620,7 @@ class MicrogridGrpcClient(MicrogridApiClient):
                 microgrid_pb.SetPowerActiveParam(
                     component_id=component_id, power=power_w
                 ),
-                timeout=DEFAULT_GRPC_CALL_TIMEOUT,  # type: ignore[arg-type]
+                timeout=int(DEFAULT_GRPC_CALL_TIMEOUT),
             )  # type: ignore[misc]
         except grpc.aio.AioRpcError as err:
             msg = f"Failed to set power. Microgrid API: {self.target}. Err: {err.details()}"


### PR DESCRIPTION
The mypy type hint errors in microgrid client were fixed in an attempt to address #774 which might no longer need to be addressed as the suggestion is just moving the type hint error from `no-name-in-module` where `protobuf.*` is imported to `no-member` where it is used. Anyway I kept these commits in case we want to merge them, otherwise we can just close this PR and #774.
