### PR TITLE
Un-Peekable-ification of the PowerDistributingActor

### DIFF
--- a/src/frequenz/sdk/_internal/_channels.py
+++ b/src/frequenz/sdk/_internal/_channels.py
@@ -4,6 +4,7 @@
 """General purpose classes for use with channels."""
 
 import abc
+import asyncio
 import typing
 
 from frequenz.channels import Receiver
@@ -24,3 +25,26 @@ class ReceiverFetcher(typing.Generic[T], typing.Protocol):
         Returns:
             A receiver instance.
         """
+
+
+class LatestValueCache(typing.Generic[T]):
+    """A cache that stores the latest value in a receiver."""
+
+    def __init__(self, receiver: Receiver[T]) -> None:
+        """Create a new cache.
+
+        Args:
+            receiver: The receiver to cache.
+        """
+        self._receiver = receiver
+        self._latest_value: T | None = None
+        self._task = asyncio.create_task(self._run())
+
+    @property
+    def latest_value(self) -> T | None:
+        """Get the latest value in the cache."""
+        return self._latest_value
+
+    async def _run(self) -> None:
+        async for value in self._receiver:
+            self._latest_value = value

--- a/src/frequenz/sdk/microgrid/client/_client.py
+++ b/src/frequenz/sdk/microgrid/client/_client.py
@@ -425,7 +425,7 @@ class MicrogridGrpcClient(MicrogridApiClient):
         if component_id in self._component_streams:
             return self._component_streams[component_id]
         task_name = f"raw-component-data-{component_id}"
-        chan = Broadcast[_GenericComponentData](task_name)
+        chan = Broadcast[_GenericComponentData](task_name, resend_latest=True)
         self._component_streams[component_id] = chan
 
         self._streaming_tasks[component_id] = asyncio.create_task(

--- a/src/frequenz/sdk/microgrid/client/_client.py
+++ b/src/frequenz/sdk/microgrid/client/_client.py
@@ -98,10 +98,6 @@ class MicrogridApiClient(ABC):
     ) -> Receiver[MeterData]:
         """Return a channel receiver that provides a `MeterData` stream.
 
-        If only the latest value is required, the `Receiver` returned by this
-        method can be converted into a `Peekable` with the `into_peekable`
-        method on the `Receiver.`
-
         Args:
             component_id: id of the meter to get data for.
             maxsize: Size of the receiver's buffer.
@@ -117,10 +113,6 @@ class MicrogridApiClient(ABC):
         maxsize: int = RECEIVER_MAX_SIZE,
     ) -> Receiver[BatteryData]:
         """Return a channel receiver that provides a `BatteryData` stream.
-
-        If only the latest value is required, the `Receiver` returned by this
-        method can be converted into a `Peekable` with the `into_peekable`
-        method on the `Receiver.`
 
         Args:
             component_id: id of the battery to get data for.
@@ -138,10 +130,6 @@ class MicrogridApiClient(ABC):
     ) -> Receiver[InverterData]:
         """Return a channel receiver that provides an `InverterData` stream.
 
-        If only the latest value is required, the `Receiver` returned by this
-        method can be converted into a `Peekable` with the `into_peekable`
-        method on the `Receiver.`
-
         Args:
             component_id: id of the inverter to get data for.
             maxsize: Size of the receiver's buffer.
@@ -157,10 +145,6 @@ class MicrogridApiClient(ABC):
         maxsize: int = RECEIVER_MAX_SIZE,
     ) -> Receiver[EVChargerData]:
         """Return a channel receiver that provides an `EvChargeData` stream.
-
-        If only the latest value is required, the `Receiver` returned by this
-        method can be converted into a `Peekable` with the `into_peekable`
-        method on the `Receiver.`
 
         Args:
             component_id: id of the ev charger to get data for.
@@ -493,10 +477,6 @@ class MicrogridGrpcClient(MicrogridApiClient):
     ) -> Receiver[MeterData]:
         """Return a channel receiver that provides a `MeterData` stream.
 
-        If only the latest value is required, the `Receiver` returned by this
-        method can be converted into a `Peekable` with the `into_peekable`
-        method on the `Receiver.`
-
         Raises:
             ValueError: if the given id is unknown or has a different type.
 
@@ -522,10 +502,6 @@ class MicrogridGrpcClient(MicrogridApiClient):
         maxsize: int = RECEIVER_MAX_SIZE,
     ) -> Receiver[BatteryData]:
         """Return a channel receiver that provides a `BatteryData` stream.
-
-        If only the latest value is required, the `Receiver` returned by this
-        method can be converted into a `Peekable` with the `into_peekable`
-        method on the `Receiver.`
 
         Raises:
             ValueError: if the given id is unknown or has a different type.
@@ -553,10 +529,6 @@ class MicrogridGrpcClient(MicrogridApiClient):
     ) -> Receiver[InverterData]:
         """Return a channel receiver that provides an `InverterData` stream.
 
-        If only the latest value is required, the `Receiver` returned by this
-        method can be converted into a `Peekable` with the `into_peekable`
-        method on the `Receiver.`
-
         Raises:
             ValueError: if the given id is unknown or has a different type.
 
@@ -582,10 +554,6 @@ class MicrogridGrpcClient(MicrogridApiClient):
         maxsize: int = RECEIVER_MAX_SIZE,
     ) -> Receiver[EVChargerData]:
         """Return a channel receiver that provides an `EvChargeData` stream.
-
-        If only the latest value is required, the `Receiver` returned by this
-        method can be converted into a `Peekable` with the `into_peekable`
-        method on the `Receiver.`
 
         Raises:
             ValueError: if the given id is unknown or has a different type.

--- a/tests/microgrid/test_client.py
+++ b/tests/microgrid/test_client.py
@@ -407,10 +407,10 @@ class TestMicrogridGrpcClient:
             with pytest.raises(ValueError):
                 # should raise a ValueError for wrong component category
                 await microgrid.meter_data(38)
-            peekable = (await microgrid.meter_data(83)).into_peekable()
+            receiver = await microgrid.meter_data(83)
             await asyncio.sleep(0.2)
 
-        latest = peekable.peek()
+        latest = await anext(receiver)
         assert isinstance(latest, MeterData)
         assert latest.component_id == 83
 
@@ -431,10 +431,10 @@ class TestMicrogridGrpcClient:
             with pytest.raises(ValueError):
                 # should raise a ValueError for wrong component category
                 await microgrid.meter_data(38)
-            peekable = (await microgrid.battery_data(83)).into_peekable()
+            receiver = await microgrid.battery_data(83)
             await asyncio.sleep(0.2)
 
-        latest = peekable.peek()
+        latest = await anext(receiver)
         assert isinstance(latest, BatteryData)
         assert latest.component_id == 83
 
@@ -455,10 +455,10 @@ class TestMicrogridGrpcClient:
             with pytest.raises(ValueError):
                 # should raise a ValueError for wrong component category
                 await microgrid.meter_data(38)
-            peekable = (await microgrid.inverter_data(83)).into_peekable()
+            receiver = await microgrid.inverter_data(83)
             await asyncio.sleep(0.2)
 
-        latest = peekable.peek()
+        latest = await anext(receiver)
         assert isinstance(latest, InverterData)
         assert latest.component_id == 83
 
@@ -479,10 +479,10 @@ class TestMicrogridGrpcClient:
             with pytest.raises(ValueError):
                 # should raise a ValueError for wrong component category
                 await microgrid.meter_data(38)
-            peekable = (await microgrid.ev_charger_data(83)).into_peekable()
+            receiver = await microgrid.ev_charger_data(83)
             await asyncio.sleep(0.2)
 
-        latest = peekable.peek()
+        latest = await anext(receiver)
         assert isinstance(latest, EVChargerData)
         assert latest.component_id == 83
 

--- a/tests/timeseries/_battery_pool/test_battery_pool_control_methods.py
+++ b/tests/timeseries/_battery_pool/test_battery_pool_control_methods.py
@@ -72,6 +72,7 @@ async def mocks(mocker: MockerFixture) -> typing.AsyncIterator[Mocks]:
         *[
             microgrid._data_pipeline._DATA_PIPELINE._stop(),
             streamer.stop(),
+            mockgrid.cleanup(),
         ]
     )
 


### PR DESCRIPTION
This PR replaces `Peekable`s with `LatestValueCache`.

And updates tests to not mock time, because that somehow makes a difference when using actual receivers.