### PR TITLE
Pass through 0W requests to the microgrid API independent of exclusion bounds

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -52,4 +52,4 @@
 
 ## Bug Fixes
 
-<!-- Here goes notable bug fixes that are worth a special mention or explanation -->
+- 0W power requests are now not adjusted to exclusion bounds by the `PowerManager` and `PowerDistributor`, and are sent over to the microgrid API directly.

--- a/src/frequenz/sdk/actor/_power_managing/_bounds.py
+++ b/src/frequenz/sdk/actor/_power_managing/_bounds.py
@@ -138,7 +138,7 @@ def clamp_to_bounds(  # pylint: disable=too-many-return-statements
 
     # If the given value is within the exclusion bounds and the exclusion bounds are
     # within the given bounds, clamp the given value to the closest exclusion bound.
-    if exclusion_bounds is not None:
+    if exclusion_bounds is not None and not value.isclose(Power.zero()):
         if exclusion_bounds.lower < value < exclusion_bounds.upper:
             return exclusion_bounds.lower, exclusion_bounds.upper
 

--- a/src/frequenz/sdk/actor/power_distributing/_distribution_algorithm/_battery_distribution_algorithm.py
+++ b/src/frequenz/sdk/actor/power_distributing/_distribution_algorithm/_battery_distribution_algorithm.py
@@ -685,7 +685,16 @@ class BatteryDistributionAlgorithm:
         Returns:
             Distribution result
         """
-        if power >= 0.0:
+        if is_close_to_zero(power):
+            return DistributionResult(
+                distribution={
+                    inverter.component_id: 0.0
+                    for _, inverters in components
+                    for inverter in inverters
+                },
+                remaining_power=0.0,
+            )
+        if power > 0.0:
             return self._distribute_consume_power(power, components)
         return self._distribute_supply_power(power, components)
 

--- a/tests/actor/_power_managing/test_matryoshka.py
+++ b/tests/actor/_power_managing/test_matryoshka.py
@@ -313,6 +313,13 @@ async def test_matryoshka_with_excl_3() -> None:
     )
 
     tester = StatefulTester(batteries, system_bounds)
+    tester.tgt_power(priority=2, power=10.0, bounds=(None, None), expected=30.0)
+    tester.tgt_power(priority=2, power=-10.0, bounds=(None, None), expected=-30.0)
+    tester.tgt_power(priority=2, power=0.0, bounds=(None, None), expected=0.0)
+    tester.tgt_power(priority=3, power=20.0, bounds=(None, None), expected=None)
+    tester.tgt_power(priority=1, power=-20.0, bounds=(None, None), expected=-30.0)
+    tester.tgt_power(priority=3, power=None, bounds=(None, None), expected=None)
+    tester.tgt_power(priority=1, power=None, bounds=(None, None), expected=0.0)
 
     tester.tgt_power(priority=2, power=25.0, bounds=(25.0, 50.0), expected=30.0)
     tester.bounds(priority=2, expected_power=30.0, expected_bounds=(-200.0, 200.0))

--- a/tests/actor/_power_managing/test_report.py
+++ b/tests/actor/_power_managing/test_report.py
@@ -58,7 +58,7 @@ def test_adjust_to_bounds() -> None:
         inclusion_bounds=(-200.0, 200.0),
         exclusion_bounds=(-30.0, 30.0),
     )
-    tester.case(0.0, -30.0, 30.0)
+    tester.case(0.0, 0.0, 0.0)
     tester.case(-210.0, -200.0, None)
     tester.case(220.0, None, 200.0)
     tester.case(-20.0, -30.0, 30.0)

--- a/tests/actor/power_distributing/test_battery_distribution_algorithm.py
+++ b/tests/actor/power_distributing/test_battery_distribution_algorithm.py
@@ -1040,6 +1040,11 @@ class TestDistWithExclBounds:
         algorithm = BatteryDistributionAlgorithm()
 
         self.assert_result(
+            algorithm.distribute_power(0, components),
+            DistributionResult({1: 0, 3: 0, 5: 0}, remaining_power=0.0),
+        )
+
+        self.assert_result(
             algorithm.distribute_power(-300, components),
             DistributionResult({1: -100, 3: -100, 5: -100}, remaining_power=0.0),
         )


### PR DESCRIPTION
The PowerManager and PowerDistributor were adjusting 0 power requests to exclusion bounds, which it shouldn't do.

It now forwards 0 power requests directly to the microgrid API, which can decide how to adjust for exclusion bounds, if necessary.

Closes #794 