### PR TITLE
WIP: Force explicit casts when using the ChannelRegistry

### DIFF
--- a/src/frequenz/sdk/actor/_data_sourcing/microgrid_api_source.py
+++ b/src/frequenz/sdk/actor/_data_sourcing/microgrid_api_source.py
@@ -6,7 +6,7 @@
 import asyncio
 import logging
 from collections.abc import Callable
-from typing import Any
+from typing import Any, cast
 
 from frequenz.channels import Receiver, Sender
 
@@ -322,7 +322,10 @@ class MicrogridApiSource:
             (
                 self._get_data_extraction_method(category, metric),
                 [
-                    self._registry.new_sender(request.get_channel_name())
+                    cast(
+                        Sender[Sample[Quantity]],
+                        self._registry.new_sender(request.get_channel_name()),
+                    )
                     for request in req_list
                 ],
             )

--- a/src/frequenz/sdk/actor/_power_managing/_power_managing_actor.py
+++ b/src/frequenz/sdk/actor/_power_managing/_power_managing_actor.py
@@ -211,14 +211,16 @@ class PowerManagingActor(Actor):
 
                 if component_ids not in self._subscriptions:
                     self._subscriptions[component_ids] = {
-                        priority: self._channel_registry.new_sender(
-                            sub.get_channel_name()
+                        priority: typing.cast(
+                            Sender[_Report],
+                            self._channel_registry.new_sender(sub.get_channel_name()),
                         )
                     }
                 elif priority not in self._subscriptions[component_ids]:
-                    self._subscriptions[component_ids][
-                        priority
-                    ] = self._channel_registry.new_sender(sub.get_channel_name())
+                    self._subscriptions[component_ids][priority] = typing.cast(
+                        Sender[_Report],
+                        self._channel_registry.new_sender(sub.get_channel_name()),
+                    )
 
                 if sub.component_ids not in self._bound_tracker_tasks:
                     self._add_bounds_tracker(sub.component_ids)

--- a/src/frequenz/sdk/actor/_resampling.py
+++ b/src/frequenz/sdk/actor/_resampling.py
@@ -7,6 +7,7 @@
 import asyncio
 import dataclasses
 import logging
+from typing import cast
 
 from frequenz.channels import Receiver, Sender
 
@@ -77,11 +78,17 @@ class ComponentMetricsResamplingActor(Actor):
         )
         data_source_channel_name = data_source_request.get_channel_name()
         await self._data_sourcing_request_sender.send(data_source_request)
-        receiver = self._channel_registry.new_receiver(data_source_channel_name)
+        receiver = cast(
+            Receiver[Sample[Quantity]],
+            self._channel_registry.new_receiver(data_source_channel_name),
+        )
 
         # This is a temporary hack until the Sender implementation uses
         # exceptions to report errors.
-        sender = self._channel_registry.new_sender(request_channel_name)
+        sender = cast(
+            Sender[Sample[Quantity]],
+            self._channel_registry.new_sender(request_channel_name),
+        )
 
         async def sink_adapter(sample: Sample[Quantity]) -> None:
             await sender.send(sample)

--- a/src/frequenz/sdk/timeseries/_grid_frequency.py
+++ b/src/frequenz/sdk/timeseries/_grid_frequency.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from frequenz.channels import Receiver, Sender
 
@@ -15,7 +15,7 @@ from ..actor import ChannelRegistry
 from ..microgrid import connection_manager
 from ..microgrid.component import Component, ComponentCategory, ComponentMetricId
 from ..timeseries._base_types import Sample
-from ..timeseries._quantities import Frequency
+from ..timeseries._quantities import Frequency, Quantity
 
 if TYPE_CHECKING:
     # Imported here to avoid a circular import.
@@ -82,8 +82,11 @@ class GridFrequency:
         Returns:
             A receiver that will receive grid frequency samples.
         """
-        receiver = self._channel_registry.new_receiver(
-            self._component_metric_request.get_channel_name()
+        receiver = cast(
+            Receiver[Sample[Quantity]],
+            self._channel_registry.new_receiver(
+                self._component_metric_request.get_channel_name()
+            ),
         )
 
         if not self._task:

--- a/src/frequenz/sdk/timeseries/battery_pool/_battery_pool.py
+++ b/src/frequenz/sdk/timeseries/battery_pool/_battery_pool.py
@@ -12,6 +12,7 @@ import asyncio
 import uuid
 from collections import abc
 from datetime import timedelta
+from typing import cast
 
 from ... import timeseries
 from ..._internal._channels import ReceiverFetcher
@@ -389,8 +390,11 @@ class BatteryPool:
         self._battery_pool._channel_registry.set_resend_latest(
             sub.get_channel_name(), True
         )
-        return self._battery_pool._channel_registry.new_receiver_fetcher(
-            sub.get_channel_name()
+        return cast(
+            ReceiverFetcher[BatteryPoolReport],
+            self._battery_pool._channel_registry.new_receiver_fetcher(
+                sub.get_channel_name()
+            ),
         )
 
     @property

--- a/src/frequenz/sdk/timeseries/ev_charger_pool/_ev_charger_pool.py
+++ b/src/frequenz/sdk/timeseries/ev_charger_pool/_ev_charger_pool.py
@@ -11,6 +11,7 @@ from asyncio import Task
 from collections import abc
 from dataclasses import dataclass
 from datetime import timedelta
+from typing import cast
 
 from frequenz.channels import Broadcast, ChannelClosedError, Receiver, Sender
 
@@ -279,7 +280,10 @@ class EVChargerPool:
                 start_time=None,
             )
             await self._resampler_subscription_sender.send(request)
-            return self._channel_registry.new_receiver(request.get_channel_name())
+            return cast(
+                Receiver[Sample[Quantity]],
+                self._channel_registry.new_receiver(request.get_channel_name()),
+            )
 
         return (
             await resampler_subscribe(ComponentMetricId.CURRENT_PHASE_1),

--- a/src/frequenz/sdk/timeseries/formula_engine/_resampled_formula_builder.py
+++ b/src/frequenz/sdk/timeseries/formula_engine/_resampled_formula_builder.py
@@ -6,7 +6,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import TYPE_CHECKING, Generic
+from typing import TYPE_CHECKING, Generic, cast
 
 from frequenz.channels import Receiver, Sender
 
@@ -72,7 +72,10 @@ class ResampledFormulaBuilder(Generic[QuantityT], FormulaBuilder[QuantityT]):
 
         request = ComponentMetricRequest(self._namespace, component_id, metric_id, None)
         self._resampler_requests.append(request)
-        return self._channel_registry.new_receiver(request.get_channel_name())
+        return cast(
+            Receiver[Sample[QuantityT]],
+            self._channel_registry.new_receiver(request.get_channel_name()),
+        )
 
     async def subscribe(self) -> None:
         """Subscribe to all resampled component metric streams."""

--- a/tests/timeseries/mock_resampler.py
+++ b/tests/timeseries/mock_resampler.py
@@ -5,6 +5,7 @@
 
 
 import asyncio
+import typing
 from datetime import datetime
 
 from frequenz.channels import Broadcast, Receiver, Sender
@@ -21,6 +22,21 @@ from frequenz.sdk.timeseries.formula_engine._formula_generators._formula_generat
 )
 
 # pylint: disable=too-many-instance-attributes
+
+
+def _cast_sample(sample: typing.Any) -> Sample[Quantity]:
+    """Cast a sample to a sample of quantities."""
+    return typing.cast(Sample[Quantity], sample)
+
+
+def _cast_sender(sender: Sender[typing.Any]) -> Sender[Sample[Quantity]]:
+    """Cast a sample to a sample of quantities."""
+    return typing.cast(Sender[Sample[Quantity]], sender)
+
+
+def _cast_receiver(receiver: Receiver[typing.Any]) -> Receiver[Sample[Quantity]]:
+    """Cast a sample to a sample of quantities."""
+    return typing.cast(Receiver[Sample[Quantity]], receiver)
 
 
 class MockResampler:
@@ -52,9 +68,10 @@ class MockResampler:
             senders: list[Sender[Sample[Quantity]]] = []
             for comp_id in comp_ids:
                 name = f"{comp_id}:{ComponentMetricId.ACTIVE_POWER}"
-                senders.append(self._channel_registry.new_sender(name))
+                senders.append(_cast_sender(self._channel_registry.new_sender(name)))
                 self._basic_receivers[name] = [
-                    self._channel_registry.new_receiver(name) for _ in range(namespaces)
+                    _cast_receiver(self._channel_registry.new_receiver(name))
+                    for _ in range(namespaces)
                 ]
             return senders
 
@@ -64,9 +81,10 @@ class MockResampler:
             senders: list[Sender[Sample[Quantity]]] = []
             for comp_id in comp_ids:
                 name = f"{comp_id}:{ComponentMetricId.FREQUENCY}"
-                senders.append(self._channel_registry.new_sender(name))
+                senders.append(_cast_sender(self._channel_registry.new_sender(name)))
                 self._basic_receivers[name] = [
-                    self._channel_registry.new_receiver(name) for _ in range(namespaces)
+                    _cast_receiver(self._channel_registry.new_receiver(name))
+                    for _ in range(namespaces)
                 ]
             return senders
 
@@ -90,21 +108,21 @@ class MockResampler:
 
                 senders.append(
                     [
-                        self._channel_registry.new_sender(p1_name),
-                        self._channel_registry.new_sender(p2_name),
-                        self._channel_registry.new_sender(p3_name),
+                        _cast_sender(self._channel_registry.new_sender(p1_name)),
+                        _cast_sender(self._channel_registry.new_sender(p2_name)),
+                        _cast_sender(self._channel_registry.new_sender(p3_name)),
                     ]
                 )
                 self._basic_receivers[p1_name] = [
-                    self._channel_registry.new_receiver(p1_name)
+                    _cast_receiver(self._channel_registry.new_receiver(p1_name))
                     for _ in range(namespaces)
                 ]
                 self._basic_receivers[p2_name] = [
-                    self._channel_registry.new_receiver(p2_name)
+                    _cast_receiver(self._channel_registry.new_receiver(p2_name))
                     for _ in range(namespaces)
                 ]
                 self._basic_receivers[p3_name] = [
-                    self._channel_registry.new_receiver(p3_name)
+                    _cast_receiver(self._channel_registry.new_receiver(p3_name))
                     for _ in range(namespaces)
                 ]
             return senders


### PR DESCRIPTION
This commit creates a new type `Unknown` to be used as the opposite of `typing.Any`, i.e. to indicate that the type is unknown and forcing the user to explicitly cast from `Unkown` to a known type.

It is intended as a quick hack to improve #806, but the problem with this approach is it is not a pleasant interface to work with, and requires a lot of casting, specially in the tests, so it will be quite some work to revert when we come up with a proper solution.
