### PR TITLE
Fix the resampler handling of output zeros

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,17 +1,9 @@
 # Frequenz Python SDK Release Notes
 
-## Summary
-
-<!-- Here goes a general summary of what this release is about -->
-
-## Upgrading
-
-<!-- Here goes notes on how to upgrade from previous versions, including deprecations and what they should be replaced with -->
-
-## New Features
-
-<!-- Here goes the main new features and examples or instructions on how to use them -->
-
 ## Bug Fixes
 
-<!-- Here goes notable bug fixes that are worth a special mention or explanation -->
+- The resampler now properly handles zero values.
+
+  A bug made the resampler interpret zero values as `None` (or NaN), producing wrong resampled averages.
+
+  In extreme cases where a long stream of zero values longer than the buffer size was sent, the resampler would just start producing `None` values.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,8 +2,6 @@
 
 ## Bug Fixes
 
-- The resampler now properly handles zero values.
+- The resampler now properly handles sending zero values.
 
-  A bug made the resampler interpret zero values as `None` (or NaN), producing wrong resampled averages.
-
-  In extreme cases where a long stream of zero values longer than the buffer size was sent, the resampler would just start producing `None` values.
+  A bug made the resampler interpret zero values as `None` when generating new samples, so if the result of the resampling is zero, the resampler would just produce `None` values.

--- a/src/frequenz/sdk/timeseries/_resampling.py
+++ b/src/frequenz/sdk/timeseries/_resampling.py
@@ -744,7 +744,7 @@ class _ResamplingHelper:
             if relevant_samples
             else None
         )
-        return Sample(timestamp, None if not value else Quantity(value))
+        return Sample(timestamp, None if value is None else Quantity(value))
 
 
 class _StreamingHelper:

--- a/tests/timeseries/test_resampling.py
+++ b/tests/timeseries/test_resampling.py
@@ -617,7 +617,7 @@ async def test_resampling_with_one_window(
     #
     # t(s)   0          1          2   2.5    3          4
     #        |----------|----------R----|-----|----------R-----> (no more samples)
-    # value  5.0       12.0            2.0   4.0        5.0
+    # value  5.0       12.0            0.0   4.0        5.0
     #
     # R = resampling is done
 
@@ -647,7 +647,7 @@ async def test_resampling_with_one_window(
     resampling_fun_mock.reset_mock()
 
     # Second resampling run
-    sample2_5s = Sample(timestamp + timedelta(seconds=2.5), value=Quantity(2.0))
+    sample2_5s = Sample(timestamp + timedelta(seconds=2.5), value=Quantity.zero())
     sample3s = Sample(timestamp + timedelta(seconds=3), value=Quantity(4.0))
     sample4s = Sample(timestamp + timedelta(seconds=4), value=Quantity(5.0))
     await source_sender.send(sample2_5s)
@@ -1242,8 +1242,8 @@ async def test_resampling_all_zeros(
     # R = resampling is done
 
     # Send a few samples and run a resample tick, advancing the fake time by one period
-    sample0s = Sample(timestamp, value=Quantity(0.0))
-    sample1s = Sample(timestamp + timedelta(seconds=1), value=Quantity(0.0))
+    sample0s = Sample(timestamp, value=Quantity.zero())
+    sample1s = Sample(timestamp + timedelta(seconds=1), value=Quantity.zero())
     await source_sender.send(sample0s)
     await source_sender.send(sample1s)
     await _advance_time(fake_time, resampling_period_s)
@@ -1267,9 +1267,9 @@ async def test_resampling_all_zeros(
     resampling_fun_mock.reset_mock()
 
     # Second resampling run
-    sample2_5s = Sample(timestamp + timedelta(seconds=2.5), value=Quantity(0.0))
-    sample3s = Sample(timestamp + timedelta(seconds=3), value=Quantity(0.0))
-    sample4s = Sample(timestamp + timedelta(seconds=4), value=Quantity(0.0))
+    sample2_5s = Sample(timestamp + timedelta(seconds=2.5), value=Quantity.zero())
+    sample3s = Sample(timestamp + timedelta(seconds=3), value=Quantity.zero())
+    sample4s = Sample(timestamp + timedelta(seconds=4), value=Quantity.zero())
     await source_sender.send(sample2_5s)
     await source_sender.send(sample3s)
     await source_sender.send(sample4s)


### PR DESCRIPTION
A bug made the resampler interpret output zero values as `None`, producing wrong resampled values when the result of the resampling function is zero.

Fixes #810.