### PR TITLE
WIP: Make `ChannelRegistry` generic

### DIFF
--- a/src/frequenz/sdk/actor/_data_sourcing/data_sourcing.py
+++ b/src/frequenz/sdk/actor/_data_sourcing/data_sourcing.py
@@ -5,6 +5,8 @@
 
 from frequenz.channels import Receiver
 
+from ...timeseries._base_types import Sample
+from ...timeseries._quantities import Quantity
 from .._actor import Actor
 from .._channel_registry import ChannelRegistry
 from ._component_metric_request import ComponentMetricRequest
@@ -17,7 +19,7 @@ class DataSourcingActor(Actor):
     def __init__(
         self,
         request_receiver: Receiver[ComponentMetricRequest],
-        registry: ChannelRegistry,
+        registry: ChannelRegistry[Sample[Quantity]],
         *,
         name: str | None = None,
     ) -> None:

--- a/src/frequenz/sdk/actor/_data_sourcing/microgrid_api_source.py
+++ b/src/frequenz/sdk/actor/_data_sourcing/microgrid_api_source.py
@@ -97,7 +97,7 @@ class MicrogridApiSource:
 
     def __init__(
         self,
-        registry: ChannelRegistry,
+        registry: ChannelRegistry[Sample[Quantity]],
     ) -> None:
         """Create a `MicrogridApiSource` instance.
 
@@ -113,7 +113,7 @@ class MicrogridApiSource:
         self.comp_data_tasks: dict[int, asyncio.Task[None]] = {}
         """The dictionary of component IDs to asyncio tasks."""
 
-        self._registry = registry
+        self._registry: ChannelRegistry[Sample[Quantity]] = registry
         self._req_streaming_metrics: dict[
             int, dict[ComponentMetricId, list[ComponentMetricRequest]]
         ] = {}

--- a/src/frequenz/sdk/actor/_power_managing/_power_managing_actor.py
+++ b/src/frequenz/sdk/actor/_power_managing/_power_managing_actor.py
@@ -17,7 +17,14 @@ from typing_extensions import override
 from ...timeseries._base_types import PoolType, SystemBounds
 from .._actor import Actor
 from .._channel_registry import ChannelRegistry
-from ._base_classes import Algorithm, BaseAlgorithm, Proposal, ReportRequest, _Report
+from ._base_classes import (
+    Algorithm,
+    BaseAlgorithm,
+    Proposal,
+    Report,
+    ReportRequest,
+    _Report,
+)
 from ._matryoshka import Matryoshka
 
 _logger = logging.getLogger(__name__)
@@ -36,7 +43,7 @@ class PowerManagingActor(Actor):
         bounds_subscription_receiver: Receiver[ReportRequest],
         power_distributing_requests_sender: Sender[power_distributing.Request],
         power_distributing_results_receiver: Receiver[power_distributing.Result],
-        channel_registry: ChannelRegistry,
+        channel_registry: ChannelRegistry[Report],
         # arguments to actors need to serializable, so we pass an enum for the algorithm
         # instead of an instance of the algorithm.
         algorithm: Algorithm = Algorithm.MATRYOSHKA,

--- a/src/frequenz/sdk/actor/_resampling.py
+++ b/src/frequenz/sdk/actor/_resampling.py
@@ -27,7 +27,7 @@ class ComponentMetricsResamplingActor(Actor):
     def __init__(  # pylint: disable=too-many-arguments
         self,
         *,
-        channel_registry: ChannelRegistry,
+        channel_registry: ChannelRegistry[Sample[Quantity]],
         data_sourcing_request_sender: Sender[ComponentMetricRequest],
         resampling_request_receiver: Receiver[ComponentMetricRequest],
         config: ResamplerConfig,
@@ -48,7 +48,7 @@ class ComponentMetricsResamplingActor(Actor):
                 is used mostly for debugging purposes.
         """
         super().__init__(name=name)
-        self._channel_registry: ChannelRegistry = channel_registry
+        self._channel_registry: ChannelRegistry[Sample[Quantity]] = channel_registry
         self._data_sourcing_request_sender: Sender[
             ComponentMetricRequest
         ] = data_sourcing_request_sender

--- a/src/frequenz/sdk/microgrid/_data_pipeline.py
+++ b/src/frequenz/sdk/microgrid/_data_pipeline.py
@@ -87,9 +87,11 @@ class _DataPipeline:  # pylint: disable=too-many-instance-attributes
         """
         from ..actor import ChannelRegistry
 
-        self._resampler_config = resampler_config
+        self._resampler_config: ResamplerConfig = resampler_config
 
-        self._channel_registry = ChannelRegistry(name="Data Pipeline Registry")
+        self._channel_registry: ChannelRegistry = ChannelRegistry(
+            name="Data Pipeline Registry"
+        )
 
         self._data_sourcing_actor: _ActorInfo | None = None
         self._resampling_actor: _ActorInfo | None = None

--- a/src/frequenz/sdk/microgrid/_data_pipeline.py
+++ b/src/frequenz/sdk/microgrid/_data_pipeline.py
@@ -21,6 +21,9 @@ from frequenz.channels import Broadcast, Sender
 from ..actor._actor import Actor
 from ..timeseries._base_types import PoolType
 from ..timeseries._grid_frequency import GridFrequency
+from ..timeseries.formula_engine._formula_engine_pool import (
+    QuantitySampleChannelRegistry,
+)
 from ..timeseries.grid import Grid
 from ..timeseries.grid import get as get_grid
 from ..timeseries.grid import initialize as initialize_grid
@@ -89,8 +92,8 @@ class _DataPipeline:  # pylint: disable=too-many-instance-attributes
 
         self._resampler_config: ResamplerConfig = resampler_config
 
-        self._channel_registry: ChannelRegistry = ChannelRegistry(
-            name="Data Pipeline Registry"
+        self._channel_registry: QuantitySampleChannelRegistry = (
+            QuantitySampleChannelRegistry(name="Data Pipeline Registry")
         )
 
         self._data_sourcing_actor: _ActorInfo | None = None
@@ -131,7 +134,7 @@ class _DataPipeline:  # pylint: disable=too-many-instance-attributes
         if self._frequency_instance is None:
             self._frequency_instance = GridFrequency(
                 self._data_sourcing_request_sender(),
-                self._channel_registry,
+                self._channel_registry.quantity,
             )
 
         return self._frequency_instance

--- a/src/frequenz/sdk/timeseries/_grid_frequency.py
+++ b/src/frequenz/sdk/timeseries/_grid_frequency.py
@@ -15,7 +15,7 @@ from ..actor import ChannelRegistry
 from ..microgrid import connection_manager
 from ..microgrid.component import Component, ComponentCategory, ComponentMetricId
 from ..timeseries._base_types import Sample
-from ..timeseries._quantities import Frequency
+from ..timeseries._quantities import Frequency, Quantity
 
 if TYPE_CHECKING:
     # Imported here to avoid a circular import.
@@ -48,7 +48,7 @@ class GridFrequency:
     def __init__(
         self,
         data_sourcing_request_sender: Sender[ComponentMetricRequest],
-        channel_registry: ChannelRegistry,
+        channel_registry: ChannelRegistry[Sample[Quantity]],
         source: Component | None = None,
     ):
         """Initialize the grid frequency formula generator.
@@ -61,7 +61,7 @@ class GridFrequency:
         self._request_sender: Sender[
             ComponentMetricRequest
         ] = data_sourcing_request_sender
-        self._channel_registry: ChannelRegistry = channel_registry
+        self._channel_registry: ChannelRegistry[Sample[Quantity]] = channel_registry
         self._source_component: Component = source or self.find_frequency_source()
         self._component_metric_request: ComponentMetricRequest = create_request(
             self._source_component.component_id

--- a/src/frequenz/sdk/timeseries/_grid_frequency.py
+++ b/src/frequenz/sdk/timeseries/_grid_frequency.py
@@ -58,10 +58,12 @@ class GridFrequency:
             channel_registry: The channel registry to use for the grid frequency.
             source: The source component to use to receive the grid frequency.
         """
-        self._request_sender = data_sourcing_request_sender
-        self._channel_registry = channel_registry
-        self._source_component = source or GridFrequency.find_frequency_source()
-        self._component_metric_request = create_request(
+        self._request_sender: Sender[
+            ComponentMetricRequest
+        ] = data_sourcing_request_sender
+        self._channel_registry: ChannelRegistry = channel_registry
+        self._source_component: Component = source or self.find_frequency_source()
+        self._component_metric_request: ComponentMetricRequest = create_request(
             self._source_component.component_id
         )
 

--- a/src/frequenz/sdk/timeseries/battery_pool/_battery_pool.py
+++ b/src/frequenz/sdk/timeseries/battery_pool/_battery_pool.py
@@ -39,7 +39,7 @@ from ._result_types import BatteryPoolReport
 class BatteryPool:
     """An interface for interaction with pools of batteries.
 
-    !!! note
+    Note:
         `BatteryPool` instances are not meant to be created directly by users.  Use the
         [`microgrid.battery_pool`][frequenz.sdk.microgrid.battery_pool] method for
         creating `BatteryPool` instances.
@@ -65,7 +65,7 @@ class BatteryPool:
     ):
         """Create a BatteryPool instance.
 
-        !!! note
+        Note:
             `BatteryPool` instances are not meant to be created directly by users.  Use
             the [`microgrid.battery_pool`][frequenz.sdk.microgrid.battery_pool] method
             for creating `BatteryPool` instances.

--- a/src/frequenz/sdk/timeseries/battery_pool/_battery_pool_reference_store.py
+++ b/src/frequenz/sdk/timeseries/battery_pool/_battery_pool_reference_store.py
@@ -13,11 +13,14 @@ from typing import Any
 from frequenz.channels import Receiver, Sender
 
 from ..._internal._asyncio import cancel_and_await
-from ...actor import ComponentMetricRequest, _channel_registry, _power_managing
+from ...actor import ComponentMetricRequest, _power_managing
 from ...actor.power_distributing._component_status import ComponentPoolStatus
 from ...microgrid import connection_manager
 from ...microgrid.component import ComponentCategory
-from ..formula_engine._formula_engine_pool import FormulaEnginePool
+from ..formula_engine._formula_engine_pool import (
+    FormulaEnginePool,
+    QuantitySampleChannelRegistry,
+)
 from ._methods import MetricAggregator
 
 
@@ -36,7 +39,7 @@ class BatteryPoolReferenceStore:  # pylint: disable=too-many-instance-attributes
 
     def __init__(  # pylint: disable=too-many-arguments
         self,
-        channel_registry: _channel_registry.ChannelRegistry,
+        channel_registry: QuantitySampleChannelRegistry,
         resampler_subscription_sender: Sender[ComponentMetricRequest],
         batteries_status_receiver: Receiver[ComponentPoolStatus],
         power_manager_requests_sender: Sender[_power_managing.Proposal],
@@ -102,7 +105,7 @@ class BatteryPoolReferenceStore:  # pylint: disable=too-many-instance-attributes
         self._power_bounds_subs: dict[str, asyncio.Task[None]] = {}
         self._namespace: str = f"battery-pool-{self._batteries}-{uuid.uuid4()}"
         self._power_distributing_namespace: str = f"power-distributor-{self._namespace}"
-        self._channel_registry: ChannelRegistry = channel_registry
+        self._channel_registry: QuantitySampleChannelRegistry = channel_registry
         self._formula_pool: FormulaEnginePool = FormulaEnginePool(
             self._namespace,
             self._channel_registry,

--- a/src/frequenz/sdk/timeseries/battery_pool/_battery_pool_reference_store.py
+++ b/src/frequenz/sdk/timeseries/battery_pool/_battery_pool_reference_store.py
@@ -74,8 +74,9 @@ class BatteryPoolReferenceStore:  # pylint: disable=too-many-instance-attributes
                 battery pool. If None or empty, then all batteries from the microgrid
                 will be used.
         """
+        self._batteries: frozenset[int]
         if batteries_id:
-            self._batteries: frozenset[int] = frozenset(batteries_id)
+            self._batteries = frozenset(batteries_id)
         else:
             self._batteries = self._get_all_batteries()
 
@@ -87,18 +88,21 @@ class BatteryPoolReferenceStore:  # pylint: disable=too-many-instance-attributes
                 self._update_battery_status(batteries_status_receiver)
             )
 
-        self._min_update_interval = min_update_interval
+        self._min_update_interval: timedelta = min_update_interval
 
-        self._power_manager_requests_sender = power_manager_requests_sender
-        self._power_manager_bounds_subscription_sender = (
-            power_manager_bounds_subscription_sender
-        )
+        self._power_manager_requests_sender: Sender[
+            _power_managing.Proposal
+        ] = power_manager_requests_sender
+
+        self._power_manager_bounds_subscription_sender: Sender[
+            _power_managing.ReportRequest
+        ] = power_manager_bounds_subscription_sender
 
         self._active_methods: dict[str, MetricAggregator[Any]] = {}
         self._power_bounds_subs: dict[str, asyncio.Task[None]] = {}
         self._namespace: str = f"battery-pool-{self._batteries}-{uuid.uuid4()}"
         self._power_distributing_namespace: str = f"power-distributor-{self._namespace}"
-        self._channel_registry = channel_registry
+        self._channel_registry: ChannelRegistry = channel_registry
         self._formula_pool: FormulaEnginePool = FormulaEnginePool(
             self._namespace,
             self._channel_registry,

--- a/src/frequenz/sdk/timeseries/ev_charger_pool/_ev_charger_pool.py
+++ b/src/frequenz/sdk/timeseries/ev_charger_pool/_ev_charger_pool.py
@@ -99,7 +99,7 @@ class EVChargerPool:
                 microgrid API, if no new calls to `set_bounds` have been made.
         """
         self._channel_registry: ChannelRegistry = channel_registry
-        self._repeat_interval = repeat_interval
+        self._repeat_interval: timedelta = repeat_interval
         self._resampler_subscription_sender: Sender[
             ComponentMetricRequest
         ] = resampler_subscription_sender

--- a/src/frequenz/sdk/timeseries/formula_engine/_formula_engine_pool.py
+++ b/src/frequenz/sdk/timeseries/formula_engine/_formula_engine_pool.py
@@ -44,9 +44,11 @@ class FormulaEnginePool:
             resampler_subscription_sender: A sender for sending metric requests to the
                 resampling actor.
         """
-        self._namespace = namespace
-        self._channel_registry = channel_registry
-        self._resampler_subscription_sender = resampler_subscription_sender
+        self._namespace: str = namespace
+        self._channel_registry: ChannelRegistry = channel_registry
+        self._resampler_subscription_sender: Sender[
+            ComponentMetricRequest
+        ] = resampler_subscription_sender
         self._string_engines: dict[str, FormulaEngine[Quantity]] = {}
         self._power_engines: dict[str, FormulaEngine[Power]] = {}
         self._current_engines: dict[str, FormulaEngine3Phase[Current]] = {}

--- a/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_formula_generator.py
+++ b/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_formula_generator.py
@@ -16,6 +16,7 @@ from frequenz.channels import Sender
 
 from ....microgrid import component, connection_manager
 from ....microgrid.component import ComponentMetricId
+from ..._base_types import Sample
 from ..._quantities import QuantityT
 from .._formula_engine import FormulaEngine, FormulaEngine3Phase
 from .._resampled_formula_builder import ResampledFormulaBuilder
@@ -58,7 +59,7 @@ class FormulaGenerator(ABC, Generic[QuantityT]):
     def __init__(
         self,
         namespace: str,
-        channel_registry: ChannelRegistry,
+        channel_registry: ChannelRegistry[Sample[QuantityT]],
         resampler_subscription_sender: Sender[ComponentMetricRequest],
         config: FormulaGeneratorConfig,
     ) -> None:
@@ -72,7 +73,7 @@ class FormulaGenerator(ABC, Generic[QuantityT]):
                 resampling actor.
             config: configs for the formula generator.
         """
-        self._channel_registry: ChannelRegistry = channel_registry
+        self._channel_registry: ChannelRegistry[Sample[QuantityT]] = channel_registry
         self._resampler_subscription_sender: Sender[
             ComponentMetricRequest
         ] = resampler_subscription_sender

--- a/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_formula_generator.py
+++ b/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_formula_generator.py
@@ -72,10 +72,12 @@ class FormulaGenerator(ABC, Generic[QuantityT]):
                 resampling actor.
             config: configs for the formula generator.
         """
-        self._channel_registry = channel_registry
-        self._resampler_subscription_sender = resampler_subscription_sender
-        self._namespace = namespace
-        self._config = config
+        self._channel_registry: ChannelRegistry = channel_registry
+        self._resampler_subscription_sender: Sender[
+            ComponentMetricRequest
+        ] = resampler_subscription_sender
+        self._namespace: str = namespace
+        self._config: FormulaGeneratorConfig = config
 
     def _get_builder(
         self,

--- a/src/frequenz/sdk/timeseries/formula_engine/_resampled_formula_builder.py
+++ b/src/frequenz/sdk/timeseries/formula_engine/_resampled_formula_builder.py
@@ -48,10 +48,12 @@ class ResampledFormulaBuilder(Generic[QuantityT], FormulaBuilder[QuantityT]):
                 formula is for generating power values, this would be
                 `Power.from_watts`, for example.
         """
-        self._channel_registry = channel_registry
-        self._resampler_subscription_sender = resampler_subscription_sender
-        self._namespace = namespace
-        self._metric_id = metric_id
+        self._channel_registry: ChannelRegistry = channel_registry
+        self._resampler_subscription_sender: Sender[
+            ComponentMetricRequest
+        ] = resampler_subscription_sender
+        self._namespace: str = namespace
+        self._metric_id: ComponentMetricId = metric_id
         self._resampler_requests: list[ComponentMetricRequest] = []
         super().__init__(formula_name, create_method)  # type: ignore[arg-type]
 

--- a/src/frequenz/sdk/timeseries/formula_engine/_resampled_formula_builder.py
+++ b/src/frequenz/sdk/timeseries/formula_engine/_resampled_formula_builder.py
@@ -28,7 +28,7 @@ class ResampledFormulaBuilder(Generic[QuantityT], FormulaBuilder[QuantityT]):
         self,
         namespace: str,
         formula_name: str,
-        channel_registry: ChannelRegistry,
+        channel_registry: ChannelRegistry[Sample[QuantityT]],
         resampler_subscription_sender: Sender[ComponentMetricRequest],
         metric_id: ComponentMetricId,
         create_method: Callable[[float], QuantityT],
@@ -48,7 +48,7 @@ class ResampledFormulaBuilder(Generic[QuantityT], FormulaBuilder[QuantityT]):
                 formula is for generating power values, this would be
                 `Power.from_watts`, for example.
         """
-        self._channel_registry: ChannelRegistry = channel_registry
+        self._channel_registry: ChannelRegistry[Sample[QuantityT]] = channel_registry
         self._resampler_subscription_sender: Sender[
             ComponentMetricRequest
         ] = resampler_subscription_sender

--- a/src/frequenz/sdk/timeseries/grid.py
+++ b/src/frequenz/sdk/timeseries/grid.py
@@ -20,7 +20,10 @@ from ..microgrid.component._component import ComponentCategory
 from . import Fuse
 from ._quantities import Current, Power
 from .formula_engine import FormulaEngine, FormulaEngine3Phase
-from .formula_engine._formula_engine_pool import FormulaEnginePool
+from .formula_engine._formula_engine_pool import (
+    FormulaEnginePool,
+    QuantitySampleChannelRegistry,
+)
 from .formula_engine._formula_generators import GridCurrentFormula, GridPowerFormula
 
 if TYPE_CHECKING:
@@ -126,7 +129,7 @@ _GRID: Grid | None = None
 
 
 def initialize(
-    channel_registry: ChannelRegistry,
+    channel_registry: QuantitySampleChannelRegistry,
     resampler_subscription_sender: Sender[ComponentMetricRequest],
 ) -> None:
     """Initialize the grid connection.

--- a/src/frequenz/sdk/timeseries/logical_meter/_logical_meter.py
+++ b/src/frequenz/sdk/timeseries/logical_meter/_logical_meter.py
@@ -85,8 +85,10 @@ class LogicalMeter:
             resampler_subscription_sender: A sender for sending metric requests to the
                 resampling actor.
         """
-        self._channel_registry = channel_registry
-        self._resampler_subscription_sender = resampler_subscription_sender
+        self._channel_registry: ChannelRegistry = channel_registry
+        self._resampler_subscription_sender: Sender[
+            ComponentMetricRequest
+        ] = resampler_subscription_sender
 
         # Use a randomly generated uuid to create a unique namespace name for the local
         # meter to use when communicating with the resampling actor.

--- a/src/frequenz/sdk/timeseries/logical_meter/_logical_meter.py
+++ b/src/frequenz/sdk/timeseries/logical_meter/_logical_meter.py
@@ -12,7 +12,10 @@ from ...actor import ChannelRegistry, ComponentMetricRequest
 from ...microgrid.component import ComponentMetricId
 from .._quantities import Power, Quantity
 from ..formula_engine import FormulaEngine
-from ..formula_engine._formula_engine_pool import FormulaEnginePool
+from ..formula_engine._formula_engine_pool import (
+    FormulaEnginePool,
+    QuantitySampleChannelRegistry,
+)
 from ..formula_engine._formula_generators import (
     CHPPowerFormula,
     ConsumerPowerFormula,
@@ -69,7 +72,7 @@ class LogicalMeter:
 
     def __init__(
         self,
-        channel_registry: ChannelRegistry,
+        channel_registry: QuantitySampleChannelRegistry,
         resampler_subscription_sender: Sender[ComponentMetricRequest],
     ) -> None:
         """Create a `LogicalMeter` instance.
@@ -85,7 +88,7 @@ class LogicalMeter:
             resampler_subscription_sender: A sender for sending metric requests to the
                 resampling actor.
         """
-        self._channel_registry: ChannelRegistry = channel_registry
+        self._channel_registry: QuantitySampleChannelRegistry = channel_registry
         self._resampler_subscription_sender: Sender[
             ComponentMetricRequest
         ] = resampler_subscription_sender


### PR DESCRIPTION
Make `ChannelRegistry` generic

Try to find out the exact type needed for some particular channel registries, but sometimes the same `ChannelRegistry` is shared by multiple types. In one case a custom channel "meta" registry could be created, `QuantitySampleChannelRegistry`, but then the data pipeline mix all other types of channels for power distribution.

It is intended as a solution for #806, but it seems like the real solution is to have a truly global meta channel registry, which can create registries for new types dynamically.
