### PR TITLE
Improve (and fix some) test finalization

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -155,8 +155,10 @@ disable = [
   "unsubscriptable-object",
   # Checked by flake8
   "line-too-long",
-  "unused-variable",
+  "redefined-outer-name",
   "unnecessary-lambda-assignment",
+  "unused-import",
+  "unused-variable",
 ]
 
 [tool.pylint.design]

--- a/tests/actor/power_distributing/test_power_distributing.py
+++ b/tests/actor/power_distributing/test_power_distributing.py
@@ -10,8 +10,9 @@ import dataclasses
 import math
 import re
 from collections import abc
+from contextlib import asynccontextmanager
 from datetime import timedelta
-from typing import TypeVar
+from typing import AsyncIterator, TypeVar
 from unittest.mock import MagicMock
 
 from frequenz.channels import Broadcast, Sender
@@ -112,6 +113,21 @@ class _Mocks:
             ]
         )
         # pylint: enable=protected-access
+
+
+@asynccontextmanager
+async def _mocks(
+    mocker: MockerFixture,
+    *,
+    graph: _MicrogridComponentGraph | None = None,
+    grid_meter: bool | None = None,
+) -> AsyncIterator[_Mocks]:
+    """Initialize the mocks."""
+    mocks = await _Mocks.new(mocker, graph=graph, grid_meter=grid_meter)
+    try:
+        yield mocks
+    finally:
+        await mocks.stop()
 
 
 class TestPowerDistributingActor:
@@ -283,92 +299,89 @@ class TestPowerDistributingActor:
         self, mocker: MockerFixture
     ) -> None:
         """Test if power distributing actor rejects non-zero requests in exclusion bounds."""
-        mocks = await _Mocks.new(mocker)
+        async with _mocks(mocker) as mocks:
+            await self._patch_battery_pool_status(mocks, mocker, {9, 19})
+            await self.init_component_data(mocks, skip_batteries={9, 19})
 
-        await self._patch_battery_pool_status(mocks, mocker, {9, 19})
-        await self.init_component_data(mocks, skip_batteries={9, 19})
-
-        mocks.streamer.start_streaming(
-            battery_msg(
-                9,
-                soc=Metric(60, Bound(20, 80)),
-                capacity=Metric(98000),
-                power=PowerBounds(-1000, -300, 300, 1000),
-            ),
-            0.05,
-        )
-
-        mocks.streamer.start_streaming(
-            battery_msg(
-                19,
-                soc=Metric(60, Bound(20, 80)),
-                capacity=Metric(98000),
-                power=PowerBounds(-1000, -300, 300, 1000),
-            ),
-            0.05,
-        )
-
-        requests_channel = Broadcast[Request]("power_distributor requests")
-        results_channel = Broadcast[Result]("power_distributor results")
-
-        battery_status_channel = Broadcast[ComponentPoolStatus]("battery_status")
-        async with PowerDistributingActor(
-            requests_receiver=requests_channel.new_receiver(),
-            results_sender=results_channel.new_sender(),
-            component_pool_status_sender=battery_status_channel.new_sender(),
-            wait_for_data_sec=0.1,
-        ):
-            # zero power requests should pass through despite the exclusion bounds.
-            request = Request(
-                power=Power.zero(),
-                component_ids={9, 19},
-                request_timeout=SAFETY_TIMEOUT,
+            mocks.streamer.start_streaming(
+                battery_msg(
+                    9,
+                    soc=Metric(60, Bound(20, 80)),
+                    capacity=Metric(98000),
+                    power=PowerBounds(-1000, -300, 300, 1000),
+                ),
+                0.05,
             )
 
-            await requests_channel.new_sender().send(request)
-            result_rx = results_channel.new_receiver()
-
-            done, pending = await asyncio.wait(
-                [asyncio.create_task(result_rx.receive())],
-                timeout=SAFETY_TIMEOUT.total_seconds(),
+            mocks.streamer.start_streaming(
+                battery_msg(
+                    19,
+                    soc=Metric(60, Bound(20, 80)),
+                    capacity=Metric(98000),
+                    power=PowerBounds(-1000, -300, 300, 1000),
+                ),
+                0.05,
             )
 
-            assert len(pending) == 0
-            assert len(done) == 1
+            requests_channel = Broadcast[Request]("power_distributor requests")
+            results_channel = Broadcast[Result]("power_distributor results")
 
-            result: Result = done.pop().result()
-            assert isinstance(result, Success)
-            assert result.succeeded_power.isclose(Power.zero(), abs_tol=1e-9)
-            assert result.excess_power.isclose(Power.zero(), abs_tol=1e-9)
-            assert result.request == request
+            battery_status_channel = Broadcast[ComponentPoolStatus]("battery_status")
+            async with PowerDistributingActor(
+                requests_receiver=requests_channel.new_receiver(),
+                results_sender=results_channel.new_sender(),
+                component_pool_status_sender=battery_status_channel.new_sender(),
+                wait_for_data_sec=0.1,
+            ):
+                # zero power requests should pass through despite the exclusion bounds.
+                request = Request(
+                    power=Power.zero(),
+                    component_ids={9, 19},
+                    request_timeout=SAFETY_TIMEOUT,
+                )
 
-            # non-zero power requests that fall within the exclusion bounds should be
-            # rejected.
-            request = Request(
-                power=Power.from_watts(300.0),
-                component_ids={9, 19},
-                request_timeout=SAFETY_TIMEOUT,
-            )
+                await requests_channel.new_sender().send(request)
+                result_rx = results_channel.new_receiver()
 
-            await requests_channel.new_sender().send(request)
-            result_rx = results_channel.new_receiver()
+                done, pending = await asyncio.wait(
+                    [asyncio.create_task(result_rx.receive())],
+                    timeout=SAFETY_TIMEOUT.total_seconds(),
+                )
 
-            done, pending = await asyncio.wait(
-                [asyncio.create_task(result_rx.receive())],
-                timeout=SAFETY_TIMEOUT.total_seconds(),
-            )
+                assert len(pending) == 0
+                assert len(done) == 1
 
-            assert len(pending) == 0
-            assert len(done) == 1
+                result: Result = done.pop().result()
+                assert isinstance(result, Success)
+                assert result.succeeded_power.isclose(Power.zero(), abs_tol=1e-9)
+                assert result.excess_power.isclose(Power.zero(), abs_tol=1e-9)
+                assert result.request == request
 
-            result = done.pop().result()
-            assert isinstance(
-                result, OutOfBounds
-            ), f"Expected OutOfBounds, got {result}"
-            assert result.bounds == PowerBounds(-1000, -600, 600, 1000)
-            assert result.request == request
+                # non-zero power requests that fall within the exclusion bounds should be
+                # rejected.
+                request = Request(
+                    power=Power.from_watts(300.0),
+                    component_ids={9, 19},
+                    request_timeout=SAFETY_TIMEOUT,
+                )
 
-        await mocks.stop()
+                await requests_channel.new_sender().send(request)
+                result_rx = results_channel.new_receiver()
+
+                done, pending = await asyncio.wait(
+                    [asyncio.create_task(result_rx.receive())],
+                    timeout=SAFETY_TIMEOUT.total_seconds(),
+                )
+
+                assert len(pending) == 0
+                assert len(done) == 1
+
+                result = done.pop().result()
+                assert isinstance(
+                    result, OutOfBounds
+                ), f"Expected OutOfBounds, got {result}"
+                assert result.bounds == PowerBounds(-1000, -600, 600, 1000)
+                assert result.request == request
 
     # pylint: disable=too-many-locals
     async def test_two_batteries_one_inverters(self, mocker: MockerFixture) -> None:
@@ -395,46 +408,47 @@ class TestPowerDistributingActor:
             )
         )
 
-        mocks = await _Mocks.new(mocker, graph=graph)
-        await self.init_component_data(mocks)
+        async with _mocks(mocker, graph=graph) as mocks:
+            await self.init_component_data(mocks)
 
-        requests_channel = Broadcast[Request]("power_distributor requests")
-        results_channel = Broadcast[Result]("power_distributor results")
-        request = Request(
-            power=Power.from_watts(1200.0),
-            component_ids={bat_component1.component_id, bat_component2.component_id},
-            request_timeout=SAFETY_TIMEOUT,
-        )
-
-        await self._patch_battery_pool_status(mocks, mocker, request.component_ids)
-
-        battery_status_channel = Broadcast[ComponentPoolStatus]("battery_status")
-
-        async with PowerDistributingActor(
-            requests_receiver=requests_channel.new_receiver(),
-            component_pool_status_sender=battery_status_channel.new_sender(),
-            results_sender=results_channel.new_sender(),
-            wait_for_data_sec=0.1,
-        ):
-            await requests_channel.new_sender().send(request)
-            result_rx = results_channel.new_receiver()
-
-            done, pending = await asyncio.wait(
-                [asyncio.create_task(result_rx.receive())],
-                timeout=SAFETY_TIMEOUT.total_seconds(),
+            requests_channel = Broadcast[Request]("power_distributor requests")
+            results_channel = Broadcast[Result]("power_distributor results")
+            request = Request(
+                power=Power.from_watts(1200.0),
+                component_ids={
+                    bat_component1.component_id,
+                    bat_component2.component_id,
+                },
+                request_timeout=SAFETY_TIMEOUT,
             )
 
-            assert len(pending) == 0
-            assert len(done) == 1
+            await self._patch_battery_pool_status(mocks, mocker, request.component_ids)
 
-            result: Result = done.pop().result()
-            assert isinstance(result, Success)
-            # Inverter bounded at 500
-            assert result.succeeded_power.isclose(Power.from_watts(500.0))
-            assert result.excess_power.isclose(Power.from_watts(700.0))
-            assert result.request == request
+            battery_status_channel = Broadcast[ComponentPoolStatus]("battery_status")
 
-        await mocks.stop()
+            async with PowerDistributingActor(
+                requests_receiver=requests_channel.new_receiver(),
+                component_pool_status_sender=battery_status_channel.new_sender(),
+                results_sender=results_channel.new_sender(),
+                wait_for_data_sec=0.1,
+            ):
+                await requests_channel.new_sender().send(request)
+                result_rx = results_channel.new_receiver()
+
+                done, pending = await asyncio.wait(
+                    [asyncio.create_task(result_rx.receive())],
+                    timeout=SAFETY_TIMEOUT.total_seconds(),
+                )
+
+                assert len(pending) == 0
+                assert len(done) == 1
+
+                result: Result = done.pop().result()
+                assert isinstance(result, Success)
+                # Inverter bounded at 500
+                assert result.succeeded_power.isclose(Power.from_watts(500.0))
+                assert result.excess_power.isclose(Power.from_watts(700.0))
+                assert result.request == request
 
     async def test_two_batteries_one_broken_one_inverters(
         self, mocker: MockerFixture
@@ -461,59 +475,58 @@ class TestPowerDistributingActor:
             )
         )
 
-        mocks = await _Mocks.new(mocker, graph=graph)
-        await self.init_component_data(
-            mocks, skip_batteries={bat_components[0].component_id}
-        )
-
-        mocks.streamer.start_streaming(
-            battery_msg(
-                bat_components[0].component_id,
-                soc=Metric(math.nan, Bound(20, 80)),
-                capacity=Metric(98000),
-                power=PowerBounds(-1000, 0, 0, 1000),
-            ),
-            0.05,
-        )
-
-        requests_channel = Broadcast[Request]("power_distributor")
-        results_channel = Broadcast[Result]("power_distributor results")
-
-        request = Request(
-            power=Power.from_watts(1200.0),
-            component_ids=set(battery.component_id for battery in bat_components),
-            request_timeout=SAFETY_TIMEOUT,
-        )
-
-        await self._patch_battery_pool_status(mocks, mocker, request.component_ids)
-        battery_status_channel = Broadcast[ComponentPoolStatus]("battery_status")
-
-        async with PowerDistributingActor(
-            requests_receiver=requests_channel.new_receiver(),
-            component_pool_status_sender=battery_status_channel.new_sender(),
-            results_sender=results_channel.new_sender(),
-            wait_for_data_sec=0.1,
-        ):
-            await requests_channel.new_sender().send(request)
-            result_rx = results_channel.new_receiver()
-
-            done, pending = await asyncio.wait(
-                [asyncio.create_task(result_rx.receive())],
-                timeout=SAFETY_TIMEOUT.total_seconds(),
+        async with _mocks(mocker, graph=graph) as mocks:
+            await self.init_component_data(
+                mocks, skip_batteries={bat_components[0].component_id}
             )
 
-            assert len(pending) == 0
-            assert len(done) == 1
-
-            result: Result = done.pop().result()
-
-            assert isinstance(result, Error)
-            assert result.request == request
-            assert (
-                result.msg == "No data for at least one of the given batteries {9, 19}"
+            mocks.streamer.start_streaming(
+                battery_msg(
+                    bat_components[0].component_id,
+                    soc=Metric(math.nan, Bound(20, 80)),
+                    capacity=Metric(98000),
+                    power=PowerBounds(-1000, 0, 0, 1000),
+                ),
+                0.05,
             )
 
-        await mocks.stop()
+            requests_channel = Broadcast[Request]("power_distributor")
+            results_channel = Broadcast[Result]("power_distributor results")
+
+            request = Request(
+                power=Power.from_watts(1200.0),
+                component_ids=set(battery.component_id for battery in bat_components),
+                request_timeout=SAFETY_TIMEOUT,
+            )
+
+            await self._patch_battery_pool_status(mocks, mocker, request.component_ids)
+            battery_status_channel = Broadcast[ComponentPoolStatus]("battery_status")
+
+            async with PowerDistributingActor(
+                requests_receiver=requests_channel.new_receiver(),
+                component_pool_status_sender=battery_status_channel.new_sender(),
+                results_sender=results_channel.new_sender(),
+                wait_for_data_sec=0.1,
+            ):
+                await requests_channel.new_sender().send(request)
+                result_rx = results_channel.new_receiver()
+
+                done, pending = await asyncio.wait(
+                    [asyncio.create_task(result_rx.receive())],
+                    timeout=SAFETY_TIMEOUT.total_seconds(),
+                )
+
+                assert len(pending) == 0
+                assert len(done) == 1
+
+                result: Result = done.pop().result()
+
+                assert isinstance(result, Error)
+                assert result.request == request
+                assert (
+                    result.msg
+                    == "No data for at least one of the given batteries {9, 19}"
+                )
 
     async def test_battery_two_inverters(self, mocker: MockerFixture) -> None:
         """Test if power distribution works with two inverters for one battery."""
@@ -540,46 +553,44 @@ class TestPowerDistributingActor:
             )
         )
 
-        mocks = await _Mocks.new(mocker, graph=graph)
-        await self.init_component_data(mocks)
+        async with _mocks(mocker, graph=graph) as mocks:
+            await self.init_component_data(mocks)
 
-        requests_channel = Broadcast[Request]("power_distributor requests")
-        results_channel = Broadcast[Result]("power_distributor results")
+            requests_channel = Broadcast[Request]("power_distributor requests")
+            results_channel = Broadcast[Result]("power_distributor results")
 
-        request = Request(
-            power=Power.from_watts(1200.0),
-            component_ids={bat_component.component_id},
-            request_timeout=SAFETY_TIMEOUT,
-        )
-
-        await self._patch_battery_pool_status(mocks, mocker, request.component_ids)
-        battery_status_channel = Broadcast[ComponentPoolStatus]("battery_status")
-
-        async with PowerDistributingActor(
-            requests_receiver=requests_channel.new_receiver(),
-            component_pool_status_sender=battery_status_channel.new_sender(),
-            results_sender=results_channel.new_sender(),
-            wait_for_data_sec=0.1,
-        ):
-            await requests_channel.new_sender().send(request)
-            result_rx = results_channel.new_receiver()
-
-            done, pending = await asyncio.wait(
-                [asyncio.create_task(result_rx.receive())],
-                timeout=SAFETY_TIMEOUT.total_seconds(),
+            request = Request(
+                power=Power.from_watts(1200.0),
+                component_ids={bat_component.component_id},
+                request_timeout=SAFETY_TIMEOUT,
             )
 
-            assert len(pending) == 0
-            assert len(done) == 1
+            await self._patch_battery_pool_status(mocks, mocker, request.component_ids)
+            battery_status_channel = Broadcast[ComponentPoolStatus]("battery_status")
 
-            result: Result = done.pop().result()
-            assert isinstance(result, Success)
-            # Inverters each bounded at 500, together 1000
-            assert result.succeeded_power.isclose(Power.from_watts(1000.0))
-            assert result.excess_power.isclose(Power.from_watts(200.0))
-            assert result.request == request
+            async with PowerDistributingActor(
+                requests_receiver=requests_channel.new_receiver(),
+                component_pool_status_sender=battery_status_channel.new_sender(),
+                results_sender=results_channel.new_sender(),
+                wait_for_data_sec=0.1,
+            ):
+                await requests_channel.new_sender().send(request)
+                result_rx = results_channel.new_receiver()
 
-        await mocks.stop()
+                done, pending = await asyncio.wait(
+                    [asyncio.create_task(result_rx.receive())],
+                    timeout=SAFETY_TIMEOUT.total_seconds(),
+                )
+
+                assert len(pending) == 0
+                assert len(done) == 1
+
+                result: Result = done.pop().result()
+                assert isinstance(result, Success)
+                # Inverters each bounded at 500, together 1000
+                assert result.succeeded_power.isclose(Power.from_watts(1000.0))
+                assert result.excess_power.isclose(Power.from_watts(200.0))
+                assert result.request == request
 
     async def test_two_batteries_three_inverters(self, mocker: MockerFixture) -> None:
         """Test if power distribution works with two batteries connected to three inverters."""
@@ -611,46 +622,44 @@ class TestPowerDistributingActor:
             )
         )
 
-        mocks = await _Mocks.new(mocker, graph=graph)
-        await self.init_component_data(mocks)
+        async with _mocks(mocker, graph=graph) as mocks:
+            await self.init_component_data(mocks)
 
-        requests_channel = Broadcast[Request]("power_distributor requests")
-        results_channel = Broadcast[Result]("power_distributor results")
+            requests_channel = Broadcast[Request]("power_distributor requests")
+            results_channel = Broadcast[Result]("power_distributor results")
 
-        request = Request(
-            power=Power.from_watts(1700.0),
-            component_ids={batteries[0].component_id, batteries[1].component_id},
-            request_timeout=SAFETY_TIMEOUT,
-        )
-
-        await self._patch_battery_pool_status(mocks, mocker, request.component_ids)
-        battery_status_channel = Broadcast[ComponentPoolStatus]("battery_status")
-
-        async with PowerDistributingActor(
-            requests_receiver=requests_channel.new_receiver(),
-            component_pool_status_sender=battery_status_channel.new_sender(),
-            results_sender=results_channel.new_sender(),
-            wait_for_data_sec=0.1,
-        ):
-            await requests_channel.new_sender().send(request)
-            result_rx = results_channel.new_receiver()
-
-            done, pending = await asyncio.wait(
-                [asyncio.create_task(result_rx.receive())],
-                timeout=SAFETY_TIMEOUT.total_seconds(),
+            request = Request(
+                power=Power.from_watts(1700.0),
+                component_ids={batteries[0].component_id, batteries[1].component_id},
+                request_timeout=SAFETY_TIMEOUT,
             )
 
-            assert len(pending) == 0
-            assert len(done) == 1
+            await self._patch_battery_pool_status(mocks, mocker, request.component_ids)
+            battery_status_channel = Broadcast[ComponentPoolStatus]("battery_status")
 
-            result: Result = done.pop().result()
-            assert isinstance(result, Success)
-            # each inverter is bounded at 500 and we have 3 inverters
-            assert result.succeeded_power.isclose(Power.from_watts(1500.0))
-            assert result.excess_power.isclose(Power.from_watts(200.0))
-            assert result.request == request
+            async with PowerDistributingActor(
+                requests_receiver=requests_channel.new_receiver(),
+                component_pool_status_sender=battery_status_channel.new_sender(),
+                results_sender=results_channel.new_sender(),
+                wait_for_data_sec=0.1,
+            ):
+                await requests_channel.new_sender().send(request)
+                result_rx = results_channel.new_receiver()
 
-        await mocks.stop()
+                done, pending = await asyncio.wait(
+                    [asyncio.create_task(result_rx.receive())],
+                    timeout=SAFETY_TIMEOUT.total_seconds(),
+                )
+
+                assert len(pending) == 0
+                assert len(done) == 1
+
+                result: Result = done.pop().result()
+                assert isinstance(result, Success)
+                # each inverter is bounded at 500 and we have 3 inverters
+                assert result.succeeded_power.isclose(Power.from_watts(1500.0))
+                assert result.excess_power.isclose(Power.from_watts(200.0))
+                assert result.request == request
 
     async def test_two_batteries_one_inverter_different_exclusion_bounds_2(
         self, mocker: MockerFixture
@@ -671,69 +680,66 @@ class TestPowerDistributingActor:
             )
         )
 
-        mocks = await _Mocks.new(mocker, graph=graph)
-
-        mocks.streamer.start_streaming(
-            inverter_msg(
-                inverter.component_id,
-                power=PowerBounds(-1000, -500, 500, 1000),
-            ),
-            0.05,
-        )
-        mocks.streamer.start_streaming(
-            battery_msg(
-                batteries[0].component_id,
-                soc=Metric(40, Bound(20, 80)),
-                capacity=Metric(10_000),
-                power=PowerBounds(-1000, -200, 200, 1000),
-            ),
-            0.05,
-        )
-        mocks.streamer.start_streaming(
-            battery_msg(
-                batteries[1].component_id,
-                soc=Metric(40, Bound(20, 80)),
-                capacity=Metric(10_000),
-                power=PowerBounds(-1000, -100, 100, 1000),
-            ),
-            0.05,
-        )
-
-        requests_channel = Broadcast[Request]("power_distributor requests")
-        results_channel = Broadcast[Result]("power_distributor results")
-
-        request = Request(
-            power=Power.from_watts(300.0),
-            component_ids={batteries[0].component_id, batteries[1].component_id},
-            request_timeout=SAFETY_TIMEOUT,
-        )
-
-        await self._patch_battery_pool_status(mocks, mocker, request.component_ids)
-        battery_status_channel = Broadcast[ComponentPoolStatus]("battery_status")
-
-        async with PowerDistributingActor(
-            requests_receiver=requests_channel.new_receiver(),
-            component_pool_status_sender=battery_status_channel.new_sender(),
-            results_sender=results_channel.new_sender(),
-            wait_for_data_sec=0.1,
-        ):
-            await requests_channel.new_sender().send(request)
-            result_rx = results_channel.new_receiver()
-
-            done, pending = await asyncio.wait(
-                [asyncio.create_task(result_rx.receive())],
-                timeout=SAFETY_TIMEOUT.total_seconds(),
+        async with _mocks(mocker, graph=graph) as mocks:
+            mocks.streamer.start_streaming(
+                inverter_msg(
+                    inverter.component_id,
+                    power=PowerBounds(-1000, -500, 500, 1000),
+                ),
+                0.05,
+            )
+            mocks.streamer.start_streaming(
+                battery_msg(
+                    batteries[0].component_id,
+                    soc=Metric(40, Bound(20, 80)),
+                    capacity=Metric(10_000),
+                    power=PowerBounds(-1000, -200, 200, 1000),
+                ),
+                0.05,
+            )
+            mocks.streamer.start_streaming(
+                battery_msg(
+                    batteries[1].component_id,
+                    soc=Metric(40, Bound(20, 80)),
+                    capacity=Metric(10_000),
+                    power=PowerBounds(-1000, -100, 100, 1000),
+                ),
+                0.05,
             )
 
-            assert len(pending) == 0
-            assert len(done) == 1
+            requests_channel = Broadcast[Request]("power_distributor requests")
+            results_channel = Broadcast[Result]("power_distributor results")
 
-            result: Result = done.pop().result()
-            assert isinstance(result, OutOfBounds)
-            assert result.request == request
-            assert result.bounds == PowerBounds(-1000, -500, 500, 1000)
+            request = Request(
+                power=Power.from_watts(300.0),
+                component_ids={batteries[0].component_id, batteries[1].component_id},
+                request_timeout=SAFETY_TIMEOUT,
+            )
 
-        await mocks.stop()
+            await self._patch_battery_pool_status(mocks, mocker, request.component_ids)
+            battery_status_channel = Broadcast[ComponentPoolStatus]("battery_status")
+
+            async with PowerDistributingActor(
+                requests_receiver=requests_channel.new_receiver(),
+                component_pool_status_sender=battery_status_channel.new_sender(),
+                results_sender=results_channel.new_sender(),
+                wait_for_data_sec=0.1,
+            ):
+                await requests_channel.new_sender().send(request)
+                result_rx = results_channel.new_receiver()
+
+                done, pending = await asyncio.wait(
+                    [asyncio.create_task(result_rx.receive())],
+                    timeout=SAFETY_TIMEOUT.total_seconds(),
+                )
+
+                assert len(pending) == 0
+                assert len(done) == 1
+
+                result: Result = done.pop().result()
+                assert isinstance(result, OutOfBounds)
+                assert result.request == request
+                assert result.bounds == PowerBounds(-1000, -500, 500, 1000)
 
     async def test_two_batteries_one_inverter_different_exclusion_bounds(
         self, mocker: MockerFixture
@@ -761,65 +767,63 @@ class TestPowerDistributingActor:
             )
         )
 
-        mocks = await _Mocks.new(mocker, graph=graph)
-        await self.init_component_data(
-            mocks, skip_batteries={bat.component_id for bat in batteries}
-        )
-        mocks.streamer.start_streaming(
-            battery_msg(
-                batteries[0].component_id,
-                soc=Metric(40, Bound(20, 80)),
-                capacity=Metric(10_000),
-                power=PowerBounds(-1000, -200, 200, 1000),
-            ),
-            0.05,
-        )
-        mocks.streamer.start_streaming(
-            battery_msg(
-                batteries[1].component_id,
-                soc=Metric(40, Bound(20, 80)),
-                capacity=Metric(10_000),
-                power=PowerBounds(-1000, -100, 100, 1000),
-            ),
-            0.05,
-        )
-
-        requests_channel = Broadcast[Request]("power_distributor requests")
-        results_channel = Broadcast[Result]("power_distributor results")
-
-        request = Request(
-            power=Power.from_watts(300.0),
-            component_ids={batteries[0].component_id, batteries[1].component_id},
-            request_timeout=SAFETY_TIMEOUT,
-        )
-
-        await self._patch_battery_pool_status(mocks, mocker, request.component_ids)
-        battery_status_channel = Broadcast[ComponentPoolStatus]("battery_status")
-
-        async with PowerDistributingActor(
-            requests_receiver=requests_channel.new_receiver(),
-            component_pool_status_sender=battery_status_channel.new_sender(),
-            results_sender=results_channel.new_sender(),
-            wait_for_data_sec=0.1,
-        ):
-            await requests_channel.new_sender().send(request)
-            result_rx = results_channel.new_receiver()
-
-            done, pending = await asyncio.wait(
-                [asyncio.create_task(result_rx.receive())],
-                timeout=SAFETY_TIMEOUT.total_seconds(),
+        async with _mocks(mocker, graph=graph) as mocks:
+            await self.init_component_data(
+                mocks, skip_batteries={bat.component_id for bat in batteries}
+            )
+            mocks.streamer.start_streaming(
+                battery_msg(
+                    batteries[0].component_id,
+                    soc=Metric(40, Bound(20, 80)),
+                    capacity=Metric(10_000),
+                    power=PowerBounds(-1000, -200, 200, 1000),
+                ),
+                0.05,
+            )
+            mocks.streamer.start_streaming(
+                battery_msg(
+                    batteries[1].component_id,
+                    soc=Metric(40, Bound(20, 80)),
+                    capacity=Metric(10_000),
+                    power=PowerBounds(-1000, -100, 100, 1000),
+                ),
+                0.05,
             )
 
-            assert len(pending) == 0
-            assert len(done) == 1
+            requests_channel = Broadcast[Request]("power_distributor requests")
+            results_channel = Broadcast[Result]("power_distributor results")
 
-            result: Result = done.pop().result()
-            assert isinstance(result, OutOfBounds)
-            assert result.request == request
-            # each inverter is bounded at 500
-            assert result.bounds == PowerBounds(-500, -400, 400, 500)
+            request = Request(
+                power=Power.from_watts(300.0),
+                component_ids={batteries[0].component_id, batteries[1].component_id},
+                request_timeout=SAFETY_TIMEOUT,
+            )
 
-        await mocks.stop()
+            await self._patch_battery_pool_status(mocks, mocker, request.component_ids)
+            battery_status_channel = Broadcast[ComponentPoolStatus]("battery_status")
+
+            async with PowerDistributingActor(
+                requests_receiver=requests_channel.new_receiver(),
+                component_pool_status_sender=battery_status_channel.new_sender(),
+                results_sender=results_channel.new_sender(),
+                wait_for_data_sec=0.1,
+            ):
+                await requests_channel.new_sender().send(request)
+                result_rx = results_channel.new_receiver()
+
+                done, pending = await asyncio.wait(
+                    [asyncio.create_task(result_rx.receive())],
+                    timeout=SAFETY_TIMEOUT.total_seconds(),
+                )
+
+                assert len(pending) == 0
+                assert len(done) == 1
+
+                result: Result = done.pop().result()
+                assert isinstance(result, OutOfBounds)
+                assert result.request == request
+                # each inverter is bounded at 500
+                assert result.bounds == PowerBounds(-500, -400, 400, 500)
 
     async def test_connected_but_not_requested_batteries(
         self, mocker: MockerFixture
@@ -845,496 +849,477 @@ class TestPowerDistributingActor:
             )
         )
 
-        mocks = await _Mocks.new(mocker, graph=graph)
-        await self.init_component_data(mocks)
+        async with _mocks(mocker, graph=graph) as mocks:
+            await self.init_component_data(mocks)
 
-        requests_channel = Broadcast[Request]("power_distributor requests")
-        results_channel = Broadcast[Result]("power_distributor results")
+            requests_channel = Broadcast[Request]("power_distributor requests")
+            results_channel = Broadcast[Result]("power_distributor results")
 
-        request = Request(
-            power=Power.from_watts(600.0),
-            component_ids={batteries[0].component_id},
-            request_timeout=SAFETY_TIMEOUT,
-        )
-
-        await self._patch_battery_pool_status(mocks, mocker, request.component_ids)
-        battery_status_channel = Broadcast[ComponentPoolStatus]("battery_status")
-
-        async with PowerDistributingActor(
-            requests_receiver=requests_channel.new_receiver(),
-            component_pool_status_sender=battery_status_channel.new_sender(),
-            results_sender=results_channel.new_sender(),
-            wait_for_data_sec=0.1,
-        ):
-            await requests_channel.new_sender().send(request)
-            result_rx = results_channel.new_receiver()
-
-            done, pending = await asyncio.wait(
-                [asyncio.create_task(result_rx.receive())],
-                timeout=SAFETY_TIMEOUT.total_seconds(),
+            request = Request(
+                power=Power.from_watts(600.0),
+                component_ids={batteries[0].component_id},
+                request_timeout=SAFETY_TIMEOUT,
             )
+
+            await self._patch_battery_pool_status(mocks, mocker, request.component_ids)
+            battery_status_channel = Broadcast[ComponentPoolStatus]("battery_status")
+
+            async with PowerDistributingActor(
+                requests_receiver=requests_channel.new_receiver(),
+                component_pool_status_sender=battery_status_channel.new_sender(),
+                results_sender=results_channel.new_sender(),
+                wait_for_data_sec=0.1,
+            ):
+                await requests_channel.new_sender().send(request)
+                result_rx = results_channel.new_receiver()
+
+                done, pending = await asyncio.wait(
+                    [asyncio.create_task(result_rx.receive())],
+                    timeout=SAFETY_TIMEOUT.total_seconds(),
+                )
+
+                assert len(pending) == 0
+                assert len(done) == 1
+
+                result: Result = done.pop().result()
+                assert isinstance(result, Error)
+                assert result.request == request
+
+                err_msg = re.search(
+                    r"'Inverters \{48\} are connected to batteries that were not "
+                    r"requested: \{19\}'",
+                    result.msg,
+                )
+                assert err_msg is not None
+
+    async def test_battery_soc_nan(self, mocker: MockerFixture) -> None:
+        """Test if battery with SoC==NaN is not used."""
+        async with _mocks(mocker, grid_meter=False) as mocks:
+            await self.init_component_data(mocks, skip_batteries={9})
+
+            mocks.streamer.start_streaming(
+                battery_msg(
+                    9,
+                    soc=Metric(math.nan, Bound(20, 80)),
+                    capacity=Metric(98000),
+                    power=PowerBounds(-1000, 0, 0, 1000),
+                ),
+                0.05,
+            )
+
+            requests_channel = Broadcast[Request]("power_distributor requests")
+            results_channel = Broadcast[Result]("power_distributor results")
+
+            request = Request(
+                power=Power.from_kilowatts(1.2),
+                component_ids={9, 19},
+                request_timeout=SAFETY_TIMEOUT,
+            )
+
+            await self._patch_battery_pool_status(mocks, mocker, request.component_ids)
+            battery_status_channel = Broadcast[ComponentPoolStatus]("battery_status")
+            async with PowerDistributingActor(
+                requests_receiver=requests_channel.new_receiver(),
+                results_sender=results_channel.new_sender(),
+                component_pool_status_sender=battery_status_channel.new_sender(),
+                wait_for_data_sec=0.1,
+            ):
+                await requests_channel.new_sender().send(request)
+                result_rx = results_channel.new_receiver()
+
+                done, pending = await asyncio.wait(
+                    [asyncio.create_task(result_rx.receive())],
+                    timeout=SAFETY_TIMEOUT.total_seconds(),
+                )
 
             assert len(pending) == 0
             assert len(done) == 1
 
             result: Result = done.pop().result()
-            assert isinstance(result, Error)
+            assert isinstance(result, Success)
+            assert result.succeeded_components == {19}
+            assert result.succeeded_power.isclose(Power.from_watts(500.0))
+            assert result.excess_power.isclose(Power.from_watts(700.0))
             assert result.request == request
-
-            err_msg = re.search(
-                r"'Inverters \{48\} are connected to batteries that were not requested: \{19\}'",
-                result.msg,
-            )
-            assert err_msg is not None
-
-        await mocks.stop()
-
-    async def test_battery_soc_nan(self, mocker: MockerFixture) -> None:
-        """Test if battery with SoC==NaN is not used."""
-        mocks = await _Mocks.new(mocker, grid_meter=False)
-        await self.init_component_data(mocks, skip_batteries={9})
-
-        mocks.streamer.start_streaming(
-            battery_msg(
-                9,
-                soc=Metric(math.nan, Bound(20, 80)),
-                capacity=Metric(98000),
-                power=PowerBounds(-1000, 0, 0, 1000),
-            ),
-            0.05,
-        )
-
-        requests_channel = Broadcast[Request]("power_distributor requests")
-        results_channel = Broadcast[Result]("power_distributor results")
-
-        request = Request(
-            power=Power.from_kilowatts(1.2),
-            component_ids={9, 19},
-            request_timeout=SAFETY_TIMEOUT,
-        )
-
-        await self._patch_battery_pool_status(mocks, mocker, request.component_ids)
-        battery_status_channel = Broadcast[ComponentPoolStatus]("battery_status")
-        async with PowerDistributingActor(
-            requests_receiver=requests_channel.new_receiver(),
-            results_sender=results_channel.new_sender(),
-            component_pool_status_sender=battery_status_channel.new_sender(),
-            wait_for_data_sec=0.1,
-        ):
-            await requests_channel.new_sender().send(request)
-            result_rx = results_channel.new_receiver()
-
-            done, pending = await asyncio.wait(
-                [asyncio.create_task(result_rx.receive())],
-                timeout=SAFETY_TIMEOUT.total_seconds(),
-            )
-
-        assert len(pending) == 0
-        assert len(done) == 1
-
-        result: Result = done.pop().result()
-        assert isinstance(result, Success)
-        assert result.succeeded_components == {19}
-        assert result.succeeded_power.isclose(Power.from_watts(500.0))
-        assert result.excess_power.isclose(Power.from_watts(700.0))
-        assert result.request == request
-
-        await mocks.stop()
 
     async def test_battery_capacity_nan(self, mocker: MockerFixture) -> None:
         """Test battery with capacity set to NaN is not used."""
-        mocks = await _Mocks.new(mocker, grid_meter=False)
-        await self.init_component_data(mocks, skip_batteries={9})
+        async with _mocks(mocker, grid_meter=False) as mocks:
+            await self.init_component_data(mocks, skip_batteries={9})
 
-        mocks.streamer.start_streaming(
-            battery_msg(
-                9,
-                soc=Metric(40, Bound(20, 80)),
-                capacity=Metric(math.nan),
-                power=PowerBounds(-1000, 0, 0, 1000),
-            ),
-            0.05,
-        )
-
-        requests_channel = Broadcast[Request]("power_distributor requests")
-        results_channel = Broadcast[Result]("power_distributor results")
-
-        request = Request(
-            power=Power.from_kilowatts(1.2),
-            component_ids={9, 19},
-            request_timeout=SAFETY_TIMEOUT,
-        )
-
-        await self._patch_battery_pool_status(mocks, mocker, request.component_ids)
-
-        battery_status_channel = Broadcast[ComponentPoolStatus]("battery_status")
-        async with PowerDistributingActor(
-            requests_receiver=requests_channel.new_receiver(),
-            results_sender=results_channel.new_sender(),
-            component_pool_status_sender=battery_status_channel.new_sender(),
-            wait_for_data_sec=0.1,
-        ):
-            await requests_channel.new_sender().send(request)
-            result_rx = results_channel.new_receiver()
-
-            done, pending = await asyncio.wait(
-                [asyncio.create_task(result_rx.receive())],
-                timeout=SAFETY_TIMEOUT.total_seconds(),
+            mocks.streamer.start_streaming(
+                battery_msg(
+                    9,
+                    soc=Metric(40, Bound(20, 80)),
+                    capacity=Metric(math.nan),
+                    power=PowerBounds(-1000, 0, 0, 1000),
+                ),
+                0.05,
             )
 
-        assert len(pending) == 0
-        assert len(done) == 1
+            requests_channel = Broadcast[Request]("power_distributor requests")
+            results_channel = Broadcast[Result]("power_distributor results")
 
-        result: Result = done.pop().result()
-        assert isinstance(result, Success)
-        assert result.succeeded_components == {19}
-        assert result.succeeded_power.isclose(Power.from_watts(500.0))
-        assert result.excess_power.isclose(Power.from_watts(700.0))
-        assert result.request == request
+            request = Request(
+                power=Power.from_kilowatts(1.2),
+                component_ids={9, 19},
+                request_timeout=SAFETY_TIMEOUT,
+            )
 
-        await mocks.stop()
+            await self._patch_battery_pool_status(mocks, mocker, request.component_ids)
+
+            battery_status_channel = Broadcast[ComponentPoolStatus]("battery_status")
+            async with PowerDistributingActor(
+                requests_receiver=requests_channel.new_receiver(),
+                results_sender=results_channel.new_sender(),
+                component_pool_status_sender=battery_status_channel.new_sender(),
+                wait_for_data_sec=0.1,
+            ):
+                await requests_channel.new_sender().send(request)
+                result_rx = results_channel.new_receiver()
+
+                done, pending = await asyncio.wait(
+                    [asyncio.create_task(result_rx.receive())],
+                    timeout=SAFETY_TIMEOUT.total_seconds(),
+                )
+
+            assert len(pending) == 0
+            assert len(done) == 1
+
+            result: Result = done.pop().result()
+            assert isinstance(result, Success)
+            assert result.succeeded_components == {19}
+            assert result.succeeded_power.isclose(Power.from_watts(500.0))
+            assert result.excess_power.isclose(Power.from_watts(700.0))
+            assert result.request == request
 
     async def test_battery_power_bounds_nan(self, mocker: MockerFixture) -> None:
         """Test battery with power bounds set to NaN is not used."""
-        mocks = await _Mocks.new(mocker, grid_meter=False)
-        await self.init_component_data(
-            mocks, skip_batteries={9}, skip_inverters={8, 18}
-        )
-
-        mocks.streamer.start_streaming(
-            inverter_msg(
-                18,
-                power=PowerBounds(-1000, 0, 0, 1000),
-            ),
-            0.05,
-        )
-
-        # Battery 9 should not work because both battery and inverter sends NaN
-        mocks.streamer.start_streaming(
-            inverter_msg(
-                8,
-                power=PowerBounds(-1000, 0, 0, math.nan),
-            ),
-            0.05,
-        )
-
-        mocks.streamer.start_streaming(
-            battery_msg(
-                9,
-                soc=Metric(40, Bound(20, 80)),
-                capacity=Metric(float(98000)),
-                power=PowerBounds(math.nan, 0, 0, math.nan),
-            ),
-            0.05,
-        )
-
-        requests_channel = Broadcast[Request]("power_distributor requests")
-        results_channel = Broadcast[Result]("power_distributor results")
-
-        request = Request(
-            power=Power.from_kilowatts(1.2),
-            component_ids={9, 19},
-            request_timeout=SAFETY_TIMEOUT,
-        )
-
-        await self._patch_battery_pool_status(mocks, mocker, request.component_ids)
-
-        battery_status_channel = Broadcast[ComponentPoolStatus]("battery_status")
-        async with PowerDistributingActor(
-            requests_receiver=requests_channel.new_receiver(),
-            results_sender=results_channel.new_sender(),
-            component_pool_status_sender=battery_status_channel.new_sender(),
-            wait_for_data_sec=0.1,
-        ):
-            await requests_channel.new_sender().send(request)
-            result_rx = results_channel.new_receiver()
-
-            done, pending = await asyncio.wait(
-                [asyncio.create_task(result_rx.receive())],
-                timeout=SAFETY_TIMEOUT.total_seconds(),
+        async with _mocks(mocker, grid_meter=False) as mocks:
+            await self.init_component_data(
+                mocks, skip_batteries={9}, skip_inverters={8, 18}
             )
 
-        assert len(pending) == 0
-        assert len(done) == 1
+            mocks.streamer.start_streaming(
+                inverter_msg(
+                    18,
+                    power=PowerBounds(-1000, 0, 0, 1000),
+                ),
+                0.05,
+            )
 
-        result: Result = done.pop().result()
-        assert isinstance(result, Success)
-        assert result.succeeded_components == {19}
-        assert result.succeeded_power.isclose(Power.from_kilowatts(1.0))
-        assert result.excess_power.isclose(Power.from_watts(200.0))
-        assert result.request == request
+            # Battery 9 should not work because both battery and inverter sends NaN
+            mocks.streamer.start_streaming(
+                inverter_msg(
+                    8,
+                    power=PowerBounds(-1000, 0, 0, math.nan),
+                ),
+                0.05,
+            )
 
-        await mocks.stop()
+            mocks.streamer.start_streaming(
+                battery_msg(
+                    9,
+                    soc=Metric(40, Bound(20, 80)),
+                    capacity=Metric(float(98000)),
+                    power=PowerBounds(math.nan, 0, 0, math.nan),
+                ),
+                0.05,
+            )
+
+            requests_channel = Broadcast[Request]("power_distributor requests")
+            results_channel = Broadcast[Result]("power_distributor results")
+
+            request = Request(
+                power=Power.from_kilowatts(1.2),
+                component_ids={9, 19},
+                request_timeout=SAFETY_TIMEOUT,
+            )
+
+            await self._patch_battery_pool_status(mocks, mocker, request.component_ids)
+
+            battery_status_channel = Broadcast[ComponentPoolStatus]("battery_status")
+            async with PowerDistributingActor(
+                requests_receiver=requests_channel.new_receiver(),
+                results_sender=results_channel.new_sender(),
+                component_pool_status_sender=battery_status_channel.new_sender(),
+                wait_for_data_sec=0.1,
+            ):
+                await requests_channel.new_sender().send(request)
+                result_rx = results_channel.new_receiver()
+
+                done, pending = await asyncio.wait(
+                    [asyncio.create_task(result_rx.receive())],
+                    timeout=SAFETY_TIMEOUT.total_seconds(),
+                )
+
+            assert len(pending) == 0
+            assert len(done) == 1
+
+            result: Result = done.pop().result()
+            assert isinstance(result, Success)
+            assert result.succeeded_components == {19}
+            assert result.succeeded_power.isclose(Power.from_kilowatts(1.0))
+            assert result.excess_power.isclose(Power.from_watts(200.0))
+            assert result.request == request
 
     async def test_power_distributor_invalid_battery_id(
         self, mocker: MockerFixture
     ) -> None:
         """Test if power distribution raises error if any battery id is invalid."""
-        mocks = await _Mocks.new(mocker, grid_meter=False)
-        await self.init_component_data(mocks)
+        async with _mocks(mocker, grid_meter=False) as mocks:
+            await self.init_component_data(mocks)
 
-        requests_channel = Broadcast[Request]("power_distributor requests")
-        results_channel = Broadcast[Result]("power_distributor results")
-        request = Request(
-            power=Power.from_kilowatts(1.2),
-            component_ids={9, 100},
-            request_timeout=SAFETY_TIMEOUT,
-        )
-
-        await self._patch_battery_pool_status(mocks, mocker, request.component_ids)
-
-        battery_status_channel = Broadcast[ComponentPoolStatus]("battery_status")
-        async with PowerDistributingActor(
-            requests_receiver=requests_channel.new_receiver(),
-            results_sender=results_channel.new_sender(),
-            component_pool_status_sender=battery_status_channel.new_sender(),
-            wait_for_data_sec=0.1,
-        ):
-            await requests_channel.new_sender().send(request)
-            result_rx = results_channel.new_receiver()
-
-            done, _ = await asyncio.wait(
-                [asyncio.create_task(result_rx.receive())],
-                timeout=SAFETY_TIMEOUT.total_seconds(),
+            requests_channel = Broadcast[Request]("power_distributor requests")
+            results_channel = Broadcast[Result]("power_distributor results")
+            request = Request(
+                power=Power.from_kilowatts(1.2),
+                component_ids={9, 100},
+                request_timeout=SAFETY_TIMEOUT,
             )
 
-        assert len(done) == 1
-        result: Result = done.pop().result()
-        assert isinstance(result, Error)
-        assert result.request == request
-        err_msg = re.search(r"No battery 100, available batteries:", result.msg)
-        assert err_msg is not None
+            await self._patch_battery_pool_status(mocks, mocker, request.component_ids)
 
-        await mocks.stop()
+            battery_status_channel = Broadcast[ComponentPoolStatus]("battery_status")
+            async with PowerDistributingActor(
+                requests_receiver=requests_channel.new_receiver(),
+                results_sender=results_channel.new_sender(),
+                component_pool_status_sender=battery_status_channel.new_sender(),
+                wait_for_data_sec=0.1,
+            ):
+                await requests_channel.new_sender().send(request)
+                result_rx = results_channel.new_receiver()
+
+                done, _ = await asyncio.wait(
+                    [asyncio.create_task(result_rx.receive())],
+                    timeout=SAFETY_TIMEOUT.total_seconds(),
+                )
+
+            assert len(done) == 1
+            result: Result = done.pop().result()
+            assert isinstance(result, Error)
+            assert result.request == request
+            err_msg = re.search(r"No battery 100, available batteries:", result.msg)
+            assert err_msg is not None
 
     async def test_power_distributor_one_user_adjust_power_consume(
         self, mocker: MockerFixture
     ) -> None:
         """Test if power distribution works with single user works."""
-        mocks = await _Mocks.new(mocker, grid_meter=False)
-        await self.init_component_data(mocks)
+        async with _mocks(mocker, grid_meter=False) as mocks:
+            await self.init_component_data(mocks)
 
-        requests_channel = Broadcast[Request]("power_distributor")
-        results_channel = Broadcast[Result]("power_distributor results")
+            requests_channel = Broadcast[Request]("power_distributor")
+            results_channel = Broadcast[Result]("power_distributor results")
 
-        request = Request(
-            power=Power.from_kilowatts(1.2),
-            component_ids={9, 19},
-            request_timeout=SAFETY_TIMEOUT,
-            adjust_power=False,
-        )
-
-        await self._patch_battery_pool_status(mocks, mocker, request.component_ids)
-
-        battery_status_channel = Broadcast[ComponentPoolStatus]("battery_status")
-        async with PowerDistributingActor(
-            requests_receiver=requests_channel.new_receiver(),
-            results_sender=results_channel.new_sender(),
-            component_pool_status_sender=battery_status_channel.new_sender(),
-            wait_for_data_sec=0.1,
-        ):
-            await requests_channel.new_sender().send(request)
-            result_rx = results_channel.new_receiver()
-
-            done, pending = await asyncio.wait(
-                [asyncio.create_task(result_rx.receive())],
-                timeout=SAFETY_TIMEOUT.total_seconds(),
+            request = Request(
+                power=Power.from_kilowatts(1.2),
+                component_ids={9, 19},
+                request_timeout=SAFETY_TIMEOUT,
+                adjust_power=False,
             )
 
-        assert len(pending) == 0
-        assert len(done) == 1
+            await self._patch_battery_pool_status(mocks, mocker, request.component_ids)
 
-        result = done.pop().result()
-        assert isinstance(result, OutOfBounds)
-        assert result is not None
-        assert result.request == request
-        assert result.bounds.inclusion_upper == 1000
+            battery_status_channel = Broadcast[ComponentPoolStatus]("battery_status")
+            async with PowerDistributingActor(
+                requests_receiver=requests_channel.new_receiver(),
+                results_sender=results_channel.new_sender(),
+                component_pool_status_sender=battery_status_channel.new_sender(),
+                wait_for_data_sec=0.1,
+            ):
+                await requests_channel.new_sender().send(request)
+                result_rx = results_channel.new_receiver()
 
-        await mocks.stop()
+                done, pending = await asyncio.wait(
+                    [asyncio.create_task(result_rx.receive())],
+                    timeout=SAFETY_TIMEOUT.total_seconds(),
+                )
+
+            assert len(pending) == 0
+            assert len(done) == 1
+
+            result = done.pop().result()
+            assert isinstance(result, OutOfBounds)
+            assert result is not None
+            assert result.request == request
+            assert result.bounds.inclusion_upper == 1000
 
     async def test_power_distributor_one_user_adjust_power_supply(
         self, mocker: MockerFixture
     ) -> None:
         """Test if power distribution works with single user works."""
-        mocks = await _Mocks.new(mocker, grid_meter=False)
-        await self.init_component_data(mocks)
+        async with _mocks(mocker, grid_meter=False) as mocks:
+            await self.init_component_data(mocks)
 
-        requests_channel = Broadcast[Request]("power_distributor requests")
-        results_channel = Broadcast[Result]("power_distributor results")
+            requests_channel = Broadcast[Request]("power_distributor requests")
+            results_channel = Broadcast[Result]("power_distributor results")
 
-        request = Request(
-            power=-Power.from_kilowatts(1.2),
-            component_ids={9, 19},
-            request_timeout=SAFETY_TIMEOUT,
-            adjust_power=False,
-        )
-
-        await self._patch_battery_pool_status(mocks, mocker, request.component_ids)
-
-        battery_status_channel = Broadcast[ComponentPoolStatus]("battery_status")
-        async with PowerDistributingActor(
-            requests_receiver=requests_channel.new_receiver(),
-            results_sender=results_channel.new_sender(),
-            component_pool_status_sender=battery_status_channel.new_sender(),
-            wait_for_data_sec=0.1,
-        ):
-            await requests_channel.new_sender().send(request)
-            result_rx = results_channel.new_receiver()
-
-            done, pending = await asyncio.wait(
-                [asyncio.create_task(result_rx.receive())],
-                timeout=SAFETY_TIMEOUT.total_seconds(),
+            request = Request(
+                power=-Power.from_kilowatts(1.2),
+                component_ids={9, 19},
+                request_timeout=SAFETY_TIMEOUT,
+                adjust_power=False,
             )
 
-        assert len(pending) == 0
-        assert len(done) == 1
+            await self._patch_battery_pool_status(mocks, mocker, request.component_ids)
 
-        result = done.pop().result()
-        assert isinstance(result, OutOfBounds)
-        assert result is not None
-        assert result.request == request
-        assert result.bounds.inclusion_lower == -1000
+            battery_status_channel = Broadcast[ComponentPoolStatus]("battery_status")
+            async with PowerDistributingActor(
+                requests_receiver=requests_channel.new_receiver(),
+                results_sender=results_channel.new_sender(),
+                component_pool_status_sender=battery_status_channel.new_sender(),
+                wait_for_data_sec=0.1,
+            ):
+                await requests_channel.new_sender().send(request)
+                result_rx = results_channel.new_receiver()
 
-        await mocks.stop()
+                done, pending = await asyncio.wait(
+                    [asyncio.create_task(result_rx.receive())],
+                    timeout=SAFETY_TIMEOUT.total_seconds(),
+                )
+
+            assert len(pending) == 0
+            assert len(done) == 1
+
+            result = done.pop().result()
+            assert isinstance(result, OutOfBounds)
+            assert result is not None
+            assert result.request == request
+            assert result.bounds.inclusion_lower == -1000
 
     async def test_power_distributor_one_user_adjust_power_success(
         self, mocker: MockerFixture
     ) -> None:
         """Test if power distribution works with single user works."""
-        mocks = await _Mocks.new(mocker, grid_meter=False)
-        await self.init_component_data(mocks)
+        async with _mocks(mocker, grid_meter=False) as mocks:
+            await self.init_component_data(mocks)
 
-        requests_channel = Broadcast[Request]("power_distributor requests")
-        results_channel = Broadcast[Result]("power_distributor results")
+            requests_channel = Broadcast[Request]("power_distributor requests")
+            results_channel = Broadcast[Result]("power_distributor results")
 
-        request = Request(
-            power=Power.from_kilowatts(1.0),
-            component_ids={9, 19},
-            request_timeout=SAFETY_TIMEOUT,
-            adjust_power=False,
-        )
-
-        await self._patch_battery_pool_status(mocks, mocker, request.component_ids)
-
-        battery_status_channel = Broadcast[ComponentPoolStatus]("battery_status")
-        async with PowerDistributingActor(
-            requests_receiver=requests_channel.new_receiver(),
-            results_sender=results_channel.new_sender(),
-            component_pool_status_sender=battery_status_channel.new_sender(),
-            wait_for_data_sec=0.1,
-        ):
-            await requests_channel.new_sender().send(request)
-            result_rx = results_channel.new_receiver()
-
-            done, pending = await asyncio.wait(
-                [asyncio.create_task(result_rx.receive())],
-                timeout=SAFETY_TIMEOUT.total_seconds(),
+            request = Request(
+                power=Power.from_kilowatts(1.0),
+                component_ids={9, 19},
+                request_timeout=SAFETY_TIMEOUT,
+                adjust_power=False,
             )
 
-        assert len(pending) == 0
-        assert len(done) == 1
+            await self._patch_battery_pool_status(mocks, mocker, request.component_ids)
 
-        result = done.pop().result()
-        assert isinstance(result, Success)
-        assert result.succeeded_power.isclose(Power.from_kilowatts(1.0))
-        assert result.excess_power.isclose(Power.zero(), abs_tol=1e-9)
-        assert result.request == request
+            battery_status_channel = Broadcast[ComponentPoolStatus]("battery_status")
+            async with PowerDistributingActor(
+                requests_receiver=requests_channel.new_receiver(),
+                results_sender=results_channel.new_sender(),
+                component_pool_status_sender=battery_status_channel.new_sender(),
+                wait_for_data_sec=0.1,
+            ):
+                await requests_channel.new_sender().send(request)
+                result_rx = results_channel.new_receiver()
 
-        await mocks.stop()
+                done, pending = await asyncio.wait(
+                    [asyncio.create_task(result_rx.receive())],
+                    timeout=SAFETY_TIMEOUT.total_seconds(),
+                )
+
+            assert len(pending) == 0
+            assert len(done) == 1
+
+            result = done.pop().result()
+            assert isinstance(result, Success)
+            assert result.succeeded_power.isclose(Power.from_kilowatts(1.0))
+            assert result.excess_power.isclose(Power.zero(), abs_tol=1e-9)
+            assert result.request == request
 
     async def test_not_all_batteries_are_working(self, mocker: MockerFixture) -> None:
         """Test if power distribution works if not all batteries are working."""
-        mocks = await _Mocks.new(mocker, grid_meter=False)
-        await self.init_component_data(mocks)
+        async with _mocks(mocker, grid_meter=False) as mocks:
+            await self.init_component_data(mocks)
 
-        batteries = {9, 19}
+            batteries = {9, 19}
 
-        await self._patch_battery_pool_status(mocks, mocker, batteries - {9})
+            await self._patch_battery_pool_status(mocks, mocker, batteries - {9})
 
-        requests_channel = Broadcast[Request]("power_distributor requests")
-        results_channel = Broadcast[Result]("power_distributor results")
+            requests_channel = Broadcast[Request]("power_distributor requests")
+            results_channel = Broadcast[Result]("power_distributor results")
 
-        battery_status_channel = Broadcast[ComponentPoolStatus]("battery_status")
-        async with PowerDistributingActor(
-            requests_receiver=requests_channel.new_receiver(),
-            results_sender=results_channel.new_sender(),
-            component_pool_status_sender=battery_status_channel.new_sender(),
-            wait_for_data_sec=0.1,
-        ):
-            request = Request(
-                power=Power.from_kilowatts(1.2),
-                component_ids=batteries,
-                request_timeout=SAFETY_TIMEOUT,
-            )
+            battery_status_channel = Broadcast[ComponentPoolStatus]("battery_status")
+            async with PowerDistributingActor(
+                requests_receiver=requests_channel.new_receiver(),
+                results_sender=results_channel.new_sender(),
+                component_pool_status_sender=battery_status_channel.new_sender(),
+                wait_for_data_sec=0.1,
+            ):
+                request = Request(
+                    power=Power.from_kilowatts(1.2),
+                    component_ids=batteries,
+                    request_timeout=SAFETY_TIMEOUT,
+                )
 
-            await requests_channel.new_sender().send(request)
-            result_rx = results_channel.new_receiver()
+                await requests_channel.new_sender().send(request)
+                result_rx = results_channel.new_receiver()
 
-            done, pending = await asyncio.wait(
-                [asyncio.create_task(result_rx.receive())],
-                timeout=SAFETY_TIMEOUT.total_seconds(),
-            )
+                done, pending = await asyncio.wait(
+                    [asyncio.create_task(result_rx.receive())],
+                    timeout=SAFETY_TIMEOUT.total_seconds(),
+                )
 
-            assert len(pending) == 0
-            assert len(done) == 1
-            result = done.pop().result()
-            assert isinstance(result, Success)
-            assert result.succeeded_components == {19}
-            assert result.excess_power.isclose(Power.from_watts(700.0))
-            assert result.succeeded_power.isclose(Power.from_watts(500.0))
-            assert result.request == request
-
-        await mocks.stop()
+                assert len(pending) == 0
+                assert len(done) == 1
+                result = done.pop().result()
+                assert isinstance(result, Success)
+                assert result.succeeded_components == {19}
+                assert result.excess_power.isclose(Power.from_watts(700.0))
+                assert result.succeeded_power.isclose(Power.from_watts(500.0))
+                assert result.request == request
 
     async def test_partial_failure_result(self, mocker: MockerFixture) -> None:
         """Test power results when the microgrid failed to set power for one of the batteries."""
-        mocks = await _Mocks.new(mocker, grid_meter=False)
-        await self.init_component_data(mocks)
+        async with _mocks(mocker, grid_meter=False) as mocks:
+            await self.init_component_data(mocks)
 
-        batteries = {9, 19, 29}
-        failed_batteries = {9}
-        failed_power = 500.0
+            batteries = {9, 19, 29}
+            failed_batteries = {9}
+            failed_power = 500.0
 
-        await self._patch_battery_pool_status(mocks, mocker, batteries)
+            await self._patch_battery_pool_status(mocks, mocker, batteries)
 
-        mocker.patch(
-            "frequenz.sdk.actor.power_distributing._component_managers._battery_manager"
-            ".BatteryManager._parse_result",
-            return_value=(failed_power, failed_batteries),
-        )
-
-        requests_channel = Broadcast[Request]("power_distributor requests")
-        results_channel = Broadcast[Result]("power_distributor results")
-
-        battery_status_channel = Broadcast[ComponentPoolStatus]("battery_status")
-        async with PowerDistributingActor(
-            requests_receiver=requests_channel.new_receiver(),
-            results_sender=results_channel.new_sender(),
-            component_pool_status_sender=battery_status_channel.new_sender(),
-            wait_for_data_sec=0.1,
-        ):
-            request = Request(
-                power=Power.from_kilowatts(1.70),
-                component_ids=batteries,
-                request_timeout=SAFETY_TIMEOUT,
+            mocker.patch(
+                "frequenz.sdk.actor.power_distributing._component_managers._battery_manager"
+                ".BatteryManager._parse_result",
+                return_value=(failed_power, failed_batteries),
             )
 
-            await requests_channel.new_sender().send(request)
-            result_rx = results_channel.new_receiver()
+            requests_channel = Broadcast[Request]("power_distributor requests")
+            results_channel = Broadcast[Result]("power_distributor results")
 
-            done, pending = await asyncio.wait(
-                [asyncio.create_task(result_rx.receive())],
-                timeout=SAFETY_TIMEOUT.total_seconds(),
-            )
-            assert len(pending) == 0
-            assert len(done) == 1
-            result = done.pop().result()
-            assert isinstance(result, PartialFailure)
-            assert result.succeeded_components == batteries - failed_batteries
-            assert result.failed_components == failed_batteries
-            assert result.succeeded_power.isclose(Power.from_watts(1000.0))
-            assert result.failed_power.isclose(Power.from_watts(failed_power))
-            assert result.excess_power.isclose(Power.from_watts(200.0))
-            assert result.request == request
+            battery_status_channel = Broadcast[ComponentPoolStatus]("battery_status")
+            async with PowerDistributingActor(
+                requests_receiver=requests_channel.new_receiver(),
+                results_sender=results_channel.new_sender(),
+                component_pool_status_sender=battery_status_channel.new_sender(),
+                wait_for_data_sec=0.1,
+            ):
+                request = Request(
+                    power=Power.from_kilowatts(1.70),
+                    component_ids=batteries,
+                    request_timeout=SAFETY_TIMEOUT,
+                )
 
-        await mocks.stop()
+                await requests_channel.new_sender().send(request)
+                result_rx = results_channel.new_receiver()
+
+                done, pending = await asyncio.wait(
+                    [asyncio.create_task(result_rx.receive())],
+                    timeout=SAFETY_TIMEOUT.total_seconds(),
+                )
+                assert len(pending) == 0
+                assert len(done) == 1
+                result = done.pop().result()
+                assert isinstance(result, PartialFailure)
+                assert result.succeeded_components == batteries - failed_batteries
+                assert result.failed_components == failed_batteries
+                assert result.succeeded_power.isclose(Power.from_watts(1000.0))
+                assert result.failed_power.isclose(Power.from_watts(failed_power))
+                assert result.excess_power.isclose(Power.from_watts(200.0))
+                assert result.request == request

--- a/tests/actor/power_distributing/test_power_distributing.py
+++ b/tests/actor/power_distributing/test_power_distributing.py
@@ -60,7 +60,7 @@ T = TypeVar("T")  # Declare type variable
 
 
 @dataclasses.dataclass(frozen=True)
-class Mocks:
+class _Mocks:
     """Mocks for the tests."""
 
     microgrid: MockMicrogrid
@@ -78,7 +78,7 @@ class Mocks:
         mocker: MockerFixture,
         graph: _MicrogridComponentGraph | None = None,
         grid_meter: bool | None = None,
-    ) -> Mocks:
+    ) -> _Mocks:
         """Initialize the mocks."""
         mockgrid = MockMicrogrid(graph=graph, grid_meter=grid_meter)
         if not graph:
@@ -123,7 +123,7 @@ class TestPowerDistributingActor:
 
     async def _patch_battery_pool_status(
         self,
-        mocks: Mocks,
+        mocks: _Mocks,
         mocker: MockerFixture,
         battery_ids: abc.Set[int] | None = None,
     ) -> None:
@@ -207,7 +207,7 @@ class TestPowerDistributingActor:
 
     async def init_component_data(
         self,
-        mocks: Mocks,
+        mocks: _Mocks,
         *,
         skip_batteries: abc.Set[int] | None = None,
         skip_inverters: abc.Set[int] | None = None,
@@ -237,7 +237,7 @@ class TestPowerDistributingActor:
 
     async def test_power_distributor_one_user(self, mocker: MockerFixture) -> None:
         """Test if power distribution works with a single user."""
-        mocks = await Mocks.new(mocker)
+        mocks = await _Mocks.new(mocker)
         requests_channel = Broadcast[Request]("power_distributor requests")
         results_channel = Broadcast[Result]("power_distributor results")
 
@@ -280,7 +280,7 @@ class TestPowerDistributingActor:
         self, mocker: MockerFixture
     ) -> None:
         """Test if power distributing actor rejects non-zero requests in exclusion bounds."""
-        mocks = await Mocks.new(mocker)
+        mocks = await _Mocks.new(mocker)
 
         await self._patch_battery_pool_status(mocks, mocker, {9, 19})
         await self.init_component_data(mocks, skip_batteries={9, 19})
@@ -392,7 +392,7 @@ class TestPowerDistributingActor:
             )
         )
 
-        mocks = await Mocks.new(mocker, graph=graph)
+        mocks = await _Mocks.new(mocker, graph=graph)
         await self.init_component_data(mocks)
 
         requests_channel = Broadcast[Request]("power_distributor requests")
@@ -458,7 +458,7 @@ class TestPowerDistributingActor:
             )
         )
 
-        mocks = await Mocks.new(mocker, graph=graph)
+        mocks = await _Mocks.new(mocker, graph=graph)
         await self.init_component_data(
             mocks, skip_batteries={bat_components[0].component_id}
         )
@@ -537,7 +537,7 @@ class TestPowerDistributingActor:
             )
         )
 
-        mocks = await Mocks.new(mocker, graph=graph)
+        mocks = await _Mocks.new(mocker, graph=graph)
         await self.init_component_data(mocks)
 
         requests_channel = Broadcast[Request]("power_distributor requests")
@@ -608,7 +608,7 @@ class TestPowerDistributingActor:
             )
         )
 
-        mocks = await Mocks.new(mocker, graph=graph)
+        mocks = await _Mocks.new(mocker, graph=graph)
         await self.init_component_data(mocks)
 
         requests_channel = Broadcast[Request]("power_distributor requests")
@@ -668,7 +668,7 @@ class TestPowerDistributingActor:
             )
         )
 
-        mocks = await Mocks.new(mocker, graph=graph)
+        mocks = await _Mocks.new(mocker, graph=graph)
 
         mocks.streamer.start_streaming(
             inverter_msg(
@@ -758,7 +758,7 @@ class TestPowerDistributingActor:
             )
         )
 
-        mocks = await Mocks.new(mocker, graph=graph)
+        mocks = await _Mocks.new(mocker, graph=graph)
         await self.init_component_data(
             mocks, skip_batteries={bat.component_id for bat in batteries}
         )
@@ -842,7 +842,7 @@ class TestPowerDistributingActor:
             )
         )
 
-        mocks = await Mocks.new(mocker, graph=graph)
+        mocks = await _Mocks.new(mocker, graph=graph)
         await self.init_component_data(mocks)
 
         requests_channel = Broadcast[Request]("power_distributor requests")
@@ -888,7 +888,7 @@ class TestPowerDistributingActor:
 
     async def test_battery_soc_nan(self, mocker: MockerFixture) -> None:
         """Test if battery with SoC==NaN is not used."""
-        mocks = await Mocks.new(mocker, grid_meter=False)
+        mocks = await _Mocks.new(mocker, grid_meter=False)
         await self.init_component_data(mocks, skip_batteries={9})
 
         mocks.streamer.start_streaming(
@@ -940,7 +940,7 @@ class TestPowerDistributingActor:
 
     async def test_battery_capacity_nan(self, mocker: MockerFixture) -> None:
         """Test battery with capacity set to NaN is not used."""
-        mocks = await Mocks.new(mocker, grid_meter=False)
+        mocks = await _Mocks.new(mocker, grid_meter=False)
         await self.init_component_data(mocks, skip_batteries={9})
 
         mocks.streamer.start_streaming(
@@ -993,7 +993,7 @@ class TestPowerDistributingActor:
 
     async def test_battery_power_bounds_nan(self, mocker: MockerFixture) -> None:
         """Test battery with power bounds set to NaN is not used."""
-        mocks = await Mocks.new(mocker, grid_meter=False)
+        mocks = await _Mocks.new(mocker, grid_meter=False)
         await self.init_component_data(
             mocks, skip_batteries={9}, skip_inverters={8, 18}
         )
@@ -1067,7 +1067,7 @@ class TestPowerDistributingActor:
         self, mocker: MockerFixture
     ) -> None:
         """Test if power distribution raises error if any battery id is invalid."""
-        mocks = await Mocks.new(mocker, grid_meter=False)
+        mocks = await _Mocks.new(mocker, grid_meter=False)
         await self.init_component_data(mocks)
 
         requests_channel = Broadcast[Request]("power_distributor requests")
@@ -1108,7 +1108,7 @@ class TestPowerDistributingActor:
         self, mocker: MockerFixture
     ) -> None:
         """Test if power distribution works with single user works."""
-        mocks = await Mocks.new(mocker, grid_meter=False)
+        mocks = await _Mocks.new(mocker, grid_meter=False)
         await self.init_component_data(mocks)
 
         requests_channel = Broadcast[Request]("power_distributor")
@@ -1153,7 +1153,7 @@ class TestPowerDistributingActor:
         self, mocker: MockerFixture
     ) -> None:
         """Test if power distribution works with single user works."""
-        mocks = await Mocks.new(mocker, grid_meter=False)
+        mocks = await _Mocks.new(mocker, grid_meter=False)
         await self.init_component_data(mocks)
 
         requests_channel = Broadcast[Request]("power_distributor requests")
@@ -1198,7 +1198,7 @@ class TestPowerDistributingActor:
         self, mocker: MockerFixture
     ) -> None:
         """Test if power distribution works with single user works."""
-        mocks = await Mocks.new(mocker, grid_meter=False)
+        mocks = await _Mocks.new(mocker, grid_meter=False)
         await self.init_component_data(mocks)
 
         requests_channel = Broadcast[Request]("power_distributor requests")
@@ -1241,7 +1241,7 @@ class TestPowerDistributingActor:
 
     async def test_not_all_batteries_are_working(self, mocker: MockerFixture) -> None:
         """Test if power distribution works if not all batteries are working."""
-        mocks = await Mocks.new(mocker, grid_meter=False)
+        mocks = await _Mocks.new(mocker, grid_meter=False)
         await self.init_component_data(mocks)
 
         batteries = {9, 19}
@@ -1285,7 +1285,7 @@ class TestPowerDistributingActor:
 
     async def test_partial_failure_result(self, mocker: MockerFixture) -> None:
         """Test power results when the microgrid failed to set power for one of the batteries."""
-        mocks = await Mocks.new(mocker, grid_meter=False)
+        mocks = await _Mocks.new(mocker, grid_meter=False)
         await self.init_component_data(mocks)
 
         batteries = {9, 19, 29}

--- a/tests/actor/test_battery_pool_status.py
+++ b/tests/actor/test_battery_pool_status.py
@@ -32,77 +32,85 @@ class TestBatteryPoolStatus:
         Args:
             mocker: Pytest mocker fixture.
         """
-        mock_microgrid = MockMicrogrid(grid_meter=True)
+        mock_microgrid = MockMicrogrid(grid_meter=True, mocker=mocker)
         mock_microgrid.add_batteries(3)
-        await mock_microgrid.start(mocker)
 
-        batteries = {
-            battery.component_id
-            for battery in mock_microgrid.mock_client.component_graph.components(
-                component_categories={ComponentCategory.BATTERY}
+        async with mock_microgrid:
+            batteries = {
+                battery.component_id
+                for battery in mock_microgrid.mock_client.component_graph.components(
+                    component_categories={ComponentCategory.BATTERY}
+                )
+            }
+            battery_status_channel = Broadcast[ComponentPoolStatus]("battery_status")
+            battery_status_recv = battery_status_channel.new_receiver(maxsize=1)
+            batteries_status = ComponentPoolStatusTracker(
+                component_ids=batteries,
+                component_status_sender=battery_status_channel.new_sender(),
+                max_data_age_sec=5,
+                max_blocking_duration_sec=30,
+                component_status_tracker_type=BatteryStatusTracker,
             )
-        }
-        battery_status_channel = Broadcast[ComponentPoolStatus]("battery_status")
-        battery_status_recv = battery_status_channel.new_receiver(maxsize=1)
-        batteries_status = ComponentPoolStatusTracker(
-            component_ids=batteries,
-            component_status_sender=battery_status_channel.new_sender(),
-            max_data_age_sec=5,
-            max_blocking_duration_sec=30,
-            component_status_tracker_type=BatteryStatusTracker,
-        )
-        await asyncio.sleep(0.1)
+            await asyncio.sleep(0.1)
 
-        expected_working: set[int] = set()
-        assert batteries_status.get_working_components(batteries) == expected_working
+            expected_working: set[int] = set()
+            assert (
+                batteries_status.get_working_components(batteries) == expected_working
+            )
 
-        batteries_list = list(batteries)
+            batteries_list = list(batteries)
 
-        await mock_microgrid.mock_client.send(
-            battery_data(component_id=batteries_list[0])
-        )
-        await asyncio.sleep(0.1)
-        assert batteries_status.get_working_components(batteries) == expected_working
+            await mock_microgrid.mock_client.send(
+                battery_data(component_id=batteries_list[0])
+            )
+            await asyncio.sleep(0.1)
+            assert (
+                batteries_status.get_working_components(batteries) == expected_working
+            )
 
-        expected_working.add(batteries_list[0])
-        await mock_microgrid.mock_client.send(
-            inverter_data(component_id=batteries_list[0] - 1)
-        )
-        await asyncio.sleep(0.1)
-        assert batteries_status.get_working_components(batteries) == expected_working
-        msg = await asyncio.wait_for(battery_status_recv.receive(), timeout=0.2)
-        assert msg == batteries_status._current_status
+            expected_working.add(batteries_list[0])
+            await mock_microgrid.mock_client.send(
+                inverter_data(component_id=batteries_list[0] - 1)
+            )
+            await asyncio.sleep(0.1)
+            assert (
+                batteries_status.get_working_components(batteries) == expected_working
+            )
+            msg = await asyncio.wait_for(battery_status_recv.receive(), timeout=0.2)
+            assert msg == batteries_status._current_status
 
-        await mock_microgrid.mock_client.send(
-            inverter_data(component_id=batteries_list[1] - 1)
-        )
-        await mock_microgrid.mock_client.send(
-            battery_data(component_id=batteries_list[1])
-        )
+            await mock_microgrid.mock_client.send(
+                inverter_data(component_id=batteries_list[1] - 1)
+            )
+            await mock_microgrid.mock_client.send(
+                battery_data(component_id=batteries_list[1])
+            )
 
-        await mock_microgrid.mock_client.send(
-            inverter_data(component_id=batteries_list[2] - 1)
-        )
-        await mock_microgrid.mock_client.send(
-            battery_data(component_id=batteries_list[2])
-        )
+            await mock_microgrid.mock_client.send(
+                inverter_data(component_id=batteries_list[2] - 1)
+            )
+            await mock_microgrid.mock_client.send(
+                battery_data(component_id=batteries_list[2])
+            )
 
-        expected_working = set(batteries_list)
-        await asyncio.sleep(0.1)
-        assert batteries_status.get_working_components(batteries) == expected_working
-        msg = await asyncio.wait_for(battery_status_recv.receive(), timeout=0.2)
-        assert msg == batteries_status._current_status
+            expected_working = set(batteries_list)
+            await asyncio.sleep(0.1)
+            assert (
+                batteries_status.get_working_components(batteries) == expected_working
+            )
+            msg = await asyncio.wait_for(battery_status_recv.receive(), timeout=0.2)
+            assert msg == batteries_status._current_status
 
-        await batteries_status.update_status(
-            succeeded_components={9}, failed_components={19, 29}
-        )
-        await asyncio.sleep(0.1)
-        assert batteries_status.get_working_components(batteries) == {9}
+            await batteries_status.update_status(
+                succeeded_components={9}, failed_components={19, 29}
+            )
+            await asyncio.sleep(0.1)
+            assert batteries_status.get_working_components(batteries) == {9}
 
-        await batteries_status.update_status(
-            succeeded_components={9, 19}, failed_components=set()
-        )
-        await asyncio.sleep(0.1)
-        assert batteries_status.get_working_components(batteries) == {9, 19}
+            await batteries_status.update_status(
+                succeeded_components={9, 19}, failed_components=set()
+            )
+            await asyncio.sleep(0.1)
+            assert batteries_status.get_working_components(batteries) == {9, 19}
 
-        await batteries_status.stop()
+            await batteries_status.stop()

--- a/tests/microgrid/test_grid.py
+++ b/tests/microgrid/test_grid.py
@@ -37,14 +37,12 @@ async def test_grid_1(mocker: MockerFixture) -> None:
     # pylint: disable=protected-access
     graph = gr._MicrogridComponentGraph(components=components, connections=connections)
 
-    mockgrid = MockMicrogrid(graph=graph)
-    await mockgrid.start(mocker)
-    grid = microgrid.grid()
+    async with MockMicrogrid(graph=graph, mocker=mocker):
+        grid = microgrid.grid()
 
-    assert grid
-    assert grid.fuse
-    assert grid.fuse.max_current == Current.from_amperes(0.0)
-    await mockgrid.cleanup()
+        assert grid
+        assert grid.fuse
+        assert grid.fuse.max_current == Current.from_amperes(0.0)
 
 
 def _create_fuse() -> Fuse:
@@ -71,16 +69,15 @@ async def test_grid_2(mocker: MockerFixture) -> None:
     # pylint: disable=protected-access
     graph = gr._MicrogridComponentGraph(components=components, connections=connections)
 
-    mockgrid = MockMicrogrid(graph=graph)
-    await mockgrid.start(mocker)
+    async with MockMicrogrid(graph=graph, mocker=mocker):
+        grid = microgrid.grid()
+        assert grid is not None
 
-    grid = microgrid.grid()
-    assert grid is not None
+        expected_fuse_current = Current.from_amperes(123.0)
+        expected_fuse = Fuse(expected_fuse_current)
 
-    expected_fuse_current = Current.from_amperes(123.0)
-    expected_fuse = Fuse(expected_fuse_current)
+        assert grid.fuse == expected_fuse
 
-    assert grid.fuse == expected_fuse
 
 
 async def test_grid_3(mocker: MockerFixture) -> None:
@@ -96,166 +93,166 @@ async def test_grid_3(mocker: MockerFixture) -> None:
     # pylint: disable=protected-access
     graph = gr._MicrogridComponentGraph(components=components, connections=connections)
 
-    mockgrid = MockMicrogrid(graph=graph)
-    await mockgrid.start(mocker)
+    async with MockMicrogrid(graph=graph, mocker=mocker):
+        grid = microgrid.grid()
+        assert grid is not None
+        assert grid.fuse is None
 
-    grid = microgrid.grid()
-    assert grid is not None
-    assert grid.fuse is None
 
 
 async def test_grid_power_1(mocker: MockerFixture) -> None:
     """Test the grid power formula with a grid side meter."""
-    mockgrid = MockMicrogrid(grid_meter=True)
+    mockgrid = MockMicrogrid(grid_meter=True, mocker=mocker)
     mockgrid.add_batteries(2)
     mockgrid.add_solar_inverters(1)
-    await mockgrid.start(mocker)
-    grid = microgrid.grid()
-    assert grid, "Grid is not initialized"
 
-    grid_power_recv = grid.power.new_receiver()
+    async with mockgrid:
+        grid = microgrid.grid()
+        assert grid, "Grid is not initialized"
 
-    grid_meter_recv = get_resampled_stream(
-        grid._formula_pool._namespace,  # pylint: disable=protected-access
-        mockgrid.meter_ids[0],
-        ComponentMetricId.ACTIVE_POWER,
-        Power.from_watts,
-    )
+        grid_power_recv = grid.power.new_receiver()
 
-    results = []
-    grid_meter_data = []
-    for count in range(10):
-        await mockgrid.mock_resampler.send_meter_power(
-            [20.0 + count, 12.0, -13.0, -5.0]
-        )
-        val = await grid_meter_recv.receive()
-        assert val is not None and val.value is not None and val.value.as_watts() != 0.0
-        grid_meter_data.append(val.value)
-
-        val = await grid_power_recv.receive()
-        assert val is not None and val.value is not None
-        results.append(val.value)
-
-    await mockgrid.cleanup()
-    await grid.stop()
-
-    assert equal_float_lists(results, grid_meter_data)
-
-
-async def test_grid_power_2(mocker: MockerFixture) -> None:
-    """Test the grid power formula without a grid side meter."""
-    mockgrid = MockMicrogrid(grid_meter=False)
-    mockgrid.add_consumer_meters(1)
-    mockgrid.add_batteries(1, no_meter=False)
-    mockgrid.add_batteries(1, no_meter=True)
-    mockgrid.add_solar_inverters(1)
-    await mockgrid.start(mocker)
-    grid = microgrid.grid()
-    assert grid, "Grid is not initialized"
-
-    grid_power_recv = grid.power.new_receiver()
-
-    component_receivers = [
-        get_resampled_stream(
+        grid_meter_recv = get_resampled_stream(
             grid._formula_pool._namespace,  # pylint: disable=protected-access
-            component_id,
+            mockgrid.meter_ids[0],
             ComponentMetricId.ACTIVE_POWER,
             Power.from_watts,
         )
-        for component_id in [
-            *mockgrid.meter_ids,
-            # The last battery has no meter, so we get the power from the inverter
-            mockgrid.battery_inverter_ids[-1],
-        ]
-    ]
 
-    results: list[Quantity] = []
-    meter_sums: list[Quantity] = []
-    for count in range(10):
-        await mockgrid.mock_resampler.send_meter_power([20.0 + count, 12.0, -13.0])
-        await mockgrid.mock_resampler.send_bat_inverter_power([0.0, -5.0])
-        meter_sum = 0.0
-        for recv in component_receivers:
-            val = await recv.receive()
+        results = []
+        grid_meter_data = []
+        for count in range(10):
+            await mockgrid.mock_resampler.send_meter_power(
+                [20.0 + count, 12.0, -13.0, -5.0]
+            )
+            val = await grid_meter_recv.receive()
             assert (
                 val is not None
                 and val.value is not None
                 and val.value.as_watts() != 0.0
             )
-            meter_sum += val.value.as_watts()
+            grid_meter_data.append(val.value)
 
-        val = await grid_power_recv.receive()
-        assert val is not None and val.value is not None
-        results.append(val.value)
-        meter_sums.append(Quantity(meter_sum))
+            val = await grid_power_recv.receive()
+            assert val is not None and val.value is not None
+            results.append(val.value)
 
-    await mockgrid.cleanup()
-    await grid.stop()
+        await grid.stop()
 
-    assert len(results) == 10
-    assert equal_float_lists(results, meter_sums)
+        assert equal_float_lists(results, grid_meter_data)
+
+
+async def test_grid_power_2(mocker: MockerFixture) -> None:
+    """Test the grid power formula without a grid side meter."""
+    mockgrid = MockMicrogrid(grid_meter=False, mocker=mocker)
+    mockgrid.add_consumer_meters(1)
+    mockgrid.add_batteries(1, no_meter=False)
+    mockgrid.add_batteries(1, no_meter=True)
+    mockgrid.add_solar_inverters(1)
+
+    async with mockgrid:
+        grid = microgrid.grid()
+        assert grid, "Grid is not initialized"
+
+        grid_power_recv = grid.power.new_receiver()
+
+        component_receivers = [
+            get_resampled_stream(
+                grid._formula_pool._namespace,  # pylint: disable=protected-access
+                component_id,
+                ComponentMetricId.ACTIVE_POWER,
+                Power.from_watts,
+            )
+            for component_id in [
+                *mockgrid.meter_ids,
+                # The last battery has no meter, so we get the power from the inverter
+                mockgrid.battery_inverter_ids[-1],
+            ]
+        ]
+
+        results: list[Quantity] = []
+        meter_sums: list[Quantity] = []
+        for count in range(10):
+            await mockgrid.mock_resampler.send_meter_power([20.0 + count, 12.0, -13.0])
+            await mockgrid.mock_resampler.send_bat_inverter_power([0.0, -5.0])
+            meter_sum = 0.0
+            for recv in component_receivers:
+                val = await recv.receive()
+                assert (
+                    val is not None
+                    and val.value is not None
+                    and val.value.as_watts() != 0.0
+                )
+                meter_sum += val.value.as_watts()
+
+            val = await grid_power_recv.receive()
+            assert val is not None and val.value is not None
+            results.append(val.value)
+            meter_sums.append(Quantity(meter_sum))
+
+        await grid.stop()
+
+        assert len(results) == 10
+        assert equal_float_lists(results, meter_sums)
 
 
 async def test_grid_production_consumption_power_consumer_meter(
     mocker: MockerFixture,
 ) -> None:
     """Test the grid production and consumption power formulas."""
-    mockgrid = MockMicrogrid(grid_meter=False)
+    mockgrid = MockMicrogrid(grid_meter=False, mocker=mocker)
     mockgrid.add_consumer_meters()
     mockgrid.add_batteries(2)
     mockgrid.add_solar_inverters(1)
-    await mockgrid.start(mocker)
 
-    grid = microgrid.grid()
-    assert grid, "Grid is not initialized"
-    grid_recv = grid.power.new_receiver()
+    async with mockgrid:
+        grid = microgrid.grid()
+        assert grid, "Grid is not initialized"
+        grid_recv = grid.power.new_receiver()
 
-    await mockgrid.mock_resampler.send_meter_power([1.0, 2.0, 3.0, 4.0])
-    assert (await grid_recv.receive()).value == Power.from_watts(10.0)
+        await mockgrid.mock_resampler.send_meter_power([1.0, 2.0, 3.0, 4.0])
+        assert (await grid_recv.receive()).value == Power.from_watts(10.0)
 
-    await mockgrid.mock_resampler.send_meter_power([1.0, 2.0, -3.0, -4.0])
-    assert (await grid_recv.receive()).value == Power.from_watts(-4.0)
+        await mockgrid.mock_resampler.send_meter_power([1.0, 2.0, -3.0, -4.0])
+        assert (await grid_recv.receive()).value == Power.from_watts(-4.0)
 
-    await mockgrid.cleanup()
-    await grid.stop()
+        await grid.stop()
 
 
 async def test_grid_production_consumption_power_no_grid_meter(
     mocker: MockerFixture,
 ) -> None:
     """Test the grid production and consumption power formulas."""
-    mockgrid = MockMicrogrid(grid_meter=False)
+    mockgrid = MockMicrogrid(grid_meter=False, mocker=mocker)
     mockgrid.add_batteries(2)
     mockgrid.add_solar_inverters(1)
-    await mockgrid.start(mocker)
 
-    grid = microgrid.grid()
-    assert grid, "Grid is not initialized"
-    grid_recv = grid.power.new_receiver()
+    async with mockgrid:
+        grid = microgrid.grid()
+        assert grid, "Grid is not initialized"
+        grid_recv = grid.power.new_receiver()
 
-    await mockgrid.mock_resampler.send_meter_power([2.5, 3.5, 4.0])
-    assert (await grid_recv.receive()).value == Power.from_watts(10.0)
+        await mockgrid.mock_resampler.send_meter_power([2.5, 3.5, 4.0])
+        assert (await grid_recv.receive()).value == Power.from_watts(10.0)
 
-    await mockgrid.mock_resampler.send_meter_power([3.0, -3.0, -4.0])
-    assert (await grid_recv.receive()).value == Power.from_watts(-4.0)
+        await mockgrid.mock_resampler.send_meter_power([3.0, -3.0, -4.0])
+        assert (await grid_recv.receive()).value == Power.from_watts(-4.0)
 
-    await mockgrid.cleanup()
-    await grid.stop()
+        await grid.stop()
 
 
 async def test_consumer_power_2_grid_meters(mocker: MockerFixture) -> None:
     """Test the grid power formula with two grid meters."""
-    mockgrid = MockMicrogrid(grid_meter=False)
+    mockgrid = MockMicrogrid(grid_meter=False, mocker=mocker)
     # with no further successor these will be detected as grid meters
     mockgrid.add_consumer_meters(2)
-    await mockgrid.start(mocker)
 
-    grid = microgrid.grid()
-    assert grid, "Grid is not initialized"
-    grid_recv = grid.power.new_receiver()
+    async with mockgrid:
+        grid = microgrid.grid()
+        assert grid, "Grid is not initialized"
+        grid_recv = grid.power.new_receiver()
 
-    await mockgrid.mock_resampler.send_meter_power([1.0, 2.0])
-    assert (await grid_recv.receive()).value == Power.from_watts(3.0)
+        await mockgrid.mock_resampler.send_meter_power([1.0, 2.0])
+        assert (await grid_recv.receive()).value == Power.from_watts(3.0)
 
-    await mockgrid.cleanup()
-    await grid.stop()
+        await grid.stop()

--- a/tests/microgrid/test_grid.py
+++ b/tests/microgrid/test_grid.py
@@ -36,8 +36,10 @@ async def test_grid_1(mocker: MockerFixture) -> None:
     connections = {
         Connection(1, 2),
     }
-    # pylint: disable=protected-access
-    graph = gr._MicrogridComponentGraph(components=components, connections=connections)
+
+    graph = gr._MicrogridComponentGraph(  # pylint: disable=protected-access
+        components=components, connections=connections
+    )
 
     async with MockMicrogrid(graph=graph, mocker=mocker), AsyncExitStack() as stack:
         grid = microgrid.grid()
@@ -70,8 +72,9 @@ async def test_grid_2(mocker: MockerFixture) -> None:
         Connection(1, 2),
     }
 
-    # pylint: disable=protected-access
-    graph = gr._MicrogridComponentGraph(components=components, connections=connections)
+    graph = gr._MicrogridComponentGraph(  # pylint: disable=protected-access
+        components=components, connections=connections
+    )
 
     async with MockMicrogrid(graph=graph, mocker=mocker), AsyncExitStack() as stack:
         grid = microgrid.grid()
@@ -94,8 +97,9 @@ async def test_grid_3(mocker: MockerFixture) -> None:
         Connection(1, 2),
     }
 
-    # pylint: disable=protected-access
-    graph = gr._MicrogridComponentGraph(components=components, connections=connections)
+    graph = gr._MicrogridComponentGraph(  # pylint: disable=protected-access
+        components=components, connections=connections
+    )
 
     async with MockMicrogrid(graph=graph, mocker=mocker), AsyncExitStack() as stack:
         grid = microgrid.grid()

--- a/tests/timeseries/_formula_engine/test_formula_composition.py
+++ b/tests/timeseries/_formula_engine/test_formula_composition.py
@@ -5,6 +5,7 @@
 
 
 import math
+from contextlib import AsyncExitStack
 
 import pytest
 from pytest_mock import MockerFixture
@@ -25,386 +26,440 @@ class TestFormulaComposition:
         mocker: MockerFixture,
     ) -> None:
         """Test the composition of formulas."""
-        mockgrid = MockMicrogrid(grid_meter=False, num_namespaces=2)
+        mockgrid = MockMicrogrid(grid_meter=False, num_namespaces=2, mocker=mocker)
         mockgrid.add_consumer_meters()
         mockgrid.add_batteries(3)
         mockgrid.add_solar_inverters(2)
-        await mockgrid.start(mocker)
 
-        logical_meter = microgrid.logical_meter()
-        battery_pool = microgrid.battery_pool()
-        grid = microgrid.grid()
-        grid_meter_recv = get_resampled_stream(
-            grid._formula_pool._namespace,  # pylint: disable=protected-access
-            mockgrid.meter_ids[0],
-            ComponentMetricId.ACTIVE_POWER,
-            Power.from_watts,
-        )
-        grid_power_recv = grid.power.new_receiver()
-        battery_power_recv = battery_pool.power.new_receiver()
-        pv_power_recv = logical_meter.pv_power.new_receiver()
+        async with mockgrid, AsyncExitStack() as stack:
+            logical_meter = microgrid.logical_meter()
+            stack.push_async_callback(logical_meter.stop)
 
-        engine = (logical_meter.pv_power + battery_pool.power).build("inv_power")
-        inv_calc_recv = engine.new_receiver()
+            battery_pool = microgrid.battery_pool()
+            stack.push_async_callback(
+                battery_pool._battery_pool.stop  # pylint: disable=protected-access
+            )
 
-        await mockgrid.mock_resampler.send_bat_inverter_power([10.0, 12.0, 14.0])
-        await mockgrid.mock_resampler.send_meter_power(
-            [100.0, 10.0, 12.0, 14.0, -100.0, -200.0]
-        )
+            grid = microgrid.grid()
+            stack.push_async_callback(grid.stop)
 
-        grid_pow = await grid_power_recv.receive()
-        pv_pow = await pv_power_recv.receive()
-        bat_pow = await battery_power_recv.receive()
-        main_pow = await grid_meter_recv.receive()
-        inv_calc_pow = await inv_calc_recv.receive()
+            grid_meter_recv = get_resampled_stream(
+                grid._formula_pool._namespace,  # pylint: disable=protected-access
+                mockgrid.meter_ids[0],
+                ComponentMetricId.ACTIVE_POWER,
+                Power.from_watts,
+            )
+            grid_power_recv = grid.power.new_receiver()
+            battery_power_recv = battery_pool.power.new_receiver()
+            pv_power_recv = logical_meter.pv_power.new_receiver()
 
-        assert (
-            grid_pow is not None
-            and grid_pow.value is not None
-            and math.isclose(grid_pow.value.base_value, -164.0)
-        )  # 100 + 10 + 12 + 14 + -100 + -200
-        assert (
-            bat_pow is not None
-            and bat_pow.value is not None
-            and math.isclose(bat_pow.value.base_value, 36.0)
-        )  # 10 + 12 + 14
-        assert (
-            pv_pow is not None
-            and pv_pow.value is not None
-            and math.isclose(pv_pow.value.base_value, -300.0)
-        )  # -100 + -200
-        assert (
-            inv_calc_pow is not None
-            and inv_calc_pow.value is not None
-            and math.isclose(inv_calc_pow.value.base_value, -264.0)  # -300 + 36
-        )
-        assert (
-            main_pow is not None
-            and main_pow.value is not None
-            and math.isclose(main_pow.value.base_value, 100.0)
-        )
+            engine = (logical_meter.pv_power + battery_pool.power).build("inv_power")
+            stack.push_async_callback(engine._stop)  # pylint: disable=protected-access
 
-        assert math.isclose(
-            inv_calc_pow.value.base_value,
-            pv_pow.value.base_value + bat_pow.value.base_value,
-        )
-        assert math.isclose(
-            grid_pow.value.base_value,
-            inv_calc_pow.value.base_value + main_pow.value.base_value,
-        )
+            inv_calc_recv = engine.new_receiver()
 
-        await mockgrid.cleanup()
-        await engine._stop()  # pylint: disable=protected-access
-        await battery_pool._battery_pool.stop()  # pylint: disable=protected-access
-        await logical_meter.stop()
-        await grid.stop()
+            await mockgrid.mock_resampler.send_bat_inverter_power([10.0, 12.0, 14.0])
+            await mockgrid.mock_resampler.send_meter_power(
+                [100.0, 10.0, 12.0, 14.0, -100.0, -200.0]
+            )
+
+            grid_pow = await grid_power_recv.receive()
+            pv_pow = await pv_power_recv.receive()
+            bat_pow = await battery_power_recv.receive()
+            main_pow = await grid_meter_recv.receive()
+            inv_calc_pow = await inv_calc_recv.receive()
+
+            assert (
+                grid_pow is not None
+                and grid_pow.value is not None
+                and math.isclose(grid_pow.value.base_value, -164.0)
+            )  # 100 + 10 + 12 + 14 + -100 + -200
+            assert (
+                bat_pow is not None
+                and bat_pow.value is not None
+                and math.isclose(bat_pow.value.base_value, 36.0)
+            )  # 10 + 12 + 14
+            assert (
+                pv_pow is not None
+                and pv_pow.value is not None
+                and math.isclose(pv_pow.value.base_value, -300.0)
+            )  # -100 + -200
+            assert (
+                inv_calc_pow is not None
+                and inv_calc_pow.value is not None
+                and math.isclose(inv_calc_pow.value.base_value, -264.0)  # -300 + 36
+            )
+            assert (
+                main_pow is not None
+                and main_pow.value is not None
+                and math.isclose(main_pow.value.base_value, 100.0)
+            )
+
+            assert math.isclose(
+                inv_calc_pow.value.base_value,
+                pv_pow.value.base_value + bat_pow.value.base_value,
+            )
+            assert math.isclose(
+                grid_pow.value.base_value,
+                inv_calc_pow.value.base_value + main_pow.value.base_value,
+            )
 
     async def test_formula_composition_missing_pv(self, mocker: MockerFixture) -> None:
         """Test the composition of formulas with missing PV power data."""
-        mockgrid = MockMicrogrid(grid_meter=False)
+        mockgrid = MockMicrogrid(grid_meter=False, mocker=mocker)
         mockgrid.add_batteries(3)
-        await mockgrid.start(mocker)
-        battery_pool = microgrid.battery_pool()
-        logical_meter = microgrid.logical_meter()
-
-        battery_power_recv = battery_pool.power.new_receiver()
-        pv_power_recv = logical_meter.pv_power.new_receiver()
-        engine = (logical_meter.pv_power + battery_pool.power).build("inv_power")
-        inv_calc_recv = engine.new_receiver()
 
         count = 0
-        for _ in range(10):
-            await mockgrid.mock_resampler.send_bat_inverter_power(
-                [10.0 + count, 12.0 + count, 14.0 + count]
+        async with mockgrid, AsyncExitStack() as stack:
+            battery_pool = microgrid.battery_pool()
+            stack.push_async_callback(
+                battery_pool._battery_pool.stop  # pylint: disable=protected-access
             )
-            await mockgrid.mock_resampler.send_non_existing_component_value()
 
-            bat_pow = await battery_power_recv.receive()
-            pv_pow = await pv_power_recv.receive()
-            inv_pow = await inv_calc_recv.receive()
+            logical_meter = microgrid.logical_meter()
+            stack.push_async_callback(logical_meter.stop)
 
-            assert inv_pow == bat_pow
-            assert (
-                pv_pow.timestamp == inv_pow.timestamp
-                and pv_pow.value == Power.from_watts(0.0)
-            )
-            count += 1
+            battery_power_recv = battery_pool.power.new_receiver()
+            pv_power_recv = logical_meter.pv_power.new_receiver()
+            engine = (logical_meter.pv_power + battery_pool.power).build("inv_power")
+            stack.push_async_callback(engine._stop)  # pylint: disable=protected-access
 
-        await mockgrid.cleanup()
-        await engine._stop()  # pylint: disable=protected-access
-        await battery_pool._battery_pool.stop()  # pylint: disable=protected-access
-        await logical_meter.stop()
+            inv_calc_recv = engine.new_receiver()
+
+            for _ in range(10):
+                await mockgrid.mock_resampler.send_bat_inverter_power(
+                    [10.0 + count, 12.0 + count, 14.0 + count]
+                )
+                await mockgrid.mock_resampler.send_non_existing_component_value()
+
+                bat_pow = await battery_power_recv.receive()
+                pv_pow = await pv_power_recv.receive()
+                inv_pow = await inv_calc_recv.receive()
+
+                assert inv_pow == bat_pow
+                assert (
+                    pv_pow.timestamp == inv_pow.timestamp
+                    and pv_pow.value == Power.from_watts(0.0)
+                )
+                count += 1
 
         assert count == 10
 
     async def test_formula_composition_missing_bat(self, mocker: MockerFixture) -> None:
         """Test the composition of formulas with missing battery power data."""
-        mockgrid = MockMicrogrid(grid_meter=False)
+        mockgrid = MockMicrogrid(grid_meter=False, mocker=mocker)
         mockgrid.add_solar_inverters(2)
-        await mockgrid.start(mocker)
-        battery_pool = microgrid.battery_pool()
-        logical_meter = microgrid.logical_meter()
-
-        battery_power_recv = battery_pool.power.new_receiver()
-        pv_power_recv = logical_meter.pv_power.new_receiver()
-        engine = (logical_meter.pv_power + battery_pool.power).build("inv_power")
-        inv_calc_recv = engine.new_receiver()
 
         count = 0
-        for _ in range(10):
-            await mockgrid.mock_resampler.send_meter_power([12.0 + count, 14.0 + count])
-            await mockgrid.mock_resampler.send_non_existing_component_value()
-            bat_pow = await battery_power_recv.receive()
-            pv_pow = await pv_power_recv.receive()
-            inv_pow = await inv_calc_recv.receive()
-
-            assert inv_pow == pv_pow
-            assert (
-                bat_pow.timestamp == inv_pow.timestamp
-                and bat_pow.value == Power.from_watts(0.0)
+        async with mockgrid, AsyncExitStack() as stack:
+            battery_pool = microgrid.battery_pool()
+            stack.push_async_callback(
+                battery_pool._battery_pool.stop  # pylint: disable=protected-access
             )
-            count += 1
+            logical_meter = microgrid.logical_meter()
+            stack.push_async_callback(logical_meter.stop)
 
-        await mockgrid.cleanup()
-        await engine._stop()  # pylint: disable=protected-access
-        await battery_pool._battery_pool.stop()  # pylint: disable=protected-access
-        await logical_meter.stop()
+            battery_power_recv = battery_pool.power.new_receiver()
+            pv_power_recv = logical_meter.pv_power.new_receiver()
+            engine = (logical_meter.pv_power + battery_pool.power).build("inv_power")
+            stack.push_async_callback(engine._stop)  # pylint: disable=protected-access
+
+            inv_calc_recv = engine.new_receiver()
+
+            for _ in range(10):
+                await mockgrid.mock_resampler.send_meter_power(
+                    [12.0 + count, 14.0 + count]
+                )
+                await mockgrid.mock_resampler.send_non_existing_component_value()
+                bat_pow = await battery_power_recv.receive()
+                pv_pow = await pv_power_recv.receive()
+                inv_pow = await inv_calc_recv.receive()
+
+                assert inv_pow == pv_pow
+                assert (
+                    bat_pow.timestamp == inv_pow.timestamp
+                    and bat_pow.value == Power.from_watts(0.0)
+                )
+                count += 1
 
         assert count == 10
 
     async def test_formula_composition_min_max(self, mocker: MockerFixture) -> None:
         """Test the composition of formulas with the min and max."""
-        mockgrid = MockMicrogrid(grid_meter=True)
+        mockgrid = MockMicrogrid(grid_meter=True, mocker=mocker)
         mockgrid.add_chps(1)
-        await mockgrid.start(mocker)
 
-        logical_meter = microgrid.logical_meter()
-        grid = microgrid.grid()
-        engine_min = grid.power.min(logical_meter.chp_power).build("grid_power_min")
-        engine_min_rx = engine_min.new_receiver()
-        engine_max = grid.power.max(logical_meter.chp_power).build("grid_power_max")
-        engine_max_rx = engine_max.new_receiver()
+        async with mockgrid, AsyncExitStack() as stack:
+            logical_meter = microgrid.logical_meter()
+            stack.push_async_callback(logical_meter.stop)
 
-        await mockgrid.mock_resampler.send_meter_power([100.0, 200.0])
+            grid = microgrid.grid()
+            stack.push_async_callback(grid.stop)
 
-        # Test min
-        min_pow = await engine_min_rx.receive()
-        assert (
-            min_pow and min_pow.value and min_pow.value.isclose(Power.from_watts(100.0))
-        )
+            engine_min = grid.power.min(logical_meter.chp_power).build("grid_power_min")
+            stack.push_async_callback(
+                engine_min._stop  # pylint: disable=protected-access
+            )
+            engine_min_rx = engine_min.new_receiver()
 
-        # Test max
-        max_pow = await engine_max_rx.receive()
-        assert (
-            max_pow and max_pow.value and max_pow.value.isclose(Power.from_watts(200.0))
-        )
+            engine_max = grid.power.max(logical_meter.chp_power).build("grid_power_max")
+            stack.push_async_callback(
+                engine_max._stop  # pylint: disable=protected-access
+            )
+            engine_max_rx = engine_max.new_receiver()
 
-        await mockgrid.mock_resampler.send_meter_power([-100.0, -200.0])
+            await mockgrid.mock_resampler.send_meter_power([100.0, 200.0])
 
-        # Test min
-        min_pow = await engine_min_rx.receive()
-        assert (
-            min_pow
-            and min_pow.value
-            and min_pow.value.isclose(Power.from_watts(-200.0))
-        )
+            # Test min
+            min_pow = await engine_min_rx.receive()
+            assert (
+                min_pow
+                and min_pow.value
+                and min_pow.value.isclose(Power.from_watts(100.0))
+            )
 
-        # Test max
-        max_pow = await engine_max_rx.receive()
-        assert (
-            max_pow
-            and max_pow.value
-            and max_pow.value.isclose(Power.from_watts(-100.0))
-        )
+            # Test max
+            max_pow = await engine_max_rx.receive()
+            assert (
+                max_pow
+                and max_pow.value
+                and max_pow.value.isclose(Power.from_watts(200.0))
+            )
 
-        await engine_min._stop()  # pylint: disable=protected-access
-        await mockgrid.cleanup()
-        await logical_meter.stop()
-        await grid.stop()
+            await mockgrid.mock_resampler.send_meter_power([-100.0, -200.0])
+
+            # Test min
+            min_pow = await engine_min_rx.receive()
+            assert (
+                min_pow
+                and min_pow.value
+                and min_pow.value.isclose(Power.from_watts(-200.0))
+            )
+
+            # Test max
+            max_pow = await engine_max_rx.receive()
+            assert (
+                max_pow
+                and max_pow.value
+                and max_pow.value.isclose(Power.from_watts(-100.0))
+            )
 
     async def test_formula_composition_min_max_const(
         self, mocker: MockerFixture
     ) -> None:
         """Test the compositing formulas and constants with the min and max functions."""
-        mockgrid = MockMicrogrid(grid_meter=True)
-        await mockgrid.start(mocker)
+        async with MockMicrogrid(
+            grid_meter=True, mocker=mocker
+        ) as mockgrid, AsyncExitStack() as stack:
+            logical_meter = microgrid.logical_meter()
+            stack.push_async_callback(logical_meter.stop)
 
-        logical_meter = microgrid.logical_meter()
-        grid = microgrid.grid()
-        engine_min = grid.power.min(Power.zero()).build("grid_power_min")
-        engine_min_rx = engine_min.new_receiver()
-        engine_max = grid.power.max(Power.zero()).build("grid_power_max")
-        engine_max_rx = engine_max.new_receiver()
+            grid = microgrid.grid()
+            stack.push_async_callback(grid.stop)
 
-        await mockgrid.mock_resampler.send_meter_power([100.0])
+            engine_min = grid.power.min(Power.zero()).build("grid_power_min")
+            stack.push_async_callback(
+                engine_min._stop  # pylint: disable=protected-access
+            )
+            engine_min_rx = engine_min.new_receiver()
 
-        # Test min
-        min_pow = await engine_min_rx.receive()
-        assert min_pow and min_pow.value and min_pow.value.isclose(Power.zero())
+            engine_max = grid.power.max(Power.zero()).build("grid_power_max")
+            stack.push_async_callback(
+                engine_max._stop  # pylint: disable=protected-access
+            )
+            engine_max_rx = engine_max.new_receiver()
 
-        # Test max
-        max_pow = await engine_max_rx.receive()
-        assert (
-            max_pow and max_pow.value and max_pow.value.isclose(Power.from_watts(100.0))
-        )
+            await mockgrid.mock_resampler.send_meter_power([100.0])
 
-        await mockgrid.mock_resampler.send_meter_power([-100.0])
+            # Test min
+            min_pow = await engine_min_rx.receive()
+            assert min_pow and min_pow.value and min_pow.value.isclose(Power.zero())
 
-        # Test min
-        min_pow = await engine_min_rx.receive()
-        assert (
-            min_pow
-            and min_pow.value
-            and min_pow.value.isclose(Power.from_watts(-100.0))
-        )
+            # Test max
+            max_pow = await engine_max_rx.receive()
+            assert (
+                max_pow
+                and max_pow.value
+                and max_pow.value.isclose(Power.from_watts(100.0))
+            )
 
-        # Test max
-        max_pow = await engine_max_rx.receive()
-        assert max_pow and max_pow.value and max_pow.value.isclose(Power.zero())
+            await mockgrid.mock_resampler.send_meter_power([-100.0])
 
-        await engine_min._stop()  # pylint: disable=protected-access
-        await mockgrid.cleanup()
-        await logical_meter.stop()
-        await grid.stop()
+            # Test min
+            min_pow = await engine_min_rx.receive()
+            assert (
+                min_pow
+                and min_pow.value
+                and min_pow.value.isclose(Power.from_watts(-100.0))
+            )
+
+            # Test max
+            max_pow = await engine_max_rx.receive()
+            assert max_pow and max_pow.value and max_pow.value.isclose(Power.zero())
 
     async def test_formula_composition_constant(self, mocker: MockerFixture) -> None:
         """Test the composition of formulas with constant values."""
-        mockgrid = MockMicrogrid(grid_meter=True)
-        await mockgrid.start(mocker)
-
-        logical_meter = microgrid.logical_meter()
-        grid = microgrid.grid()
-        engine_add = (grid.power + Power.from_watts(50)).build("grid_power_addition")
-        engine_sub = (grid.power - Power.from_watts(100)).build(
-            "grid_power_subtraction"
-        )
-        engine_mul = (grid.power * 2.0).build("grid_power_multiplication")
-        engine_div = (grid.power / 2.0).build("grid_power_division")
-
-        await mockgrid.mock_resampler.send_meter_power([100.0])
-
-        # Test addition
-        grid_power_addition = await engine_add.new_receiver().receive()
-        assert grid_power_addition.value is not None
-        assert math.isclose(
-            grid_power_addition.value.as_watts(),
-            150.0,
-        )
-
-        # Test subtraction
-        grid_power_subtraction = await engine_sub.new_receiver().receive()
-        assert grid_power_subtraction.value is not None
-        assert math.isclose(
-            grid_power_subtraction.value.as_watts(),
-            0.0,
-        )
-
-        # Test multiplication
-        grid_power_multiplication = await engine_mul.new_receiver().receive()
-        assert grid_power_multiplication.value is not None
-        assert math.isclose(
-            grid_power_multiplication.value.as_watts(),
-            200.0,
-        )
-
-        # Test division
-        grid_power_division = await engine_div.new_receiver().receive()
-        assert grid_power_division.value is not None
-        assert math.isclose(
-            grid_power_division.value.as_watts(),
-            50.0,
-        )
-
-        # Test multiplication with a Quantity
-        with pytest.raises(RuntimeError):
-            engine_assert = (grid.power * Power.from_watts(2.0)).build(  # type: ignore
-                "grid_power_multiplication"
+        async with MockMicrogrid(
+            grid_meter=True, mocker=mocker
+        ) as mockgrid, AsyncExitStack() as stack:
+            logical_meter = microgrid.logical_meter()
+            stack.push_async_callback(logical_meter.stop)
+            grid = microgrid.grid()
+            stack.push_async_callback(grid.stop)
+            engine_add = (grid.power + Power.from_watts(50)).build(
+                "grid_power_addition"
             )
-            await engine_assert.new_receiver().receive()
-
-        # Test addition with a float
-        with pytest.raises(RuntimeError):
-            engine_assert = (grid.power + 2.0).build(  # type: ignore
-                "grid_power_multiplication"
+            stack.push_async_callback(
+                engine_add._stop  # pylint: disable=protected-access
             )
-            await engine_assert.new_receiver().receive()
+            engine_sub = (grid.power - Power.from_watts(100)).build(
+                "grid_power_subtraction"
+            )
+            stack.push_async_callback(
+                engine_sub._stop  # pylint: disable=protected-access
+            )
+            engine_mul = (grid.power * 2.0).build("grid_power_multiplication")
+            stack.push_async_callback(
+                engine_mul._stop  # pylint: disable=protected-access
+            )
+            engine_div = (grid.power / 2.0).build("grid_power_division")
+            stack.push_async_callback(
+                engine_div._stop  # pylint: disable=protected-access
+            )
 
-        await engine_add._stop()  # pylint: disable=protected-access
-        await engine_sub._stop()  # pylint: disable=protected-access
-        await engine_mul._stop()  # pylint: disable=protected-access
-        await engine_div._stop()  # pylint: disable=protected-access
-        await mockgrid.cleanup()
-        await logical_meter.stop()
-        await grid.stop()
+            await mockgrid.mock_resampler.send_meter_power([100.0])
+
+            # Test addition
+            grid_power_addition = await engine_add.new_receiver().receive()
+            assert grid_power_addition.value is not None
+            assert math.isclose(
+                grid_power_addition.value.as_watts(),
+                150.0,
+            )
+
+            # Test subtraction
+            grid_power_subtraction = await engine_sub.new_receiver().receive()
+            assert grid_power_subtraction.value is not None
+            assert math.isclose(
+                grid_power_subtraction.value.as_watts(),
+                0.0,
+            )
+
+            # Test multiplication
+            grid_power_multiplication = await engine_mul.new_receiver().receive()
+            assert grid_power_multiplication.value is not None
+            assert math.isclose(
+                grid_power_multiplication.value.as_watts(),
+                200.0,
+            )
+
+            # Test division
+            grid_power_division = await engine_div.new_receiver().receive()
+            assert grid_power_division.value is not None
+            assert math.isclose(
+                grid_power_division.value.as_watts(),
+                50.0,
+            )
+
+            # Test multiplication with a Quantity
+            with pytest.raises(RuntimeError):
+                engine_assert = (grid.power * Power.from_watts(2.0)).build(  # type: ignore
+                    "grid_power_multiplication"
+                )
+                await engine_assert.new_receiver().receive()
+
+            # Test addition with a float
+            with pytest.raises(RuntimeError):
+                engine_assert = (grid.power + 2.0).build(  # type: ignore
+                    "grid_power_multiplication"
+                )
+                await engine_assert.new_receiver().receive()
 
     async def test_3_phase_formulas(self, mocker: MockerFixture) -> None:
         """Test 3 phase formulas current formulas and their composition."""
-        mockgrid = MockMicrogrid(grid_meter=False, sample_rate_s=0.05, num_namespaces=2)
+        mockgrid = MockMicrogrid(
+            grid_meter=False, sample_rate_s=0.05, num_namespaces=2, mocker=mocker
+        )
         mockgrid.add_batteries(3)
         mockgrid.add_ev_chargers(1)
-        await mockgrid.start(mocker)
-        logical_meter = microgrid.logical_meter()
-        ev_pool = microgrid.ev_charger_pool()
-        grid = microgrid.grid()
-
-        grid_current_recv = grid.current.new_receiver()
-        ev_current_recv = ev_pool.current.new_receiver()
-
-        engine = (grid.current - ev_pool.current).build("net_current")
-        net_current_recv = engine.new_receiver()
 
         count = 0
+        async with mockgrid, AsyncExitStack() as stack:
+            logical_meter = microgrid.logical_meter()
+            stack.push_async_callback(logical_meter.stop)
 
-        for _ in range(10):
-            await mockgrid.mock_resampler.send_meter_current(
-                [
-                    [10.0, 12.0, 14.0],
-                    [10.0, 12.0, 14.0],
-                    [10.0, 12.0, 14.0],
-                ]
-            )
-            await mockgrid.mock_resampler.send_evc_current(
-                [[10.0 + count, 12.0 + count, 14.0 + count]]
-            )
+            ev_pool = microgrid.ev_charger_pool()
+            stack.push_async_callback(ev_pool.stop)
 
-            grid_amps = await grid_current_recv.receive()
-            ev_amps = await ev_current_recv.receive()
-            net_amps = await net_current_recv.receive()
+            grid = microgrid.grid()
+            stack.push_async_callback(grid.stop)
 
-            assert (
-                grid_amps.value_p1 is not None and grid_amps.value_p1.base_value > 0.0
-            )
-            assert (
-                grid_amps.value_p2 is not None and grid_amps.value_p2.base_value > 0.0
-            )
-            assert (
-                grid_amps.value_p3 is not None and grid_amps.value_p3.base_value > 0.0
-            )
-            assert ev_amps.value_p1 is not None and ev_amps.value_p1.base_value > 0.0
-            assert ev_amps.value_p2 is not None and ev_amps.value_p2.base_value > 0.0
-            assert ev_amps.value_p3 is not None and ev_amps.value_p3.base_value > 0.0
-            assert net_amps.value_p1 is not None and net_amps.value_p1.base_value > 0.0
-            assert net_amps.value_p2 is not None and net_amps.value_p2.base_value > 0.0
-            assert net_amps.value_p3 is not None and net_amps.value_p3.base_value > 0.0
+            grid_current_recv = grid.current.new_receiver()
+            ev_current_recv = ev_pool.current.new_receiver()
 
-            assert (
-                net_amps.value_p1.base_value
-                == grid_amps.value_p1.base_value - ev_amps.value_p1.base_value
-            )
-            assert (
-                net_amps.value_p2.base_value
-                == grid_amps.value_p2.base_value - ev_amps.value_p2.base_value
-            )
-            assert (
-                net_amps.value_p3.base_value
-                == grid_amps.value_p3.base_value - ev_amps.value_p3.base_value
-            )
-            count += 1
+            engine = (grid.current - ev_pool.current).build("net_current")
+            stack.push_async_callback(engine._stop)  # pylint: disable=protected-access
+            net_current_recv = engine.new_receiver()
 
-        await mockgrid.cleanup()
-        await engine._stop()  # pylint: disable=protected-access
-        await logical_meter.stop()
-        await ev_pool.stop()
-        await grid.stop()
+            for _ in range(10):
+                await mockgrid.mock_resampler.send_meter_current(
+                    [
+                        [10.0, 12.0, 14.0],
+                        [10.0, 12.0, 14.0],
+                        [10.0, 12.0, 14.0],
+                    ]
+                )
+                await mockgrid.mock_resampler.send_evc_current(
+                    [[10.0 + count, 12.0 + count, 14.0 + count]]
+                )
+
+                grid_amps = await grid_current_recv.receive()
+                ev_amps = await ev_current_recv.receive()
+                net_amps = await net_current_recv.receive()
+
+                assert (
+                    grid_amps.value_p1 is not None
+                    and grid_amps.value_p1.base_value > 0.0
+                )
+                assert (
+                    grid_amps.value_p2 is not None
+                    and grid_amps.value_p2.base_value > 0.0
+                )
+                assert (
+                    grid_amps.value_p3 is not None
+                    and grid_amps.value_p3.base_value > 0.0
+                )
+                assert (
+                    ev_amps.value_p1 is not None and ev_amps.value_p1.base_value > 0.0
+                )
+                assert (
+                    ev_amps.value_p2 is not None and ev_amps.value_p2.base_value > 0.0
+                )
+                assert (
+                    ev_amps.value_p3 is not None and ev_amps.value_p3.base_value > 0.0
+                )
+                assert (
+                    net_amps.value_p1 is not None and net_amps.value_p1.base_value > 0.0
+                )
+                assert (
+                    net_amps.value_p2 is not None and net_amps.value_p2.base_value > 0.0
+                )
+                assert (
+                    net_amps.value_p3 is not None and net_amps.value_p3.base_value > 0.0
+                )
+
+                assert (
+                    net_amps.value_p1.base_value
+                    == grid_amps.value_p1.base_value - ev_amps.value_p1.base_value
+                )
+                assert (
+                    net_amps.value_p2.base_value
+                    == grid_amps.value_p2.base_value - ev_amps.value_p2.base_value
+                )
+                assert (
+                    net_amps.value_p3.base_value
+                    == grid_amps.value_p3.base_value - ev_amps.value_p3.base_value
+                )
+                count += 1
 
         assert count == 10

--- a/tests/timeseries/mock_microgrid.py
+++ b/tests/timeseries/mock_microgrid.py
@@ -5,9 +5,9 @@
 
 
 import asyncio
-import typing
 from collections.abc import Callable
 from datetime import datetime, timedelta, timezone
+from typing import Coroutine
 
 from pytest_mock import MockerFixture
 
@@ -151,7 +151,7 @@ class MockMicrogrid:  # pylint: disable=too-many-instance-attributes
         self.evc_component_states: dict[int, EVChargerComponentState] = {}
         self.evc_cable_states: dict[int, EVChargerCableState] = {}
 
-        self._streaming_coros: list[typing.Coroutine[None, None, None]] = []
+        self._streaming_coros: list[Coroutine[None, None, None]] = []
         self._streaming_tasks: list[asyncio.Task[None]] = []
 
         if grid_meter:

--- a/tests/timeseries/mock_microgrid.py
+++ b/tests/timeseries/mock_microgrid.py
@@ -3,6 +3,7 @@
 
 """A configurable mock microgrid for testing logical meter formulas."""
 
+from __future__ import annotations
 
 import asyncio
 from collections.abc import Callable
@@ -569,3 +570,12 @@ class MockMicrogrid:  # pylint: disable=too-many-instance-attributes
             await cancel_and_await(task)
         microgrid.connection_manager._CONNECTION_MANAGER = None
         # pylint: enable=protected-access
+
+    async def __aenter__(self) -> MockMicrogrid:
+        """Enter context manager."""
+        await self.start()
+        return self
+
+    async def __aexit__(self, exc_type: None, exc_val: None, exc_tb: None) -> None:
+        """Exit context manager."""
+        await self.cleanup()

--- a/tests/timeseries/test_ev_charger_pool.py
+++ b/tests/timeseries/test_ev_charger_pool.py
@@ -5,6 +5,8 @@
 
 
 import asyncio
+from contextlib import AsyncExitStack, asynccontextmanager
+from typing import Any, AsyncIterator
 
 from pytest_mock import MockerFixture
 
@@ -21,78 +23,87 @@ from frequenz.sdk.timeseries.ev_charger_pool._state_tracker import (
 from tests.timeseries.mock_microgrid import MockMicrogrid
 
 
+@asynccontextmanager
+async def new_state_tracker(*args: Any, **kwargs: Any) -> AsyncIterator[StateTracker]:
+    """Create a state tracker."""
+    tracker = StateTracker(*args, **kwargs)
+    try:
+        yield tracker
+    finally:
+        await tracker.stop()
+
+
 class TestEVChargerPool:
     """Tests for the `EVChargerPool`."""
 
     async def test_state_updates(self, mocker: MockerFixture) -> None:
         """Test ev charger state updates are visible."""
         mockgrid = MockMicrogrid(
-            grid_meter=False, api_client_streaming=True, sample_rate_s=0.01
+            grid_meter=False,
+            api_client_streaming=True,
+            sample_rate_s=0.01,
+            mocker=mocker,
         )
         mockgrid.add_ev_chargers(5)
-        await mockgrid.start(mocker)
 
-        state_tracker = StateTracker(set(mockgrid.evc_ids))
-        await asyncio.sleep(0.05)
-
-        async def check_states(
-            expected: dict[int, EVChargerState],
-        ) -> None:
-            await mockgrid.send_ev_charger_data(
-                [0.0] * 5  # for testing status updates, the values don't matter.
-            )
+        async with mockgrid, new_state_tracker(set(mockgrid.evc_ids)) as state_tracker:
             await asyncio.sleep(0.05)
-            for comp_id, exp_state in expected.items():
-                assert state_tracker.get(comp_id) == exp_state
 
-        # check that all chargers are in idle state.
-        expected_states = {evc_id: EVChargerState.IDLE for evc_id in mockgrid.evc_ids}
-        assert len(expected_states) == 5
-        await check_states(expected_states)
+            async def check_states(
+                expected: dict[int, EVChargerState],
+            ) -> None:
+                await mockgrid.send_ev_charger_data(
+                    [0.0] * 5  # for testing status updates, the values don't matter.
+                )
+                await asyncio.sleep(0.05)
+                for comp_id, exp_state in expected.items():
+                    assert state_tracker.get(comp_id) == exp_state
 
-        # check that EV_PLUGGED state gets set
-        evc_2_id = mockgrid.evc_ids[2]
-        mockgrid.evc_cable_states[evc_2_id] = EVChargerCableState.EV_PLUGGED
-        mockgrid.evc_component_states[evc_2_id] = EVChargerComponentState.READY
-        expected_states[evc_2_id] = EVChargerState.EV_PLUGGED
-        await check_states(expected_states)
+            # check that all chargers are in idle state.
+            expected_states = {
+                evc_id: EVChargerState.IDLE for evc_id in mockgrid.evc_ids
+            }
+            assert len(expected_states) == 5
+            await check_states(expected_states)
 
-        # check that EV_LOCKED state gets set
-        evc_3_id = mockgrid.evc_ids[3]
-        mockgrid.evc_cable_states[evc_3_id] = EVChargerCableState.EV_LOCKED
-        mockgrid.evc_component_states[evc_3_id] = EVChargerComponentState.READY
-        expected_states[evc_3_id] = EVChargerState.EV_LOCKED
-        await check_states(expected_states)
+            # check that EV_PLUGGED state gets set
+            evc_2_id = mockgrid.evc_ids[2]
+            mockgrid.evc_cable_states[evc_2_id] = EVChargerCableState.EV_PLUGGED
+            mockgrid.evc_component_states[evc_2_id] = EVChargerComponentState.READY
+            expected_states[evc_2_id] = EVChargerState.EV_PLUGGED
+            await check_states(expected_states)
 
-        # check that ERROR state gets set
-        evc_1_id = mockgrid.evc_ids[1]
-        mockgrid.evc_cable_states[evc_1_id] = EVChargerCableState.EV_LOCKED
-        mockgrid.evc_component_states[evc_1_id] = EVChargerComponentState.ERROR
-        expected_states[evc_1_id] = EVChargerState.ERROR
-        await check_states(expected_states)
+            # check that EV_LOCKED state gets set
+            evc_3_id = mockgrid.evc_ids[3]
+            mockgrid.evc_cable_states[evc_3_id] = EVChargerCableState.EV_LOCKED
+            mockgrid.evc_component_states[evc_3_id] = EVChargerComponentState.READY
+            expected_states[evc_3_id] = EVChargerState.EV_LOCKED
+            await check_states(expected_states)
 
-        await state_tracker.stop()
-        await mockgrid.cleanup()
+            # check that ERROR state gets set
+            evc_1_id = mockgrid.evc_ids[1]
+            mockgrid.evc_cable_states[evc_1_id] = EVChargerCableState.EV_LOCKED
+            mockgrid.evc_component_states[evc_1_id] = EVChargerComponentState.ERROR
+            expected_states[evc_1_id] = EVChargerState.ERROR
+            await check_states(expected_states)
 
     async def test_ev_power(  # pylint: disable=too-many-locals
         self,
         mocker: MockerFixture,
     ) -> None:
         """Test the ev power formula."""
-        mockgrid = MockMicrogrid(grid_meter=False)
+        mockgrid = MockMicrogrid(grid_meter=False, mocker=mocker)
         mockgrid.add_ev_chargers(3)
-        await mockgrid.start(mocker)
 
-        ev_pool = microgrid.ev_charger_pool()
-        power_receiver = ev_pool.power.new_receiver()
+        async with mockgrid:
+            ev_pool = microgrid.ev_charger_pool()
+            power_receiver = ev_pool.power.new_receiver()
 
-        await mockgrid.mock_resampler.send_evc_power([2.0, 4.0, 10.0])
-        assert (await power_receiver.receive()).value == Power.from_watts(16.0)
+            await mockgrid.mock_resampler.send_evc_power([2.0, 4.0, 10.0])
+            assert (await power_receiver.receive()).value == Power.from_watts(16.0)
 
-        await mockgrid.mock_resampler.send_evc_power([2.0, 4.0, -10.0])
-        assert (await power_receiver.receive()).value == Power.from_watts(-4.0)
-
-        await mockgrid.cleanup()
+            await mockgrid.mock_resampler.send_evc_power([2.0, 4.0, -10.0])
+            assert (await power_receiver.receive()).value == Power.from_watts(-4.0)
 
     async def test_ev_component_data(self, mocker: MockerFixture) -> None:
         """Test the component_data method of EVChargerPool."""
@@ -100,101 +111,99 @@ class TestEVChargerPool:
             grid_meter=False,
             api_client_streaming=True,
             sample_rate_s=0.05,
+            mocker=mocker,
         )
         mockgrid.add_ev_chargers(1)
 
-        await mockgrid.start(mocker)
+        async with mockgrid, AsyncExitStack() as stack:
+            evc_id = mockgrid.evc_ids[0]
+            ev_pool = microgrid.ev_charger_pool()
+            stack.push_async_callback(ev_pool.stop)
 
-        evc_id = mockgrid.evc_ids[0]
-        ev_pool = microgrid.ev_charger_pool()
+            recv = ev_pool.component_data(evc_id)
 
-        recv = ev_pool.component_data(evc_id)
+            await mockgrid.send_ev_charger_data(
+                [0.0]  # only the status gets used from this.
+            )
+            await asyncio.sleep(0.05)
+            await mockgrid.mock_resampler.send_evc_current([[2, 3, 5]])
+            status = await recv.receive()
+            assert (
+                status.current.value_p1,
+                status.current.value_p2,
+                status.current.value_p3,
+            ) == (
+                Current.from_amperes(2),
+                Current.from_amperes(3),
+                Current.from_amperes(5),
+            )
+            assert status.state == EVChargerState.MISSING
 
-        await mockgrid.send_ev_charger_data(
-            [0.0]  # only the status gets used from this.
-        )
-        await asyncio.sleep(0.05)
-        await mockgrid.mock_resampler.send_evc_current([[2, 3, 5]])
-        status = await recv.receive()
-        assert (
-            status.current.value_p1,
-            status.current.value_p2,
-            status.current.value_p3,
-        ) == (
-            Current.from_amperes(2),
-            Current.from_amperes(3),
-            Current.from_amperes(5),
-        )
-        assert status.state == EVChargerState.MISSING
+            await mockgrid.send_ev_charger_data(
+                [0.0]  # only the status gets used from this.
+            )
+            await asyncio.sleep(0.05)
+            await mockgrid.mock_resampler.send_evc_current([[2, 3, None]])
+            status = await recv.receive()
+            assert (
+                status.current.value_p1,
+                status.current.value_p2,
+                status.current.value_p3,
+            ) == (
+                Current.from_amperes(2),
+                Current.from_amperes(3),
+                None,
+            )
+            assert status.state == EVChargerState.IDLE
 
-        await mockgrid.send_ev_charger_data(
-            [0.0]  # only the status gets used from this.
-        )
-        await asyncio.sleep(0.05)
-        await mockgrid.mock_resampler.send_evc_current([[2, 3, None]])
-        status = await recv.receive()
-        assert (
-            status.current.value_p1,
-            status.current.value_p2,
-            status.current.value_p3,
-        ) == (
-            Current.from_amperes(2),
-            Current.from_amperes(3),
-            None,
-        )
-        assert status.state == EVChargerState.IDLE
+            await mockgrid.send_ev_charger_data(
+                [0.0]  # only the status gets used from this.
+            )
+            await asyncio.sleep(0.05)
+            await mockgrid.mock_resampler.send_evc_current([[None, None, None]])
+            status = await recv.receive()
+            assert (
+                status.current.value_p1,
+                status.current.value_p2,
+                status.current.value_p3,
+            ) == (
+                None,
+                None,
+                None,
+            )
+            assert status.state == EVChargerState.MISSING
 
-        await mockgrid.send_ev_charger_data(
-            [0.0]  # only the status gets used from this.
-        )
-        await asyncio.sleep(0.05)
-        await mockgrid.mock_resampler.send_evc_current([[None, None, None]])
-        status = await recv.receive()
-        assert (
-            status.current.value_p1,
-            status.current.value_p2,
-            status.current.value_p3,
-        ) == (
-            None,
-            None,
-            None,
-        )
-        assert status.state == EVChargerState.MISSING
+            mockgrid.evc_cable_states[evc_id] = EVChargerCableState.EV_PLUGGED
+            await mockgrid.send_ev_charger_data(
+                [0.0]  # only the status gets used from this.
+            )
+            await asyncio.sleep(0.05)
+            await mockgrid.mock_resampler.send_evc_current([[None, None, None]])
+            status = await recv.receive()
+            assert (
+                status.current.value_p1,
+                status.current.value_p2,
+                status.current.value_p3,
+            ) == (
+                None,
+                None,
+                None,
+            )
+            assert status.state == EVChargerState.MISSING
 
-        mockgrid.evc_cable_states[evc_id] = EVChargerCableState.EV_PLUGGED
-        await mockgrid.send_ev_charger_data(
-            [0.0]  # only the status gets used from this.
-        )
-        await asyncio.sleep(0.05)
-        await mockgrid.mock_resampler.send_evc_current([[None, None, None]])
-        status = await recv.receive()
-        assert (
-            status.current.value_p1,
-            status.current.value_p2,
-            status.current.value_p3,
-        ) == (
-            None,
-            None,
-            None,
-        )
-        assert status.state == EVChargerState.MISSING
-
-        await mockgrid.send_ev_charger_data(
-            [0.0]  # only the status gets used from this.
-        )
-        await asyncio.sleep(0.05)
-        await mockgrid.mock_resampler.send_evc_current([[4, None, None]])
-        status = await recv.receive()
-        assert (
-            status.current.value_p1,
-            status.current.value_p2,
-            status.current.value_p3,
-        ) == (
-            Current.from_amperes(4),
-            None,
-            None,
-        )
-        assert status.state == EVChargerState.EV_PLUGGED
-
-        await mockgrid.cleanup()
-        await ev_pool.stop()
+            await mockgrid.send_ev_charger_data(
+                [0.0]  # only the status gets used from this.
+            )
+            await asyncio.sleep(0.05)
+            await mockgrid.mock_resampler.send_evc_current([[4, None, None]])
+            status = await recv.receive()
+            assert (
+                status.current.value_p1,
+                status.current.value_p2,
+                status.current.value_p3,
+            ) == (
+                Current.from_amperes(4),
+                None,
+                None,
+            )
+            assert status.state == EVChargerState.EV_PLUGGED

--- a/tests/timeseries/test_frequency_streaming.py
+++ b/tests/timeseries/test_frequency_streaming.py
@@ -49,36 +49,36 @@ async def test_grid_frequency_none(mocker: MockerFixture) -> None:
 
 async def test_grid_frequency_1(mocker: MockerFixture) -> None:
     """Test the grid frequency formula."""
-    mockgrid = MockMicrogrid(grid_meter=True)
+    mockgrid = MockMicrogrid(grid_meter=True, mocker=mocker)
     mockgrid.add_batteries(2)
     mockgrid.add_solar_inverters(1)
-    await mockgrid.start(mocker)
 
-    grid_freq = microgrid.frequency()
-    grid_freq_recv = grid_freq.new_receiver()
+    async with mockgrid:
+        grid_freq = microgrid.frequency()
+        grid_freq_recv = grid_freq.new_receiver()
 
-    assert grid_freq._task is not None
-    # We have to wait for the metric request to be sent
-    await grid_freq._task
-    # And consumed
-    await asyncio.sleep(0)
+        assert grid_freq._task is not None
+        # We have to wait for the metric request to be sent
+        await grid_freq._task
+        # And consumed
+        await asyncio.sleep(0)
 
-    results = []
-    grid_meter_data = []
-    for count in range(10):
-        freq = float(50.0 + (1 if count % 2 == 0 else -1) * 0.01)
-        await mockgrid.mock_client.send(
-            component_data_wrapper.MeterDataWrapper(
-                mockgrid.meter_ids[0], datetime.now(tz=timezone.utc), frequency=freq
+        results = []
+        grid_meter_data = []
+        for count in range(10):
+            freq = float(50.0 + (1 if count % 2 == 0 else -1) * 0.01)
+            await mockgrid.mock_client.send(
+                component_data_wrapper.MeterDataWrapper(
+                    mockgrid.meter_ids[0], datetime.now(tz=timezone.utc), frequency=freq
+                )
             )
-        )
 
-        grid_meter_data.append(Frequency.from_hertz(freq))
-        val = await grid_freq_recv.receive()
-        assert val is not None and val.value is not None
-        assert val.value.as_hertz() == freq
-        results.append(val.value)
-    await mockgrid.cleanup()
+            grid_meter_data.append(Frequency.from_hertz(freq))
+            val = await grid_freq_recv.receive()
+            assert val is not None and val.value is not None
+            assert val.value.as_hertz() == freq
+            results.append(val.value)
+
     assert equal_float_lists(results, grid_meter_data)
 
 
@@ -86,36 +86,37 @@ async def test_grid_frequency_no_grid_meter_no_consumer_meter(
     mocker: MockerFixture,
 ) -> None:
     """Test the grid frequency formula without a grid side meter."""
-    mockgrid = MockMicrogrid(grid_meter=False)
+    mockgrid = MockMicrogrid(grid_meter=False, mocker=mocker)
     mockgrid.add_consumer_meters()
     mockgrid.add_batteries(1, no_meter=False)
     mockgrid.add_batteries(1, no_meter=False)
-    await mockgrid.start(mocker)
-    grid_freq = microgrid.frequency()
 
-    grid_freq_recv = grid_freq.new_receiver()
-    # We have to wait for the metric request to be sent
-    assert grid_freq._task is not None
-    await grid_freq._task
-    # And consumed
-    await asyncio.sleep(0)
+    async with mockgrid:
+        grid_freq = microgrid.frequency()
 
-    results = []
-    meter_data = []
-    for count in range(10):
-        freq = float(50.0 + (1 if count % 2 == 0 else -1) * 0.01)
-        await mockgrid.mock_client.send(
-            component_data_wrapper.MeterDataWrapper(
-                mockgrid.meter_ids[0], datetime.now(tz=timezone.utc), frequency=freq
+        grid_freq_recv = grid_freq.new_receiver()
+        # We have to wait for the metric request to be sent
+        assert grid_freq._task is not None
+        await grid_freq._task
+        # And consumed
+        await asyncio.sleep(0)
+
+        results = []
+        meter_data = []
+        for count in range(10):
+            freq = float(50.0 + (1 if count % 2 == 0 else -1) * 0.01)
+            await mockgrid.mock_client.send(
+                component_data_wrapper.MeterDataWrapper(
+                    mockgrid.meter_ids[0], datetime.now(tz=timezone.utc), frequency=freq
+                )
             )
-        )
-        meter_data.append(Frequency.from_hertz(freq))
+            meter_data.append(Frequency.from_hertz(freq))
 
-        val = await grid_freq_recv.receive()
-        assert val is not None and val.value is not None
-        assert val.value.as_hertz() == freq
-        results.append(val.value)
-    await mockgrid.cleanup()
+            val = await grid_freq_recv.receive()
+            assert val is not None and val.value is not None
+            assert val.value.as_hertz() == freq
+            results.append(val.value)
+
     assert equal_float_lists(results, meter_data)
 
 
@@ -123,35 +124,36 @@ async def test_grid_frequency_no_grid_meter(
     mocker: MockerFixture,
 ) -> None:
     """Test the grid frequency formula without a grid side meter."""
-    mockgrid = MockMicrogrid(grid_meter=False)
+    mockgrid = MockMicrogrid(grid_meter=False, mocker=mocker)
     mockgrid.add_batteries(1, no_meter=False)
     mockgrid.add_batteries(1, no_meter=True)
-    await mockgrid.start(mocker)
-    grid_freq = microgrid.frequency()
 
-    grid_freq_recv = grid_freq.new_receiver()
-    # We have to wait for the metric request to be sent
-    assert grid_freq._task is not None
-    await grid_freq._task
-    # And consumed
-    await asyncio.sleep(0)
+    async with mockgrid:
+        grid_freq = microgrid.frequency()
 
-    results = []
-    meter_data = []
-    for count in range(10):
-        freq = float(50.0 + (1 if count % 2 == 0 else -1) * 0.01)
-        await mockgrid.mock_client.send(
-            component_data_wrapper.MeterDataWrapper(
-                mockgrid.meter_ids[0], datetime.now(tz=timezone.utc), frequency=freq
+        grid_freq_recv = grid_freq.new_receiver()
+        # We have to wait for the metric request to be sent
+        assert grid_freq._task is not None
+        await grid_freq._task
+        # And consumed
+        await asyncio.sleep(0)
+
+        results = []
+        meter_data = []
+        for count in range(10):
+            freq = float(50.0 + (1 if count % 2 == 0 else -1) * 0.01)
+            await mockgrid.mock_client.send(
+                component_data_wrapper.MeterDataWrapper(
+                    mockgrid.meter_ids[0], datetime.now(tz=timezone.utc), frequency=freq
+                )
             )
-        )
-        meter_data.append(Frequency.from_hertz(freq))
+            meter_data.append(Frequency.from_hertz(freq))
 
-        val = await grid_freq_recv.receive()
-        assert val is not None and val.value is not None
-        assert val.value.as_hertz() == freq
-        results.append(val.value)
-    await mockgrid.cleanup()
+            val = await grid_freq_recv.receive()
+            assert val is not None and val.value is not None
+            assert val.value.as_hertz() == freq
+            results.append(val.value)
+
     assert equal_float_lists(results, meter_data)
 
 
@@ -159,35 +161,35 @@ async def test_grid_frequency_only_inverter(
     mocker: MockerFixture,
 ) -> None:
     """Test the grid frequency formula without any meter but only inverters."""
-    mockgrid = MockMicrogrid(grid_meter=False)
+    mockgrid = MockMicrogrid(grid_meter=False, mocker=mocker)
     mockgrid.add_batteries(2, no_meter=True)
-    await mockgrid.start(mocker)
 
-    grid_freq = microgrid.frequency()
-    grid_freq_recv = grid_freq.new_receiver()
-    # We have to wait for the metric request to be sent
-    assert grid_freq._task is not None
-    await grid_freq._task
-    # And consumed
-    await asyncio.sleep(0)
+    async with mockgrid:
+        grid_freq = microgrid.frequency()
+        grid_freq_recv = grid_freq.new_receiver()
+        # We have to wait for the metric request to be sent
+        assert grid_freq._task is not None
+        await grid_freq._task
+        # And consumed
+        await asyncio.sleep(0)
 
-    results = []
-    meter_data = []
-    for count in range(10):
-        freq = float(50.0 + (1 if count % 2 == 0 else -1) * 0.01)
+        results = []
+        meter_data = []
+        for count in range(10):
+            freq = float(50.0 + (1 if count % 2 == 0 else -1) * 0.01)
 
-        await mockgrid.mock_client.send(
-            component_data_wrapper.InverterDataWrapper(
-                mockgrid.battery_inverter_ids[0],
-                datetime.now(tz=timezone.utc),
-                frequency=freq,
+            await mockgrid.mock_client.send(
+                component_data_wrapper.InverterDataWrapper(
+                    mockgrid.battery_inverter_ids[0],
+                    datetime.now(tz=timezone.utc),
+                    frequency=freq,
+                )
             )
-        )
 
-        meter_data.append(Frequency.from_hertz(freq))
-        val = await grid_freq_recv.receive()
-        assert val is not None and val.value is not None
-        assert val.value.as_hertz() == freq
-        results.append(val.value)
-    await mockgrid.cleanup()
+            meter_data.append(Frequency.from_hertz(freq))
+            val = await grid_freq_recv.receive()
+            assert val is not None and val.value is not None
+            assert val.value.as_hertz() == freq
+            results.append(val.value)
+
     assert equal_float_lists(results, meter_data)

--- a/tests/timeseries/test_logical_meter.py
+++ b/tests/timeseries/test_logical_meter.py
@@ -4,6 +4,8 @@
 """Tests for the logical meter."""
 
 
+from contextlib import AsyncExitStack
+
 from pytest_mock import MockerFixture
 
 from frequenz.sdk import microgrid
@@ -20,157 +22,185 @@ class TestLogicalMeter:  # pylint: disable=too-many-public-methods
 
     async def test_chp_power(self, mocker: MockerFixture) -> None:
         """Test the chp power formula."""
-        mockgrid = MockMicrogrid(grid_meter=False)
+        mockgrid = MockMicrogrid(grid_meter=False, mocker=mocker)
         mockgrid.add_chps(1)
         mockgrid.add_batteries(2)
-        await mockgrid.start(mocker)
 
-        logical_meter = microgrid.logical_meter()
-        chp_power_receiver = logical_meter.chp_power.new_receiver()
+        async with mockgrid, AsyncExitStack() as stack:
+            logical_meter = microgrid.logical_meter()
+            stack.push_async_callback(logical_meter.stop)
 
-        await mockgrid.mock_resampler.send_meter_power([2.0, 3.0, 4.0])
-        assert (await chp_power_receiver.receive()).value == Power.from_watts(2.0)
+            chp_power_receiver = logical_meter.chp_power.new_receiver()
 
-        await mockgrid.mock_resampler.send_meter_power([-12.0, None, 10.2])
-        assert (await chp_power_receiver.receive()).value == Power.from_watts(-12.0)
+            await mockgrid.mock_resampler.send_meter_power([2.0, 3.0, 4.0])
+            assert (await chp_power_receiver.receive()).value == Power.from_watts(2.0)
+
+            await mockgrid.mock_resampler.send_meter_power([-12.0, None, 10.2])
+            assert (await chp_power_receiver.receive()).value == Power.from_watts(-12.0)
 
     async def test_pv_power(self, mocker: MockerFixture) -> None:
         """Test the pv power formula."""
-        mockgrid = MockMicrogrid(grid_meter=False)
+        mockgrid = MockMicrogrid(grid_meter=False, mocker=mocker)
         mockgrid.add_solar_inverters(2)
-        await mockgrid.start(mocker)
 
-        logical_meter = microgrid.logical_meter()
-        pv_power_receiver = logical_meter.pv_power.new_receiver()
+        async with mockgrid, AsyncExitStack() as stack:
+            logical_meter = microgrid.logical_meter()
+            stack.push_async_callback(logical_meter.stop)
+            pv_power_receiver = logical_meter.pv_power.new_receiver()
 
-        await mockgrid.mock_resampler.send_meter_power([-1.0, -2.0])
-        assert (await pv_power_receiver.receive()).value == Power.from_watts(-3.0)
+            await mockgrid.mock_resampler.send_meter_power([-1.0, -2.0])
+            assert (await pv_power_receiver.receive()).value == Power.from_watts(-3.0)
 
     async def test_pv_power_no_meter(self, mocker: MockerFixture) -> None:
         """Test the pv power formula."""
-        mockgrid = MockMicrogrid(grid_meter=False)
+        mockgrid = MockMicrogrid(grid_meter=False, mocker=mocker)
         mockgrid.add_solar_inverters(2, no_meter=True)
-        await mockgrid.start(mocker)
 
-        logical_meter = microgrid.logical_meter()
-        pv_power_receiver = logical_meter.pv_power.new_receiver()
+        async with mockgrid, AsyncExitStack() as stack:
+            logical_meter = microgrid.logical_meter()
+            stack.push_async_callback(logical_meter.stop)
+            pv_power_receiver = logical_meter.pv_power.new_receiver()
 
-        await mockgrid.mock_resampler.send_pv_inverter_power([-1.0, -2.0])
-        assert (await pv_power_receiver.receive()).value == Power.from_watts(-3.0)
+            await mockgrid.mock_resampler.send_pv_inverter_power([-1.0, -2.0])
+            assert (await pv_power_receiver.receive()).value == Power.from_watts(-3.0)
 
     async def test_pv_power_no_pv_components(self, mocker: MockerFixture) -> None:
         """Test the pv power formula without having any pv components."""
-        mockgrid = MockMicrogrid(grid_meter=True)
-        await mockgrid.start(mocker)
+        async with MockMicrogrid(
+            grid_meter=True, mocker=mocker
+        ) as mockgrid, AsyncExitStack() as stack:
+            logical_meter = microgrid.logical_meter()
+            stack.push_async_callback(logical_meter.stop)
+            pv_power_receiver = logical_meter.pv_power.new_receiver()
 
-        logical_meter = microgrid.logical_meter()
-        pv_power_receiver = logical_meter.pv_power.new_receiver()
-
-        await mockgrid.mock_resampler.send_non_existing_component_value()
-        assert (await pv_power_receiver.receive()).value == Power.zero()
+            await mockgrid.mock_resampler.send_non_existing_component_value()
+            assert (await pv_power_receiver.receive()).value == Power.zero()
 
     async def test_consumer_power_grid_meter(self, mocker: MockerFixture) -> None:
         """Test the consumer power formula with a grid meter."""
-        mockgrid = MockMicrogrid(grid_meter=True)
+        mockgrid = MockMicrogrid(grid_meter=True, mocker=mocker)
         mockgrid.add_batteries(2)
         mockgrid.add_solar_inverters(2)
-        await mockgrid.start(mocker)
 
-        logical_meter = microgrid.logical_meter()
-        consumer_power_receiver = logical_meter.consumer_power.new_receiver()
+        async with mockgrid, AsyncExitStack() as stack:
+            logical_meter = microgrid.logical_meter()
+            stack.push_async_callback(logical_meter.stop)
+            consumer_power_receiver = logical_meter.consumer_power.new_receiver()
 
-        await mockgrid.mock_resampler.send_meter_power([20.0, 2.0, 3.0, 4.0, 5.0])
-        assert (await consumer_power_receiver.receive()).value == Power.from_watts(6.0)
+            await mockgrid.mock_resampler.send_meter_power([20.0, 2.0, 3.0, 4.0, 5.0])
+            assert (await consumer_power_receiver.receive()).value == Power.from_watts(
+                6.0
+            )
 
     async def test_consumer_power_no_grid_meter(self, mocker: MockerFixture) -> None:
         """Test the consumer power formula without a grid meter."""
-        mockgrid = MockMicrogrid(grid_meter=False)
+        mockgrid = MockMicrogrid(grid_meter=False, mocker=mocker)
         mockgrid.add_consumer_meters()
         mockgrid.add_batteries(2)
         mockgrid.add_solar_inverters(2)
-        await mockgrid.start(mocker)
 
-        logical_meter = microgrid.logical_meter()
-        consumer_power_receiver = logical_meter.consumer_power.new_receiver()
+        async with mockgrid, AsyncExitStack() as stack:
+            logical_meter = microgrid.logical_meter()
+            stack.push_async_callback(logical_meter.stop)
+            consumer_power_receiver = logical_meter.consumer_power.new_receiver()
 
-        await mockgrid.mock_resampler.send_meter_power([20.0, 2.0, 3.0, 4.0, 5.0])
-        assert (await consumer_power_receiver.receive()).value == Power.from_watts(20.0)
+            await mockgrid.mock_resampler.send_meter_power([20.0, 2.0, 3.0, 4.0, 5.0])
+            assert (await consumer_power_receiver.receive()).value == Power.from_watts(
+                20.0
+            )
 
     async def test_consumer_power_no_grid_meter_no_consumer_meter(
         self, mocker: MockerFixture
     ) -> None:
         """Test the consumer power formula without a grid meter."""
-        mockgrid = MockMicrogrid(grid_meter=False)
+        mockgrid = MockMicrogrid(grid_meter=False, mocker=mocker)
         mockgrid.add_batteries(2)
         mockgrid.add_solar_inverters(2)
-        await mockgrid.start(mocker)
 
-        logical_meter = microgrid.logical_meter()
-        consumer_power_receiver = logical_meter.consumer_power.new_receiver()
+        async with mockgrid, AsyncExitStack() as stack:
+            logical_meter = microgrid.logical_meter()
+            stack.push_async_callback(logical_meter.stop)
+            consumer_power_receiver = logical_meter.consumer_power.new_receiver()
 
-        await mockgrid.mock_resampler.send_non_existing_component_value()
-        assert (await consumer_power_receiver.receive()).value == Power.from_watts(0.0)
+            await mockgrid.mock_resampler.send_non_existing_component_value()
+            assert (await consumer_power_receiver.receive()).value == Power.from_watts(
+                0.0
+            )
 
     async def test_producer_power(self, mocker: MockerFixture) -> None:
         """Test the producer power formula."""
-        mockgrid = MockMicrogrid(grid_meter=False)
+        mockgrid = MockMicrogrid(grid_meter=False, mocker=mocker)
         mockgrid.add_solar_inverters(2)
         mockgrid.add_chps(2)
-        await mockgrid.start(mocker)
 
-        logical_meter = microgrid.logical_meter()
-        producer_power_receiver = logical_meter.producer_power.new_receiver()
+        async with mockgrid, AsyncExitStack() as stack:
+            logical_meter = microgrid.logical_meter()
+            stack.push_async_callback(logical_meter.stop)
+            producer_power_receiver = logical_meter.producer_power.new_receiver()
 
-        await mockgrid.mock_resampler.send_meter_power([2.0, 3.0, 4.0, 5.0])
-        assert (await producer_power_receiver.receive()).value == Power.from_watts(14.0)
+            await mockgrid.mock_resampler.send_meter_power([2.0, 3.0, 4.0, 5.0])
+            assert (await producer_power_receiver.receive()).value == Power.from_watts(
+                14.0
+            )
 
     async def test_producer_power_no_chp(self, mocker: MockerFixture) -> None:
         """Test the producer power formula without a chp."""
-        mockgrid = MockMicrogrid(grid_meter=False)
+        mockgrid = MockMicrogrid(grid_meter=False, mocker=mocker)
         mockgrid.add_solar_inverters(2)
 
-        await mockgrid.start(mocker)
+        async with mockgrid, AsyncExitStack() as stack:
+            logical_meter = microgrid.logical_meter()
+            stack.push_async_callback(logical_meter.stop)
+            producer_power_receiver = logical_meter.producer_power.new_receiver()
 
-        logical_meter = microgrid.logical_meter()
-        producer_power_receiver = logical_meter.producer_power.new_receiver()
-
-        await mockgrid.mock_resampler.send_meter_power([2.0, 3.0])
-        assert (await producer_power_receiver.receive()).value == Power.from_watts(5.0)
+            await mockgrid.mock_resampler.send_meter_power([2.0, 3.0])
+            assert (await producer_power_receiver.receive()).value == Power.from_watts(
+                5.0
+            )
 
     async def test_producer_power_no_pv_no_consumer_meter(
         self, mocker: MockerFixture
     ) -> None:
         """Test the producer power formula without pv and without consumer meter."""
-        mockgrid = MockMicrogrid(grid_meter=False)
+        mockgrid = MockMicrogrid(grid_meter=False, mocker=mocker)
         mockgrid.add_chps(1, True)
-        await mockgrid.start(mocker)
 
-        logical_meter = microgrid.logical_meter()
-        producer_power_receiver = logical_meter.producer_power.new_receiver()
+        async with mockgrid, AsyncExitStack() as stack:
+            logical_meter = microgrid.logical_meter()
+            stack.push_async_callback(logical_meter.stop)
+            producer_power_receiver = logical_meter.producer_power.new_receiver()
 
-        await mockgrid.mock_resampler.send_chp_power([2.0])
-        assert (await producer_power_receiver.receive()).value == Power.from_watts(2.0)
+            await mockgrid.mock_resampler.send_chp_power([2.0])
+            assert (await producer_power_receiver.receive()).value == Power.from_watts(
+                2.0
+            )
 
     async def test_producer_power_no_pv(self, mocker: MockerFixture) -> None:
         """Test the producer power formula without pv."""
-        mockgrid = MockMicrogrid(grid_meter=False)
+        mockgrid = MockMicrogrid(grid_meter=False, mocker=mocker)
         mockgrid.add_consumer_meters()
         mockgrid.add_chps(1)
-        await mockgrid.start(mocker)
 
-        logical_meter = microgrid.logical_meter()
-        producer_power_receiver = logical_meter.producer_power.new_receiver()
+        async with mockgrid, AsyncExitStack() as stack:
+            logical_meter = microgrid.logical_meter()
+            stack.push_async_callback(logical_meter.stop)
+            producer_power_receiver = logical_meter.producer_power.new_receiver()
 
-        await mockgrid.mock_resampler.send_meter_power([20.0, 2.0])
-        assert (await producer_power_receiver.receive()).value == Power.from_watts(2.0)
+            await mockgrid.mock_resampler.send_meter_power([20.0, 2.0])
+            assert (await producer_power_receiver.receive()).value == Power.from_watts(
+                2.0
+            )
 
     async def test_no_producer_power(self, mocker: MockerFixture) -> None:
         """Test the producer power formula without producers."""
-        mockgrid = MockMicrogrid(grid_meter=True)
-        await mockgrid.start(mocker)
+        async with MockMicrogrid(
+            grid_meter=True, mocker=mocker
+        ) as mockgrid, AsyncExitStack() as stack:
+            logical_meter = microgrid.logical_meter()
+            stack.push_async_callback(logical_meter.stop)
+            producer_power_receiver = logical_meter.producer_power.new_receiver()
 
-        logical_meter = microgrid.logical_meter()
-        producer_power_receiver = logical_meter.producer_power.new_receiver()
-
-        await mockgrid.mock_resampler.send_non_existing_component_value()
-        assert (await producer_power_receiver.receive()).value == Power.from_watts(0.0)
+            await mockgrid.mock_resampler.send_non_existing_component_value()
+            assert (await producer_power_receiver.receive()).value == Power.from_watts(
+                0.0
+            )

--- a/tests/timeseries/test_voltage_streamer.py
+++ b/tests/timeseries/test_voltage_streamer.py
@@ -17,108 +17,102 @@ from .mock_microgrid import MockMicrogrid
 
 async def test_voltage_1(mocker: MockerFixture) -> None:
     """Test the phase-to-neutral voltage with a grid side meter."""
-    mockgrid = MockMicrogrid(grid_meter=True)
+    mockgrid = MockMicrogrid(grid_meter=True, mocker=mocker)
     mockgrid.add_batteries(1, no_meter=True)
     mockgrid.add_batteries(1, no_meter=False)
-    await mockgrid.start(mocker)
 
-    voltage = microgrid.voltage()
-    voltage_recv = voltage.new_receiver()
+    async with mockgrid:
+        voltage = microgrid.voltage()
+        voltage_recv = voltage.new_receiver()
 
-    assert voltage._task is not None
-    # Wait for voltage requests to be sent, one request per phase.
-    await asyncio.sleep(0)
-    await asyncio.sleep(0)
-    await asyncio.sleep(0)
+        assert voltage._task is not None
+        # Wait for voltage requests to be sent, one request per phase.
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
 
-    for count in range(10):
-        volt_delta = 1 if count % 2 == 0 else -1
-        volt_phases: list[float | None] = [
-            220.0 * volt_delta,
-            219.8 * volt_delta,
-            220.2 * volt_delta,
-        ]
+        for count in range(10):
+            volt_delta = 1 if count % 2 == 0 else -1
+            volt_phases: list[float | None] = [
+                220.0 * volt_delta,
+                219.8 * volt_delta,
+                220.2 * volt_delta,
+            ]
 
-        await mockgrid.mock_resampler.send_meter_voltage([volt_phases, volt_phases])
+            await mockgrid.mock_resampler.send_meter_voltage([volt_phases, volt_phases])
 
-        val = await voltage_recv.receive()
-        assert val is not None
-        assert val.value_p1 and val.value_p2 and val.value_p3
-        assert val.value_p1.as_volts() == volt_phases[0]
-        assert val.value_p2.as_volts() == volt_phases[1]
-        assert val.value_p3.as_volts() == volt_phases[2]
-
-    await mockgrid.cleanup()
+            val = await voltage_recv.receive()
+            assert val is not None
+            assert val.value_p1 and val.value_p2 and val.value_p3
+            assert val.value_p1.as_volts() == volt_phases[0]
+            assert val.value_p2.as_volts() == volt_phases[1]
+            assert val.value_p3.as_volts() == volt_phases[2]
 
 
 async def test_voltage_2(mocker: MockerFixture) -> None:
     """Test the phase-to-neutral voltage without a grid side meter."""
-    mockgrid = MockMicrogrid(grid_meter=False)
+    mockgrid = MockMicrogrid(grid_meter=False, mocker=mocker)
     mockgrid.add_batteries(1, no_meter=False)
     mockgrid.add_batteries(1, no_meter=True)
-    await mockgrid.start(mocker)
 
-    voltage = microgrid.voltage()
-    voltage_recv = voltage.new_receiver()
+    async with mockgrid:
+        voltage = microgrid.voltage()
+        voltage_recv = voltage.new_receiver()
 
-    assert voltage._task is not None
-    # Wait for voltage requests to be sent, one request per phase.
-    await asyncio.sleep(0)
-    await asyncio.sleep(0)
-    await asyncio.sleep(0)
+        assert voltage._task is not None
+        # Wait for voltage requests to be sent, one request per phase.
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
 
-    for count in range(10):
-        volt_delta = 1 if count % 2 == 0 else -1
-        volt_phases: list[float | None] = [
-            220.0 * volt_delta,
-            219.8 * volt_delta,
-            220.2 * volt_delta,
-        ]
+        for count in range(10):
+            volt_delta = 1 if count % 2 == 0 else -1
+            volt_phases: list[float | None] = [
+                220.0 * volt_delta,
+                219.8 * volt_delta,
+                220.2 * volt_delta,
+            ]
 
-        await mockgrid.mock_resampler.send_meter_voltage([volt_phases])
+            await mockgrid.mock_resampler.send_meter_voltage([volt_phases])
 
-        val = await voltage_recv.receive()
-        assert val is not None
-        assert val.value_p1 and val.value_p2 and val.value_p3
-        assert val.value_p1.as_volts() == volt_phases[0]
-        assert val.value_p2.as_volts() == volt_phases[1]
-        assert val.value_p3.as_volts() == volt_phases[2]
-
-    await mockgrid.cleanup()
+            val = await voltage_recv.receive()
+            assert val is not None
+            assert val.value_p1 and val.value_p2 and val.value_p3
+            assert val.value_p1.as_volts() == volt_phases[0]
+            assert val.value_p2.as_volts() == volt_phases[1]
+            assert val.value_p3.as_volts() == volt_phases[2]
 
 
 async def test_voltage_3(mocker: MockerFixture) -> None:
     """Test the phase-to-neutral voltage with None values."""
-    mockgrid = MockMicrogrid(grid_meter=True)
+    mockgrid = MockMicrogrid(grid_meter=True, mocker=mocker)
     mockgrid.add_batteries(2, no_meter=False)
-    await mockgrid.start(mocker)
 
-    voltage = microgrid.voltage()
-    voltage_recv = voltage.new_receiver()
+    async with mockgrid:
+        voltage = microgrid.voltage()
+        voltage_recv = voltage.new_receiver()
 
-    assert voltage._task is not None
-    # Wait for voltage requests to be sent, one request per phase.
-    await asyncio.sleep(0)
-    await asyncio.sleep(0)
-    await asyncio.sleep(0)
+        assert voltage._task is not None
+        # Wait for voltage requests to be sent, one request per phase.
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
 
-    for count in range(10):
-        volt_delta = 1 if count % 2 == 0 else -1
-        volt_phases: list[float | None] = [
-            220.0 * volt_delta,
-            219.8 * volt_delta,
-            220.2 * volt_delta,
-        ]
+        for count in range(10):
+            volt_delta = 1 if count % 2 == 0 else -1
+            volt_phases: list[float | None] = [
+                220.0 * volt_delta,
+                219.8 * volt_delta,
+                220.2 * volt_delta,
+            ]
 
-        await mockgrid.mock_resampler.send_meter_voltage(
-            [volt_phases, [None, None, None], [None, 219.8, 220.2]]
-        )
+            await mockgrid.mock_resampler.send_meter_voltage(
+                [volt_phases, [None, None, None], [None, 219.8, 220.2]]
+            )
 
-        val = await voltage_recv.receive()
-        assert val is not None
-        assert val.value_p1 and val.value_p2 and val.value_p3
-        assert val.value_p1.as_volts() == volt_phases[0]
-        assert val.value_p2.as_volts() == volt_phases[1]
-        assert val.value_p3.as_volts() == volt_phases[2]
-
-    await mockgrid.cleanup()
+            val = await voltage_recv.receive()
+            assert val is not None
+            assert val.value_p1 and val.value_p2 and val.value_p3
+            assert val.value_p1.as_volts() == volt_phases[0]
+            assert val.value_p2.as_volts() == volt_phases[1]
+            assert val.value_p3.as_volts() == volt_phases[2]


### PR DESCRIPTION
- Remove some duplicate checks from pylint
- Make Mocks private to the module
- Import module from `typing`
- Allow passing the mocker in the constructor
- Make `MockMicrogrid` an async context manager
- Use the `MockMicrogrid` as an async context manager
- Improve finalization of power distributing tests
- Improve finalization of voltage streamer tests
- Improve finalization of logical meter tests
- Improve finalization of formula formatter tests
- Improve finalization of EV charger pool tests
- Improve finalization of formula composition tests
- Improve finalization of battery status tests
- Improve finalization of grid tests
- Disable pylint check only in one line
