### PR TITLE
Bump frequenz-api-microgrid to 0.15.3

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -108,3 +108,7 @@
 - The PowerManager no longer holds on to proposals from dead actors forever.  If an actor hasn't sent a new proposal in 60 seconds, the available proposal from that actor is dropped.
 
 - Fix `Quantity.__format__()` sometimes skipping the number for very small values.
+
+- Not strictly a bug fix, but the microgrid API version was bumped to v0.15.3, which indirectly bumps the common API dependency to v0.5.x, so the SDK can be compatible with other APIs using a newer version of the common API.
+
+  Downstream projects that require a `frequenz-api-common` v0.5.x and want to ensure proper dependency resolution should update their minimum SDK version to this release.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 ]
 requires-python = ">= 3.11, < 4"
 dependencies = [
-  "frequenz-api-microgrid >= 0.15.1, < 0.16.0",
+  "frequenz-api-microgrid >= 0.15.3, < 0.16.0",
   # Make sure to update the mkdocs.yml file when
   # changing the version
   # (plugins.mkdocstrings.handlers.python.import)


### PR DESCRIPTION
This is only to indirectly bump the api-common dependency to 0.5.x so it is compatible with other APIs.
