### PR TITLE
Remove unused type stubs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,12 +74,7 @@ dev-mypy = [
   "mypy == 1.8.0",
   "grpc-stubs == 1.24.12",               # This dependency introduces breaking changes in patch releases
   "types-Markdown == 3.5.0.3",
-  "types-PyYAML == 6.0.12.12",
-  "types-Pygments == 2.17.0.0",
-  "types-colorama == 0.4.15.12",
   "types-protobuf == 4.24.0.20240129",
-  "types-python-dateutil == 2.8.19.14",
-  "types-pytz == 2023.3.1.1",
   "types-setuptools == 69.0.0.20240125",
   # For checking the noxfile, docs/ script, and tests
   "frequenz-sdk[dev-mkdocs,dev-noxfile,dev-pytest]",


### PR DESCRIPTION
These stubs were probably added to the project when we were using some dependencies that were removed or replaced. We can safely remove these type stubs now.
