### PR TITLE
Remove unnecessary send adapter

### DIFF
--- a/src/frequenz/sdk/actor/_resampling.py
+++ b/src/frequenz/sdk/actor/_resampling.py
@@ -87,10 +87,7 @@ class ComponentMetricsResamplingActor(Actor):
             Sample[Quantity], request_channel_name
         ).new_sender()
 
-        async def sink_adapter(sample: Sample[Quantity]) -> None:
-            await sender.send(sample)
-
-        self._resampler.add_timeseries(request_channel_name, receiver, sink_adapter)
+        self._resampler.add_timeseries(request_channel_name, receiver, sender.send)
 
     async def _process_resampling_requests(self) -> None:
         """Process resampling data requests."""


### PR DESCRIPTION
In previous versions of the `channels` library, the `send()` method returned `bool` to indicate if the send was succesful or not. Recent versions use exception to report errors and return `None`, making the `send()` method directly compatible with what the resampler expects, so we don't need an adapter any more.
