### PR TITLE
Update minimum versions for many dependencies

### DIFF
--- a/benchmarks/timeseries/benchmark_ringbuffer.py
+++ b/benchmarks/timeseries/benchmark_ringbuffer.py
@@ -174,14 +174,14 @@ def main() -> None:
         "Time to fill 29 days with data:\n\t"
         + f"Array: {array_times['fill']} seconds\n\t"
         + f"List:  {list_times['fill']} seconds\n\t"
-        + f"Diff:  {array_times['fill'] -  list_times['fill']}"
+        + f"Diff:  {array_times['fill'] - list_times['fill']}"
     )
 
     print(
         "Day-Slices into 29 days with data:\n\t"
         + f"Array: {array_times['test']/num_runs} seconds\n\t"
         + f"List:  {list_times['test']/num_runs} seconds\n\t"
-        + f"Diff:  {array_times['test']/num_runs -  list_times['test']/num_runs}"
+        + f"Diff:  {array_times['test']/num_runs - list_times['test']/num_runs}"
     )
 
     print(f"       {''.join(['='] * (num_runs + 1))}")
@@ -195,7 +195,7 @@ def main() -> None:
         "Avg of windows of 29 days and running average & mean on every day:\n\t"
         + f"Array: {slicing_array_times['avg']/num_runs} seconds\n\t"
         + f"List:  {slicing_list_times['avg']/num_runs} seconds\n\t"
-        + f"Diff:  {slicing_array_times['avg']/num_runs -  slicing_list_times['avg']/num_runs}"
+        + f"Diff:  {slicing_array_times['avg']/num_runs - slicing_list_times['avg']/num_runs}"
     )
 
     print(
@@ -203,7 +203,7 @@ def main() -> None:
         + f"Array: {slicing_array_times['median']/num_runs} seconds\n\t"
         + f"List:  {slicing_list_times['median']/num_runs} seconds\n\t"
         + "Diff:  "
-        + f"{slicing_array_times['median']/num_runs -  slicing_list_times['median']/num_runs}"
+        + f"{slicing_array_times['median']/num_runs - slicing_list_times['median']/num_runs}"
     )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,17 +31,17 @@ dependencies = [
   # changing the version
   # (plugins.mkdocstrings.handlers.python.import)
   "frequenz-channels == 1.0.0b2",
-  "google-api-python-client >= 2.71, < 3",
-  "grpcio >= 1.54.2, < 2",
-  "grpcio-tools >= 1.54.2, < 2",
-  "networkx >= 2.8, < 4",
-  "numpy >= 1.24.2, < 2",
-  "protobuf >= 4.21.6, < 5",
-  "pydantic >= 2.3, < 3",
-  "timezonefinder >= 6.2.0, < 7",
+  "google-api-python-client >= 2.119.0, < 3",
+  "grpcio >= 1.62.0, < 2",
+  "grpcio-tools >= 1.62.0, < 2",
+  "networkx >= 3.2.1, < 4",
+  "numpy >= 1.26.4, < 2",
+  "protobuf >= 4.25.3, < 5",
+  "pydantic >= 2.6.2, < 3",
+  "timezonefinder >= 6.4.1, < 7",
   "tqdm >= 4.38.0, < 5",
-  "typing_extensions >= 4.6.1, < 5",
-  "watchfiles >= 0.15.0",
+  "typing_extensions >= 4.10.0, < 5",
+  "watchfiles >= 0.21.0",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
This can be merged after v1-rc5, so that we'll have some more time to look for issues.

| dependency               | from   | to      |
|--------------------------|--------|---------|
| google-api-python-client | 2.71   | 2.119.0 |
| grpcio, grpcio-tools     | 1.54.2 | 1.62.0  |
| protobuf                 | 4.21.6 | 4.25.3  |
| networkx                 | 2.8    | 3.2.1   |
| numpy                    | 1.24.2 | 1.26.4  |
| pydantic                 | 2.3    | 2.6.2   |
| timezonefinder           | 6.2.0  | 6.4.1   |
| typing_extensions        | 4.6.1  | 4.10.0  |
| watchfiles               | 0.15.0 | 0.21.0  |
