### PR TITLE
Upgrade channel version to `1.0.0-rc1`

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -8,7 +8,7 @@
 
 - The SDK is now using the microgrid API client from [`frequenz-client-microgrid`](https://github.com/frequenz-floss/frequenz-client-microgrid-python/). You should update your code if you are using the microgrid API client directly.
 
-- The minimum required `frequenz-channels` version is not [`v1.0.0-rc1`](https://github.com/frequenz-floss/frequenz-channels-python/releases/tag/v1.0.0-rc.1).
+- The minimum required `frequenz-channels` version is now [`v1.0.0-rc1`](https://github.com/frequenz-floss/frequenz-channels-python/releases/tag/v1.0.0-rc.1).
 
 ## New Features
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -8,6 +8,8 @@
 
 - The SDK is now using the microgrid API client from [`frequenz-client-microgrid`](https://github.com/frequenz-floss/frequenz-client-microgrid-python/). You should update your code if you are using the microgrid API client directly.
 
+- The minimum required `frequenz-channels` version is not [`v1.0.0-rc1`](https://github.com/frequenz-floss/frequenz-channels-python/releases/tag/v1.0.0-rc.1).
+
 ## New Features
 
 <!-- Here goes the main new features and examples or instructions on how to use them -->

--- a/benchmarks/power_distribution/power_distributor.py
+++ b/benchmarks/power_distribution/power_distributor.py
@@ -111,9 +111,9 @@ async def run_test(  # pylint: disable=too-many-locals
     """
     start = timeit.default_timer()
 
-    power_request_channel = Broadcast[Request]("power-request")
-    battery_status_channel = Broadcast[ComponentPoolStatus]("battery-status")
-    power_result_channel = Broadcast[Result]("power-result")
+    power_request_channel = Broadcast[Request](name="power-request")
+    battery_status_channel = Broadcast[ComponentPoolStatus](name="battery-status")
+    power_result_channel = Broadcast[Result](name="power-result")
     async with PowerDistributingActor(
         requests_receiver=power_request_channel.new_receiver(),
         results_sender=power_result_channel.new_sender(),

--- a/benchmarks/timeseries/benchmark_datasourcing.py
+++ b/benchmarks/timeseries/benchmark_datasourcing.py
@@ -83,7 +83,7 @@ async def benchmark_data_sourcing(
     channel_registry = ChannelRegistry(name="Microgrid Channel Registry")
     request_receiver = request_channel.new_receiver(
         name="datasourcing-benchmark",
-        maxsize=(num_ev_chargers * len(COMPONENT_METRIC_IDS)),
+        limit=(num_ev_chargers * len(COMPONENT_METRIC_IDS)),
     )
     request_sender = request_channel.new_sender()
 

--- a/benchmarks/timeseries/benchmark_datasourcing.py
+++ b/benchmarks/timeseries/benchmark_datasourcing.py
@@ -77,12 +77,13 @@ async def benchmark_data_sourcing(
     mock_grid.start_mock_client(enable_mock_client)
 
     request_channel = Broadcast[ComponentMetricRequest](
-        "DataSourcingActor Request Channel"
+        name="DataSourcingActor Request Channel"
     )
 
     channel_registry = ChannelRegistry(name="Microgrid Channel Registry")
     request_receiver = request_channel.new_receiver(
-        "datasourcing-benchmark", maxsize=(num_ev_chargers * len(COMPONENT_METRIC_IDS))
+        name="datasourcing-benchmark",
+        maxsize=(num_ev_chargers * len(COMPONENT_METRIC_IDS)),
     )
     request_sender = request_channel.new_sender()
 

--- a/benchmarks/timeseries/periodic_feature_extractor.py
+++ b/benchmarks/timeseries/periodic_feature_extractor.py
@@ -33,7 +33,7 @@ async def init_feature_extractor(
 ) -> collections.abc.AsyncIterator[PeriodicFeatureExtractor]:
     """Initialize the PeriodicFeatureExtractor class."""
     # We only need the moving window to initialize the PeriodicFeatureExtractor class.
-    lm_chan = Broadcast[Sample[Quantity]]("lm_net_power")
+    lm_chan = Broadcast[Sample[Quantity]](name="lm_net_power")
     async with MovingWindow(
         timedelta(seconds=1), lm_chan.new_receiver(), timedelta(seconds=1)
     ) as moving_window:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,8 +30,8 @@ dependencies = [
   # Make sure to update the mkdocs.yml file when
   # changing the version
   # (plugins.mkdocstrings.handlers.python.import)
-  "frequenz-channels == 1.0.0b2",
-  "frequenz-client-microgrid >= 0.1.2, < 0.2.0",
+  "frequenz-channels == 1.0.0-rc1",
+  "frequenz-client-microgrid >= 0.2.0, < 0.3.0",
   "google-api-python-client >= 2.71, < 3",
   "grpcio >= 1.54.2, < 2",
   "grpcio-tools >= 1.54.2, < 2",

--- a/src/frequenz/sdk/_internal/_channels.py
+++ b/src/frequenz/sdk/_internal/_channels.py
@@ -9,14 +9,14 @@ import typing
 
 from frequenz.channels import Receiver
 
-T = typing.TypeVar("T")
+T_co = typing.TypeVar("T_co", covariant=True)
 
 
-class ReceiverFetcher(typing.Generic[T], typing.Protocol):
+class ReceiverFetcher(typing.Generic[T_co], typing.Protocol):
     """An interface that just exposes a `new_receiver` method."""
 
     @abc.abstractmethod
-    def new_receiver(self, *, maxsize: int = 50) -> Receiver[T]:
+    def new_receiver(self, *, maxsize: int = 50) -> Receiver[T_co]:
         """Get a receiver from the channel.
 
         Args:
@@ -31,20 +31,20 @@ class _Sentinel:
     """A sentinel to denote that no value has been received yet."""
 
 
-class LatestValueCache(typing.Generic[T]):
+class LatestValueCache(typing.Generic[T_co]):
     """A cache that stores the latest value in a receiver."""
 
-    def __init__(self, receiver: Receiver[T]) -> None:
+    def __init__(self, receiver: Receiver[T_co]) -> None:
         """Create a new cache.
 
         Args:
             receiver: The receiver to cache.
         """
         self._receiver = receiver
-        self._latest_value: T | _Sentinel = _Sentinel()
+        self._latest_value: T_co | _Sentinel = _Sentinel()
         self._task = asyncio.create_task(self._run())
 
-    def get(self) -> T:
+    def get(self) -> T_co:
         """Return the latest value that has been received.
 
         This raises a `ValueError` if no value has been received yet. Use `has_value` to

--- a/src/frequenz/sdk/actor/_channel_registry.py
+++ b/src/frequenz/sdk/actor/_channel_registry.py
@@ -98,7 +98,9 @@ class ChannelRegistry:
                     message_type,
                     "".join(traceback.format_stack(limit=10)[:9]),
                 )
-            self._channels[key] = _Entry(message_type, Broadcast(f"{self._name}-{key}"))
+            self._channels[key] = _Entry(
+                message_type, Broadcast(name=f"{self._name}-{key}")
+            )
 
         entry = self._channels[key]
         if entry.message_type is not message_type:

--- a/src/frequenz/sdk/actor/_config_managing.py
+++ b/src/frequenz/sdk/actor/_config_managing.py
@@ -10,7 +10,7 @@ from collections import abc
 from typing import Any, assert_never
 
 from frequenz.channels import Sender
-from frequenz.channels.file_watcher import FileWatcher
+from frequenz.channels.file_watcher import EventType, FileWatcher
 
 from ..actor._actor import Actor
 from ..config import Config
@@ -34,7 +34,7 @@ class ConfigManagingActor(Actor):
         self,
         config_path: pathlib.Path | str,
         output: Sender[Config],
-        event_types: abc.Set[FileWatcher.EventType] = frozenset(FileWatcher.EventType),
+        event_types: abc.Set[EventType] = frozenset(EventType),
         *,
         name: str | None = None,
     ) -> None:
@@ -99,21 +99,21 @@ class ConfigManagingActor(Actor):
                 continue
 
             match event.type:
-                case FileWatcher.EventType.CREATE:
+                case EventType.CREATE:
                     _logger.info(
                         "%s: The configuration file %s was created, sending new config...",
                         self,
                         self._config_path,
                     )
                     await self.send_config()
-                case FileWatcher.EventType.MODIFY:
+                case EventType.MODIFY:
                     _logger.info(
                         "%s: The configuration file %s was modified, sending update...",
                         self,
                         self._config_path,
                     )
                     await self.send_config()
-                case FileWatcher.EventType.DELETE:
+                case EventType.DELETE:
                     _logger.info(
                         "%s: The configuration file %s was deleted, ignoring...",
                         self,

--- a/src/frequenz/sdk/actor/_config_managing.py
+++ b/src/frequenz/sdk/actor/_config_managing.py
@@ -10,7 +10,7 @@ from collections import abc
 from typing import Any, assert_never
 
 from frequenz.channels import Sender
-from frequenz.channels.util import FileWatcher
+from frequenz.channels.file_watcher import FileWatcher
 
 from ..actor._actor import Actor
 from ..config import Config

--- a/src/frequenz/sdk/actor/_power_managing/_power_managing_actor.py
+++ b/src/frequenz/sdk/actor/_power_managing/_power_managing_actor.py
@@ -195,7 +195,7 @@ class PowerManagingActor(Actor):
             drop_old_proposals_timer,
         ):
             if selected_from(selected, self._proposals_receiver):
-                proposal = selected.value
+                proposal = selected.message
                 if proposal.component_ids not in self._bound_tracker_tasks:
                     self._add_bounds_tracker(proposal.component_ids)
 
@@ -214,7 +214,7 @@ class PowerManagingActor(Actor):
                 await self._send_reports(proposal.component_ids)
 
             elif selected_from(selected, self._bounds_subscription_receiver):
-                sub = selected.value
+                sub = selected.message
                 component_ids = sub.component_ids
                 priority = sub.priority
 
@@ -239,7 +239,7 @@ class PowerManagingActor(Actor):
                     power_distributing,
                 )
 
-                result = selected.value
+                result = selected.message
                 self._distribution_results[frozenset(result.request.component_ids)] = (
                     result
                 )

--- a/src/frequenz/sdk/actor/_power_managing/_power_managing_actor.py
+++ b/src/frequenz/sdk/actor/_power_managing/_power_managing_actor.py
@@ -10,8 +10,8 @@ import logging
 import typing
 from datetime import datetime, timedelta, timezone
 
-from frequenz.channels import Receiver, Sender
-from frequenz.channels.util import SkipMissedAndDrift, Timer, select, selected_from
+from frequenz.channels import Receiver, Sender, select, selected_from
+from frequenz.channels.timer import SkipMissedAndDrift, Timer
 from frequenz.client.microgrid import ComponentCategory
 from typing_extensions import override
 

--- a/src/frequenz/sdk/actor/power_distributing/_component_pool_status_tracker.py
+++ b/src/frequenz/sdk/actor/power_distributing/_component_pool_status_tracker.py
@@ -65,7 +65,7 @@ class ComponentPoolStatusTracker:
 
         # Channel for sending results of requests to the components.
         self._set_power_result_channel = Broadcast[SetPowerResult](
-            "component_request_status"
+            name="component_request_status"
         )
         self._set_power_result_sender = self._set_power_result_channel.new_sender()
         self._component_status_trackers: list[ComponentStatusTracker] = []
@@ -92,7 +92,7 @@ class ComponentPoolStatusTracker:
 
         for component_id in self._component_ids:
             channel: Broadcast[ComponentStatus] = Broadcast(
-                f"component_{component_id}_status"
+                name=f"component_{component_id}_status"
             )
             tracker = self._component_status_tracker_type(
                 component_id=component_id,

--- a/src/frequenz/sdk/actor/power_distributing/_component_pool_status_tracker.py
+++ b/src/frequenz/sdk/actor/power_distributing/_component_pool_status_tracker.py
@@ -10,8 +10,7 @@ import logging
 from collections import abc
 from datetime import timedelta
 
-from frequenz.channels import Broadcast, Receiver, Sender
-from frequenz.channels.util import Merge
+from frequenz.channels import Broadcast, Merger, Receiver, Sender, merge
 
 from ..._internal._asyncio import cancel_and_await
 from ._component_status import (
@@ -88,7 +87,7 @@ class ComponentPoolStatusTracker:
 
     def _make_merged_status_receiver(
         self,
-    ) -> Merge[ComponentStatus]:
+    ) -> Merger[ComponentStatus]:
         status_receivers: list[Receiver[ComponentStatus]] = []
 
         for component_id in self._component_ids:
@@ -104,7 +103,7 @@ class ComponentPoolStatusTracker:
             )
             self._component_status_trackers.append(tracker)
             status_receivers.append(channel.new_receiver())
-        return Merge(*status_receivers)
+        return merge(*status_receivers)
 
     async def _run(self) -> None:
         """Start tracking component status."""

--- a/src/frequenz/sdk/actor/power_distributing/_component_status/_battery_status_tracker.py
+++ b/src/frequenz/sdk/actor/power_distributing/_component_status/_battery_status_tracker.py
@@ -28,8 +28,8 @@ from frequenz.api.microgrid.common_pb2 import ErrorLevel
 from frequenz.api.microgrid.inverter_pb2 import ComponentState as InverterComponentState
 
 # pylint: enable=no-name-in-module
-from frequenz.channels import Receiver, Sender
-from frequenz.channels.util import Timer, select, selected_from
+from frequenz.channels import Receiver, Sender, select, selected_from
+from frequenz.channels.timer import Timer
 from frequenz.client.microgrid import (
     BatteryData,
     ComponentCategory,

--- a/src/frequenz/sdk/actor/power_distributing/_component_status/_battery_status_tracker.py
+++ b/src/frequenz/sdk/actor/power_distributing/_component_status/_battery_status_tracker.py
@@ -277,13 +277,13 @@ class BatteryStatusTracker(ComponentStatusTracker, BackgroundService):
                     new_status = None
 
                     if selected_from(selected, battery):
-                        self._handle_status_battery(selected.value)
+                        self._handle_status_battery(selected.message)
 
                     elif selected_from(selected, inverter):
-                        self._handle_status_inverter(selected.value)
+                        self._handle_status_inverter(selected.message)
 
                     elif selected_from(selected, set_power_result):
-                        self._handle_status_set_power_result(selected.value)
+                        self._handle_status_set_power_result(selected.message)
 
                     elif selected_from(selected, battery_timer):
                         if (

--- a/src/frequenz/sdk/actor/power_distributing/_component_status/_battery_status_tracker.py
+++ b/src/frequenz/sdk/actor/power_distributing/_component_status/_battery_status_tracker.py
@@ -29,7 +29,7 @@ from frequenz.api.microgrid.inverter_pb2 import ComponentState as InverterCompon
 
 # pylint: enable=no-name-in-module
 from frequenz.channels import Receiver, Sender, select, selected_from
-from frequenz.channels.timer import Timer
+from frequenz.channels.timer import SkipMissedAndDrift, Timer
 from frequenz.client.microgrid import (
     BatteryData,
     ComponentCategory,
@@ -147,11 +147,11 @@ class BatteryStatusTracker(ComponentStatusTracker, BackgroundService):
 
         self._battery: _ComponentStreamStatus = _ComponentStreamStatus(
             component_id,
-            data_recv_timer=Timer.timeout(max_data_age),
+            data_recv_timer=Timer(max_data_age, SkipMissedAndDrift()),
         )
         self._inverter: _ComponentStreamStatus = _ComponentStreamStatus(
             inverter_id,
-            data_recv_timer=Timer.timeout(max_data_age),
+            data_recv_timer=Timer(max_data_age, SkipMissedAndDrift()),
         )
 
         # Select needs receivers that can be get in async way only.

--- a/src/frequenz/sdk/microgrid/_data_pipeline.py
+++ b/src/frequenz/sdk/microgrid/_data_pipeline.py
@@ -259,7 +259,7 @@ class _DataPipeline:  # pylint: disable=too-many-instance-attributes
 
         if self._data_sourcing_actor is None:
             channel: Broadcast[ComponentMetricRequest] = Broadcast(
-                "Data Pipeline: Data Sourcing Actor Request Channel"
+                name="Data Pipeline: Data Sourcing Actor Request Channel"
             )
             actor = DataSourcingActor(
                 request_receiver=channel.new_receiver(
@@ -283,7 +283,7 @@ class _DataPipeline:  # pylint: disable=too-many-instance-attributes
 
         if self._resampling_actor is None:
             channel: Broadcast[ComponentMetricRequest] = Broadcast(
-                "Data Pipeline: Component Metric Resampling Actor Request Channel"
+                name="Data Pipeline: Component Metric Resampling Actor Request Channel"
             )
             actor = ComponentMetricsResamplingActor(
                 channel_registry=self._channel_registry,

--- a/src/frequenz/sdk/microgrid/_data_pipeline.py
+++ b/src/frequenz/sdk/microgrid/_data_pipeline.py
@@ -233,7 +233,7 @@ class _DataPipeline:  # pylint: disable=too-many-instance-attributes
                 channel_registry=self._channel_registry,
                 resampler_subscription_sender=self._resampling_request_sender(),
                 batteries_status_receiver=self._battery_power_wrapper.status_channel.new_receiver(
-                    maxsize=1
+                    limit=1
                 ),
                 power_manager_requests_sender=(
                     self._battery_power_wrapper.proposal_channel.new_sender()
@@ -262,9 +262,7 @@ class _DataPipeline:  # pylint: disable=too-many-instance-attributes
                 name="Data Pipeline: Data Sourcing Actor Request Channel"
             )
             actor = DataSourcingActor(
-                request_receiver=channel.new_receiver(
-                    maxsize=_REQUEST_RECV_BUFFER_SIZE
-                ),
+                request_receiver=channel.new_receiver(limit=_REQUEST_RECV_BUFFER_SIZE),
                 registry=self._channel_registry,
             )
             self._data_sourcing_actor = _ActorInfo(actor, channel)
@@ -289,7 +287,7 @@ class _DataPipeline:  # pylint: disable=too-many-instance-attributes
                 channel_registry=self._channel_registry,
                 data_sourcing_request_sender=self._data_sourcing_request_sender(),
                 resampling_request_receiver=channel.new_receiver(
-                    maxsize=_REQUEST_RECV_BUFFER_SIZE
+                    limit=_REQUEST_RECV_BUFFER_SIZE
                 ),
                 config=self._resampler_config,
             )

--- a/src/frequenz/sdk/microgrid/_power_wrapper.py
+++ b/src/frequenz/sdk/microgrid/_power_wrapper.py
@@ -43,20 +43,20 @@ class PowerWrapper:
         self._channel_registry = channel_registry
 
         self.status_channel: Broadcast[ComponentPoolStatus] = Broadcast(
-            "Component Status Channel", resend_latest=True
+            name="Component Status Channel", resend_latest=True
         )
         self._power_distribution_requests_channel: Broadcast[Request] = Broadcast(
-            "Power Distributing Actor, Requests Broadcast Channel"
+            name="Power Distributing Actor, Requests Broadcast Channel"
         )
         self._power_distribution_results_channel: Broadcast[Result] = Broadcast(
-            "Power Distributing Actor, Results Broadcast Channel"
+            name="Power Distributing Actor, Results Broadcast Channel"
         )
 
         self.proposal_channel: Broadcast[_power_managing.Proposal] = Broadcast(
-            "Power Managing Actor, Requests Broadcast Channel"
+            name="Power Managing Actor, Requests Broadcast Channel"
         )
         self.bounds_subscription_channel: Broadcast[_power_managing.ReportRequest] = (
-            Broadcast("Power Managing Actor, Bounds Subscription Channel")
+            Broadcast(name="Power Managing Actor, Bounds Subscription Channel")
         )
 
         self._power_distributing_actor: PowerDistributingActor | None = None

--- a/src/frequenz/sdk/timeseries/_moving_window.py
+++ b/src/frequenz/sdk/timeseries/_moving_window.py
@@ -65,7 +65,7 @@ class MovingWindow(BackgroundService):
                 await asyncio.sleep(1.0)
 
         async def run() -> None:
-            resampled_data_channel = Broadcast[Sample]("sample-data")
+            resampled_data_channel = Broadcast[Sample](name="sample-data")
             resampled_data_receiver = resampled_data_channel.new_receiver()
             resampled_data_sender = resampled_data_channel.new_sender()
 
@@ -102,7 +102,7 @@ class MovingWindow(BackgroundService):
                 await asyncio.sleep(1.0)
 
         async def run() -> None:
-            resampled_data_channel = Broadcast[Sample]("sample-data")
+            resampled_data_channel = Broadcast[Sample](name="sample-data")
             resampled_data_receiver = resampled_data_channel.new_receiver()
             resampled_data_sender = resampled_data_channel.new_sender()
 
@@ -345,7 +345,7 @@ class MovingWindow(BackgroundService):
             if sample.value is not None:
                 self._buffer.update(sample)
 
-        resampler_channel = Broadcast[Sample[Quantity]]("average")
+        resampler_channel = Broadcast[Sample[Quantity]](name="average")
         self._resampler_sender = resampler_channel.new_sender()
         self._resampler.add_timeseries(
             "avg", resampler_channel.new_receiver(), sink_buffer

--- a/src/frequenz/sdk/timeseries/_resampling.py
+++ b/src/frequenz/sdk/timeseries/_resampling.py
@@ -16,8 +16,7 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from typing import cast
 
-from frequenz.channels.util import Timer
-from frequenz.channels.util._timer import _to_microseconds
+from frequenz.channels.timer import Timer, _to_microseconds
 
 from .._internal._asyncio import cancel_and_await
 from ._base_types import UNIX_EPOCH, Sample

--- a/src/frequenz/sdk/timeseries/_resampling.py
+++ b/src/frequenz/sdk/timeseries/_resampling.py
@@ -16,7 +16,7 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from typing import cast
 
-from frequenz.channels.timer import Timer, _to_microseconds
+from frequenz.channels.timer import Timer, TriggerAllMissed, _to_microseconds
 
 from .._internal._asyncio import cancel_and_await
 from ._base_types import UNIX_EPOCH, Sample
@@ -384,7 +384,7 @@ class Resampler:
         the window end is deterministic.
         """
 
-        self._timer: Timer = Timer.periodic(config.resampling_period)
+        self._timer: Timer = Timer(config.resampling_period, TriggerAllMissed())
         """The timer used to trigger the resampling windows."""
 
         # Hack to align the timer, this should be implemented in the Timer class

--- a/src/frequenz/sdk/timeseries/battery_pool/_methods.py
+++ b/src/frequenz/sdk/timeseries/battery_pool/_methods.py
@@ -130,7 +130,7 @@ class SendOnUpdate(MetricAggregator[T]):
         """
         if maxsize is None:
             return self._result_channel.new_receiver()
-        return self._result_channel.new_receiver(maxsize=maxsize)
+        return self._result_channel.new_receiver(limit=maxsize)
 
     def update_working_batteries(self, new_working_batteries: set[int]) -> None:
         """Update set of the working batteries.

--- a/src/frequenz/sdk/timeseries/ev_charger_pool/_ev_charger_pool.py
+++ b/src/frequenz/sdk/timeseries/ev_charger_pool/_ev_charger_pool.py
@@ -202,7 +202,7 @@ class EVChargerPool:
             _logger.warning("Restarting component_status for id: %s", component_id)
         else:
             output_chan = Broadcast[EVChargerData](
-                f"evpool-component_status-{component_id}"
+                name=f"evpool-component_status-{component_id}"
             )
 
         task = asyncio.create_task(

--- a/src/frequenz/sdk/timeseries/ev_charger_pool/_set_current_bounds.py
+++ b/src/frequenz/sdk/timeseries/ev_charger_pool/_set_current_bounds.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 from datetime import timedelta
 
 from frequenz.channels import Broadcast, Sender, select, selected_from
-from frequenz.channels.timer import Timer
+from frequenz.channels.timer import SkipMissedAndDrift, Timer
 from frequenz.client.microgrid import ComponentCategory
 
 from ..._internal._asyncio import cancel_and_await
@@ -100,7 +100,9 @@ class BoundsSetter:
         latest_bound: dict[int, ComponentCurrentLimit] = {}
 
         bound_chan = self._bounds_rx
-        timer = Timer.timeout(timedelta(self._repeat_interval.total_seconds()))
+        timer = Timer(
+            timedelta(self._repeat_interval.total_seconds()), SkipMissedAndDrift()
+        )
 
         async for selected in select(bound_chan, timer):
             meter = meter_data.get()

--- a/src/frequenz/sdk/timeseries/ev_charger_pool/_set_current_bounds.py
+++ b/src/frequenz/sdk/timeseries/ev_charger_pool/_set_current_bounds.py
@@ -110,7 +110,7 @@ class BoundsSetter:
                 raise ValueError("Meter channel closed.")
 
             if selected_from(selected, bound_chan):
-                bound: ComponentCurrentLimit = selected.value
+                bound: ComponentCurrentLimit = selected.message
                 if (
                     bound.component_id in latest_bound
                     and latest_bound[bound.component_id] == bound

--- a/src/frequenz/sdk/timeseries/ev_charger_pool/_set_current_bounds.py
+++ b/src/frequenz/sdk/timeseries/ev_charger_pool/_set_current_bounds.py
@@ -50,7 +50,9 @@ class BoundsSetter:
         self._repeat_interval = repeat_interval
 
         self._task: asyncio.Task[None] = asyncio.create_task(self._run())
-        self._bounds_chan: Broadcast[ComponentCurrentLimit] = Broadcast("BoundsSetter")
+        self._bounds_chan: Broadcast[ComponentCurrentLimit] = Broadcast(
+            name="BoundsSetter"
+        )
         self._bounds_rx = self._bounds_chan.new_receiver()
         self._bounds_tx = self._bounds_chan.new_sender()
 

--- a/src/frequenz/sdk/timeseries/ev_charger_pool/_set_current_bounds.py
+++ b/src/frequenz/sdk/timeseries/ev_charger_pool/_set_current_bounds.py
@@ -8,8 +8,8 @@ import logging
 from dataclasses import dataclass
 from datetime import timedelta
 
-from frequenz.channels import Broadcast, Sender
-from frequenz.channels.util import Timer, select, selected_from
+from frequenz.channels import Broadcast, Sender, select, selected_from
+from frequenz.channels.timer import Timer
 from frequenz.client.microgrid import ComponentCategory
 
 from ..._internal._asyncio import cancel_and_await

--- a/src/frequenz/sdk/timeseries/ev_charger_pool/_state_tracker.py
+++ b/src/frequenz/sdk/timeseries/ev_charger_pool/_state_tracker.py
@@ -8,8 +8,7 @@ from __future__ import annotations
 import asyncio
 from enum import Enum
 
-from frequenz.channels import Receiver
-from frequenz.channels.util import Merge
+from frequenz.channels import Merger, Receiver, merge
 from frequenz.client.microgrid import (
     EVChargerCableState,
     EVChargerComponentState,
@@ -87,7 +86,7 @@ class StateTracker:
         """
         self._component_ids = component_ids
         self._task: asyncio.Task[None] = asyncio.create_task(self._run())
-        self._merged_stream: Merge[EVChargerData] | None = None
+        self._merged_stream: Merger[EVChargerData] | None = None
 
         # Initialize all components to the `MISSING` state.  This will change as data
         # starts arriving from the individual components.
@@ -124,7 +123,7 @@ class StateTracker:
         streams: list[Receiver[EVChargerData]] = await asyncio.gather(
             *[api_client.ev_charger_data(cid) for cid in self._component_ids]
         )
-        self._merged_stream = Merge(*streams)
+        self._merged_stream = merge(*streams)
         async for data in self._merged_stream:
             self._update(data)
 

--- a/src/frequenz/sdk/timeseries/formula_engine/_formula_engine.py
+++ b/src/frequenz/sdk/timeseries/formula_engine/_formula_engine.py
@@ -310,7 +310,7 @@ class FormulaEngine(
         self._name: str = builder.name
         self._builder: FormulaBuilder[QuantityT] = builder
         self._create_method = create_method
-        self._channel: Broadcast[Sample[QuantityT]] = Broadcast(self._name)
+        self._channel: Broadcast[Sample[QuantityT]] = Broadcast(name=self._name)
 
     @classmethod
     def from_receiver(
@@ -415,7 +415,7 @@ class FormulaEngine(
         if self._task is None:
             self._task = asyncio.create_task(self._run())
 
-        recv = self._channel.new_receiver(name, max_size)
+        recv = self._channel.new_receiver(name=name, max_size)
 
         # This is a hack to ensure that the lifetime of the engine is tied to the
         # lifetime of the receiver.  This is necessary because the engine is a task that
@@ -507,7 +507,7 @@ class FormulaEngine3Phase(
         self._higher_order_builder = HigherOrderFormulaBuilder3Phase
         self._name: str = name
         self._create_method = create_method
-        self._channel: Broadcast[Sample3Phase[QuantityT]] = Broadcast(self._name)
+        self._channel: Broadcast[Sample3Phase[QuantityT]] = Broadcast(name=self._name)
         self._task: asyncio.Task[None] | None = None
         self._streams: tuple[
             FormulaEngine[QuantityT],
@@ -553,7 +553,7 @@ class FormulaEngine3Phase(
         if self._task is None:
             self._task = asyncio.create_task(self._run())
 
-        return self._channel.new_receiver(name, max_size)
+        return self._channel.new_receiver(name=name, max_size)
 
 
 class FormulaBuilder(Generic[QuantityT]):
@@ -570,9 +570,9 @@ class FormulaBuilder(Generic[QuantityT]):
         ```python
         from frequenz.sdk.timeseries import Power
 
-        channel = Broadcast[Sample[Power]]("channel")
-        receiver_1 = channel.new_receiver("receiver_1")
-        receiver_2 = channel.new_receiver("receiver_2")
+        channel = Broadcast[Sample[Power]](name="channel")
+        receiver_1 = channel.new_receiver(name="receiver_1")
+        receiver_2 = channel.new_receiver(name="receiver_2")
         builder = FormulaBuilder("addition", Power)
         builder.push_metric("metric_1", receiver_1, nones_are_zeros=True)
         builder.push_oper("+")
@@ -681,9 +681,9 @@ class FormulaBuilder(Generic[QuantityT]):
         from frequenz.sdk.timeseries import Power
 
         builder = FormulaBuilder("example", Power)
-        channel = Broadcast[Sample[Power]]("channel")
-        receiver_1 = channel.new_receiver("receiver_1")
-        receiver_2 = channel.new_receiver("receiver_2")
+        channel = Broadcast[Sample[Power]](name="channel")
+        receiver_1 = channel.new_receiver(name="receiver_1")
+        receiver_2 = channel.new_receiver(name="receiver_2")
 
         builder.push_oper("(")
         builder.push_metric("metric_1", receiver_1, nones_are_zeros=True)
@@ -699,9 +699,9 @@ class FormulaBuilder(Generic[QuantityT]):
         from frequenz.sdk.timeseries import Power
 
         builder = FormulaBuilder("example", Power)
-        channel = Broadcast[Sample[Power]]("channel")
-        receiver_1 = channel.new_receiver("receiver_1")
-        receiver_2 = channel.new_receiver("receiver_2")
+        channel = Broadcast[Sample[Power]](name="channel")
+        receiver_1 = channel.new_receiver(name="receiver_1")
+        receiver_2 = channel.new_receiver(name="receiver_2")
 
         builder.push_metric("metric_1", receiver_1, nones_are_zeros=True)
         builder.push_oper("+")

--- a/src/frequenz/sdk/timeseries/formula_engine/_formula_engine.py
+++ b/src/frequenz/sdk/timeseries/formula_engine/_formula_engine.py
@@ -415,7 +415,7 @@ class FormulaEngine(
         if self._task is None:
             self._task = asyncio.create_task(self._run())
 
-        recv = self._channel.new_receiver(name=name, max_size)
+        recv = self._channel.new_receiver(name=name, limit=max_size)
 
         # This is a hack to ensure that the lifetime of the engine is tied to the
         # lifetime of the receiver.  This is necessary because the engine is a task that
@@ -553,7 +553,7 @@ class FormulaEngine3Phase(
         if self._task is None:
             self._task = asyncio.create_task(self._run())
 
-        return self._channel.new_receiver(name=name, max_size)
+        return self._channel.new_receiver(name=name, limit=max_size)
 
 
 class FormulaBuilder(Generic[QuantityT]):

--- a/tests/actor/power_distributing/test_power_distributing.py
+++ b/tests/actor/power_distributing/test_power_distributing.py
@@ -179,9 +179,11 @@ class TestPowerDistributingActor:
         mockgrid.add_batteries(1, no_meter=True)
 
         async with mockgrid:
-            requests_channel = Broadcast[Request]("power_distributor requests")
-            results_channel = Broadcast[Result]("power_distributor results")
-            battery_status_channel = Broadcast[ComponentPoolStatus]("battery_status")
+            requests_channel = Broadcast[Request](name="power_distributor requests")
+            results_channel = Broadcast[Result](name="power_distributor results")
+            battery_status_channel = Broadcast[ComponentPoolStatus](
+                name="battery_status"
+            )
             async with PowerDistributingActor(
                 requests_receiver=requests_channel.new_receiver(),
                 results_sender=results_channel.new_sender(),
@@ -206,9 +208,11 @@ class TestPowerDistributingActor:
         mockgrid.add_batteries(2, no_meter=True)
 
         async with mockgrid:
-            requests_channel = Broadcast[Request]("power_distributor requests")
-            results_channel = Broadcast[Result]("power_distributor results")
-            battery_status_channel = Broadcast[ComponentPoolStatus]("battery_status")
+            requests_channel = Broadcast[Request](name="power_distributor requests")
+            results_channel = Broadcast[Result](name="power_distributor results")
+            battery_status_channel = Broadcast[ComponentPoolStatus](
+                name="battery_status"
+            )
             async with PowerDistributingActor(
                 requests_receiver=requests_channel.new_receiver(),
                 results_sender=results_channel.new_sender(),
@@ -259,8 +263,8 @@ class TestPowerDistributingActor:
     async def test_power_distributor_one_user(self, mocker: MockerFixture) -> None:
         """Test if power distribution works with a single user."""
         mocks = await _Mocks.new(mocker)
-        requests_channel = Broadcast[Request]("power_distributor requests")
-        results_channel = Broadcast[Result]("power_distributor results")
+        requests_channel = Broadcast[Request](name="power_distributor requests")
+        results_channel = Broadcast[Result](name="power_distributor results")
 
         request = Request(
             power=Power.from_kilowatts(1.2),
@@ -271,7 +275,7 @@ class TestPowerDistributingActor:
         await self._patch_battery_pool_status(mocks, mocker, request.component_ids)
         await self.init_component_data(mocks)
 
-        battery_status_channel = Broadcast[ComponentPoolStatus]("battery_status")
+        battery_status_channel = Broadcast[ComponentPoolStatus](name="battery_status")
         async with PowerDistributingActor(
             requests_receiver=requests_channel.new_receiver(),
             results_sender=results_channel.new_sender(),
@@ -325,10 +329,12 @@ class TestPowerDistributingActor:
                 0.05,
             )
 
-            requests_channel = Broadcast[Request]("power_distributor requests")
-            results_channel = Broadcast[Result]("power_distributor results")
+            requests_channel = Broadcast[Request](name="power_distributor requests")
+            results_channel = Broadcast[Result](name="power_distributor results")
 
-            battery_status_channel = Broadcast[ComponentPoolStatus]("battery_status")
+            battery_status_channel = Broadcast[ComponentPoolStatus](
+                name="battery_status"
+            )
             async with PowerDistributingActor(
                 requests_receiver=requests_channel.new_receiver(),
                 results_sender=results_channel.new_sender(),
@@ -413,8 +419,8 @@ class TestPowerDistributingActor:
         async with _mocks(mocker, graph=graph) as mocks:
             await self.init_component_data(mocks)
 
-            requests_channel = Broadcast[Request]("power_distributor requests")
-            results_channel = Broadcast[Result]("power_distributor results")
+            requests_channel = Broadcast[Request](name="power_distributor requests")
+            results_channel = Broadcast[Result](name="power_distributor results")
             request = Request(
                 power=Power.from_watts(1200.0),
                 component_ids={
@@ -426,7 +432,9 @@ class TestPowerDistributingActor:
 
             await self._patch_battery_pool_status(mocks, mocker, request.component_ids)
 
-            battery_status_channel = Broadcast[ComponentPoolStatus]("battery_status")
+            battery_status_channel = Broadcast[ComponentPoolStatus](
+                name="battery_status"
+            )
 
             async with PowerDistributingActor(
                 requests_receiver=requests_channel.new_receiver(),
@@ -492,8 +500,8 @@ class TestPowerDistributingActor:
                 0.05,
             )
 
-            requests_channel = Broadcast[Request]("power_distributor")
-            results_channel = Broadcast[Result]("power_distributor results")
+            requests_channel = Broadcast[Request](name="power_distributor")
+            results_channel = Broadcast[Result](name="power_distributor results")
 
             request = Request(
                 power=Power.from_watts(1200.0),
@@ -502,7 +510,9 @@ class TestPowerDistributingActor:
             )
 
             await self._patch_battery_pool_status(mocks, mocker, request.component_ids)
-            battery_status_channel = Broadcast[ComponentPoolStatus]("battery_status")
+            battery_status_channel = Broadcast[ComponentPoolStatus](
+                name="battery_status"
+            )
 
             async with PowerDistributingActor(
                 requests_receiver=requests_channel.new_receiver(),
@@ -544,8 +554,8 @@ class TestPowerDistributingActor:
         async with _mocks(mocker, graph=graph) as mocks:
             await self.init_component_data(mocks)
 
-            requests_channel = Broadcast[Request]("power_distributor requests")
-            results_channel = Broadcast[Result]("power_distributor results")
+            requests_channel = Broadcast[Request](name="power_distributor requests")
+            results_channel = Broadcast[Result](name="power_distributor results")
 
             request = Request(
                 power=Power.from_watts(1200.0),
@@ -554,7 +564,9 @@ class TestPowerDistributingActor:
             )
 
             await self._patch_battery_pool_status(mocks, mocker, request.component_ids)
-            battery_status_channel = Broadcast[ComponentPoolStatus]("battery_status")
+            battery_status_channel = Broadcast[ComponentPoolStatus](
+                name="battery_status"
+            )
 
             async with PowerDistributingActor(
                 requests_receiver=requests_channel.new_receiver(),
@@ -592,8 +604,8 @@ class TestPowerDistributingActor:
         async with _mocks(mocker, graph=graph) as mocks:
             await self.init_component_data(mocks)
 
-            requests_channel = Broadcast[Request]("power_distributor requests")
-            results_channel = Broadcast[Result]("power_distributor results")
+            requests_channel = Broadcast[Request](name="power_distributor requests")
+            results_channel = Broadcast[Result](name="power_distributor results")
 
             request = Request(
                 power=Power.from_watts(1700.0),
@@ -602,7 +614,9 @@ class TestPowerDistributingActor:
             )
 
             await self._patch_battery_pool_status(mocks, mocker, request.component_ids)
-            battery_status_channel = Broadcast[ComponentPoolStatus]("battery_status")
+            battery_status_channel = Broadcast[ComponentPoolStatus](
+                name="battery_status"
+            )
 
             async with PowerDistributingActor(
                 requests_receiver=requests_channel.new_receiver(),
@@ -674,8 +688,8 @@ class TestPowerDistributingActor:
                 0.05,
             )
 
-            requests_channel = Broadcast[Request]("power_distributor requests")
-            results_channel = Broadcast[Result]("power_distributor results")
+            requests_channel = Broadcast[Request](name="power_distributor requests")
+            results_channel = Broadcast[Result](name="power_distributor results")
 
             request = Request(
                 power=Power.from_watts(300.0),
@@ -684,7 +698,9 @@ class TestPowerDistributingActor:
             )
 
             await self._patch_battery_pool_status(mocks, mocker, request.component_ids)
-            battery_status_channel = Broadcast[ComponentPoolStatus]("battery_status")
+            battery_status_channel = Broadcast[ComponentPoolStatus](
+                name="battery_status"
+            )
 
             async with PowerDistributingActor(
                 requests_receiver=requests_channel.new_receiver(),
@@ -757,8 +773,8 @@ class TestPowerDistributingActor:
                 0.05,
             )
 
-            requests_channel = Broadcast[Request]("power_distributor requests")
-            results_channel = Broadcast[Result]("power_distributor results")
+            requests_channel = Broadcast[Request](name="power_distributor requests")
+            results_channel = Broadcast[Result](name="power_distributor results")
 
             request = Request(
                 power=Power.from_watts(300.0),
@@ -767,7 +783,9 @@ class TestPowerDistributingActor:
             )
 
             await self._patch_battery_pool_status(mocks, mocker, request.component_ids)
-            battery_status_channel = Broadcast[ComponentPoolStatus]("battery_status")
+            battery_status_channel = Broadcast[ComponentPoolStatus](
+                name="battery_status"
+            )
 
             async with PowerDistributingActor(
                 requests_receiver=requests_channel.new_receiver(),
@@ -819,8 +837,8 @@ class TestPowerDistributingActor:
         async with _mocks(mocker, graph=graph) as mocks:
             await self.init_component_data(mocks)
 
-            requests_channel = Broadcast[Request]("power_distributor requests")
-            results_channel = Broadcast[Result]("power_distributor results")
+            requests_channel = Broadcast[Request](name="power_distributor requests")
+            results_channel = Broadcast[Result](name="power_distributor results")
 
             request = Request(
                 power=Power.from_watts(600.0),
@@ -829,7 +847,9 @@ class TestPowerDistributingActor:
             )
 
             await self._patch_battery_pool_status(mocks, mocker, request.component_ids)
-            battery_status_channel = Broadcast[ComponentPoolStatus]("battery_status")
+            battery_status_channel = Broadcast[ComponentPoolStatus](
+                name="battery_status"
+            )
 
             async with PowerDistributingActor(
                 requests_receiver=requests_channel.new_receiver(),
@@ -874,8 +894,8 @@ class TestPowerDistributingActor:
                 0.05,
             )
 
-            requests_channel = Broadcast[Request]("power_distributor requests")
-            results_channel = Broadcast[Result]("power_distributor results")
+            requests_channel = Broadcast[Request](name="power_distributor requests")
+            results_channel = Broadcast[Result](name="power_distributor results")
 
             request = Request(
                 power=Power.from_kilowatts(1.2),
@@ -884,7 +904,9 @@ class TestPowerDistributingActor:
             )
 
             await self._patch_battery_pool_status(mocks, mocker, request.component_ids)
-            battery_status_channel = Broadcast[ComponentPoolStatus]("battery_status")
+            battery_status_channel = Broadcast[ComponentPoolStatus](
+                name="battery_status"
+            )
             async with PowerDistributingActor(
                 requests_receiver=requests_channel.new_receiver(),
                 results_sender=results_channel.new_sender(),
@@ -924,8 +946,8 @@ class TestPowerDistributingActor:
                 0.05,
             )
 
-            requests_channel = Broadcast[Request]("power_distributor requests")
-            results_channel = Broadcast[Result]("power_distributor results")
+            requests_channel = Broadcast[Request](name="power_distributor requests")
+            results_channel = Broadcast[Result](name="power_distributor results")
 
             request = Request(
                 power=Power.from_kilowatts(1.2),
@@ -935,7 +957,9 @@ class TestPowerDistributingActor:
 
             await self._patch_battery_pool_status(mocks, mocker, request.component_ids)
 
-            battery_status_channel = Broadcast[ComponentPoolStatus]("battery_status")
+            battery_status_channel = Broadcast[ComponentPoolStatus](
+                name="battery_status"
+            )
             async with PowerDistributingActor(
                 requests_receiver=requests_channel.new_receiver(),
                 results_sender=results_channel.new_sender(),
@@ -994,8 +1018,8 @@ class TestPowerDistributingActor:
                 0.05,
             )
 
-            requests_channel = Broadcast[Request]("power_distributor requests")
-            results_channel = Broadcast[Result]("power_distributor results")
+            requests_channel = Broadcast[Request](name="power_distributor requests")
+            results_channel = Broadcast[Result](name="power_distributor results")
 
             request = Request(
                 power=Power.from_kilowatts(1.2),
@@ -1005,7 +1029,9 @@ class TestPowerDistributingActor:
 
             await self._patch_battery_pool_status(mocks, mocker, request.component_ids)
 
-            battery_status_channel = Broadcast[ComponentPoolStatus]("battery_status")
+            battery_status_channel = Broadcast[ComponentPoolStatus](
+                name="battery_status"
+            )
             async with PowerDistributingActor(
                 requests_receiver=requests_channel.new_receiver(),
                 results_sender=results_channel.new_sender(),
@@ -1037,8 +1063,8 @@ class TestPowerDistributingActor:
         async with _mocks(mocker, grid_meter=False) as mocks:
             await self.init_component_data(mocks)
 
-            requests_channel = Broadcast[Request]("power_distributor requests")
-            results_channel = Broadcast[Result]("power_distributor results")
+            requests_channel = Broadcast[Request](name="power_distributor requests")
+            results_channel = Broadcast[Result](name="power_distributor results")
             request = Request(
                 power=Power.from_kilowatts(1.2),
                 component_ids={9, 100},
@@ -1047,7 +1073,9 @@ class TestPowerDistributingActor:
 
             await self._patch_battery_pool_status(mocks, mocker, request.component_ids)
 
-            battery_status_channel = Broadcast[ComponentPoolStatus]("battery_status")
+            battery_status_channel = Broadcast[ComponentPoolStatus](
+                name="battery_status"
+            )
             async with PowerDistributingActor(
                 requests_receiver=requests_channel.new_receiver(),
                 results_sender=results_channel.new_sender(),
@@ -1076,8 +1104,8 @@ class TestPowerDistributingActor:
         async with _mocks(mocker, grid_meter=False) as mocks:
             await self.init_component_data(mocks)
 
-            requests_channel = Broadcast[Request]("power_distributor")
-            results_channel = Broadcast[Result]("power_distributor results")
+            requests_channel = Broadcast[Request](name="power_distributor")
+            results_channel = Broadcast[Result](name="power_distributor results")
 
             request = Request(
                 power=Power.from_kilowatts(1.2),
@@ -1088,7 +1116,9 @@ class TestPowerDistributingActor:
 
             await self._patch_battery_pool_status(mocks, mocker, request.component_ids)
 
-            battery_status_channel = Broadcast[ComponentPoolStatus]("battery_status")
+            battery_status_channel = Broadcast[ComponentPoolStatus](
+                name="battery_status"
+            )
             async with PowerDistributingActor(
                 requests_receiver=requests_channel.new_receiver(),
                 results_sender=results_channel.new_sender(),
@@ -1119,8 +1149,8 @@ class TestPowerDistributingActor:
         async with _mocks(mocker, grid_meter=False) as mocks:
             await self.init_component_data(mocks)
 
-            requests_channel = Broadcast[Request]("power_distributor requests")
-            results_channel = Broadcast[Result]("power_distributor results")
+            requests_channel = Broadcast[Request](name="power_distributor requests")
+            results_channel = Broadcast[Result](name="power_distributor results")
 
             request = Request(
                 power=-Power.from_kilowatts(1.2),
@@ -1131,7 +1161,9 @@ class TestPowerDistributingActor:
 
             await self._patch_battery_pool_status(mocks, mocker, request.component_ids)
 
-            battery_status_channel = Broadcast[ComponentPoolStatus]("battery_status")
+            battery_status_channel = Broadcast[ComponentPoolStatus](
+                name="battery_status"
+            )
             async with PowerDistributingActor(
                 requests_receiver=requests_channel.new_receiver(),
                 results_sender=results_channel.new_sender(),
@@ -1162,8 +1194,8 @@ class TestPowerDistributingActor:
         async with _mocks(mocker, grid_meter=False) as mocks:
             await self.init_component_data(mocks)
 
-            requests_channel = Broadcast[Request]("power_distributor requests")
-            results_channel = Broadcast[Result]("power_distributor results")
+            requests_channel = Broadcast[Request](name="power_distributor requests")
+            results_channel = Broadcast[Result](name="power_distributor results")
 
             request = Request(
                 power=Power.from_kilowatts(1.0),
@@ -1174,7 +1206,9 @@ class TestPowerDistributingActor:
 
             await self._patch_battery_pool_status(mocks, mocker, request.component_ids)
 
-            battery_status_channel = Broadcast[ComponentPoolStatus]("battery_status")
+            battery_status_channel = Broadcast[ComponentPoolStatus](
+                name="battery_status"
+            )
             async with PowerDistributingActor(
                 requests_receiver=requests_channel.new_receiver(),
                 results_sender=results_channel.new_sender(),
@@ -1207,10 +1241,12 @@ class TestPowerDistributingActor:
 
             await self._patch_battery_pool_status(mocks, mocker, batteries - {9})
 
-            requests_channel = Broadcast[Request]("power_distributor requests")
-            results_channel = Broadcast[Result]("power_distributor results")
+            requests_channel = Broadcast[Request](name="power_distributor requests")
+            results_channel = Broadcast[Result](name="power_distributor results")
 
-            battery_status_channel = Broadcast[ComponentPoolStatus]("battery_status")
+            battery_status_channel = Broadcast[ComponentPoolStatus](
+                name="battery_status"
+            )
             async with PowerDistributingActor(
                 requests_receiver=requests_channel.new_receiver(),
                 results_sender=results_channel.new_sender(),
@@ -1257,10 +1293,12 @@ class TestPowerDistributingActor:
                 return_value=(failed_power, failed_batteries),
             )
 
-            requests_channel = Broadcast[Request]("power_distributor requests")
-            results_channel = Broadcast[Result]("power_distributor results")
+            requests_channel = Broadcast[Request](name="power_distributor requests")
+            results_channel = Broadcast[Result](name="power_distributor results")
 
-            battery_status_channel = Broadcast[ComponentPoolStatus]("battery_status")
+            battery_status_channel = Broadcast[ComponentPoolStatus](
+                name="battery_status"
+            )
             async with PowerDistributingActor(
                 requests_receiver=requests_channel.new_receiver(),
                 results_sender=results_channel.new_sender(),

--- a/tests/actor/test_actor.py
+++ b/tests/actor/test_actor.py
@@ -7,8 +7,7 @@ import asyncio
 from datetime import timedelta
 
 import pytest
-from frequenz.channels import Broadcast, Receiver, Sender
-from frequenz.channels.util import select, selected_from
+from frequenz.channels import Broadcast, Receiver, Sender, select, selected_from
 
 from frequenz.sdk.actor import Actor, run
 

--- a/tests/actor/test_actor.py
+++ b/tests/actor/test_actor.py
@@ -156,10 +156,10 @@ async def test_basic_actor(caplog: pytest.LogCaptureFixture) -> None:
     """Initialize the TestActor send a message and wait for the response."""
     caplog.set_level("DEBUG", logger="frequenz.sdk.actor._actor")
 
-    input_chan_1: Broadcast[bool] = Broadcast("TestChannel1")
-    input_chan_2: Broadcast[bool] = Broadcast("TestChannel2")
+    input_chan_1: Broadcast[bool] = Broadcast(name="TestChannel1")
+    input_chan_2: Broadcast[bool] = Broadcast(name="TestChannel2")
 
-    echo_chan: Broadcast[bool] = Broadcast("echo output")
+    echo_chan: Broadcast[bool] = Broadcast(name="echo output")
     echo_rx = echo_chan.new_receiver()
 
     async with EchoActor(
@@ -209,7 +209,7 @@ async def test_restart_on_unhandled_exception(
     caplog.set_level("DEBUG", logger="frequenz.sdk.actor._actor")
     caplog.set_level("DEBUG", logger="frequenz.sdk.actor._run_utils")
 
-    channel: Broadcast[int] = Broadcast("channel")
+    channel: Broadcast[int] = Broadcast(name="channel")
 
     # NB: We're adding 1.0s to the timeout to account for the time it takes to
     # run, crash, and restart the actor.
@@ -283,7 +283,7 @@ async def test_does_not_restart_on_normal_exit(
     caplog.set_level("DEBUG", logger="frequenz.sdk.actor._actor")
     caplog.set_level("DEBUG", logger="frequenz.sdk.actor._run_utils")
 
-    channel: Broadcast[int] = Broadcast("channel")
+    channel: Broadcast[int] = Broadcast(name="channel")
 
     actor = NopActor()
 
@@ -311,7 +311,7 @@ async def test_does_not_restart_on_base_exception(
     caplog.set_level("DEBUG", logger="frequenz.sdk.actor._actor")
     caplog.set_level("DEBUG", logger="frequenz.sdk.actor._run_utils")
 
-    channel: Broadcast[int] = Broadcast("channel")
+    channel: Broadcast[int] = Broadcast(name="channel")
 
     actor = RaiseBaseExceptionActor(channel.new_receiver())
 
@@ -346,10 +346,10 @@ async def test_does_not_restart_if_cancelled(
     caplog.set_level("DEBUG", logger="frequenz.sdk.actor._actor")
     caplog.set_level("DEBUG", logger="frequenz.sdk.actor._run_utils")
 
-    input_chan_1: Broadcast[bool] = Broadcast("TestChannel1")
-    input_chan_2: Broadcast[bool] = Broadcast("TestChannel2")
+    input_chan_1: Broadcast[bool] = Broadcast(name="TestChannel1")
+    input_chan_2: Broadcast[bool] = Broadcast(name="TestChannel2")
 
-    echo_chan: Broadcast[bool] = Broadcast("echo output")
+    echo_chan: Broadcast[bool] = Broadcast(name="echo output")
     echo_rx = echo_chan.new_receiver()
 
     actor = EchoActor(

--- a/tests/actor/test_actor.py
+++ b/tests/actor/test_actor.py
@@ -141,13 +141,13 @@ class EchoActor(BaseTestActor):
         channel_2 = self._recv2
 
         async for selected in select(channel_1, channel_2):
-            print(f"{self} received message {selected.value!r}")
+            print(f"{self} received message {selected.message!r}")
             if selected_from(selected, channel_1):
                 print(f"{self} sending message received from channel_1")
-                await self._output.send(selected.value)
+                await self._output.send(selected.message)
             elif selected_from(selected, channel_2):
                 print(f"{self} sending message received from channel_2")
-                await self._output.send(selected.value)
+                await self._output.send(selected.message)
 
         print(f"{self} done (should not happen)")
 

--- a/tests/actor/test_battery_pool_status.py
+++ b/tests/actor/test_battery_pool_status.py
@@ -43,7 +43,9 @@ class TestBatteryPoolStatus:
                     component_categories={ComponentCategory.BATTERY}
                 )
             }
-            battery_status_channel = Broadcast[ComponentPoolStatus]("battery_status")
+            battery_status_channel = Broadcast[ComponentPoolStatus](
+                name="battery_status"
+            )
             battery_status_recv = battery_status_channel.new_receiver(maxsize=1)
             batteries_status = ComponentPoolStatusTracker(
                 component_ids=batteries,

--- a/tests/actor/test_battery_pool_status.py
+++ b/tests/actor/test_battery_pool_status.py
@@ -46,7 +46,7 @@ class TestBatteryPoolStatus:
             battery_status_channel = Broadcast[ComponentPoolStatus](
                 name="battery_status"
             )
-            battery_status_recv = battery_status_channel.new_receiver(maxsize=1)
+            battery_status_recv = battery_status_channel.new_receiver(limit=1)
             batteries_status = ComponentPoolStatusTracker(
                 component_ids=batteries,
                 component_status_sender=battery_status_channel.new_sender(),

--- a/tests/actor/test_battery_status.py
+++ b/tests/actor/test_battery_status.py
@@ -753,7 +753,7 @@ class TestBatteryStatusRecovery:
             mock_microgrid,
             BatteryStatusTracker(
                 BATTERY_ID,
-                max_data_age=timedelta(seconds=0.1),
+                max_data_age=timedelta(seconds=0.2),
                 max_blocking_duration=timedelta(seconds=1),
                 status_sender=status_channel.new_sender(),
                 set_power_result_receiver=set_power_result_channel.new_receiver(),
@@ -1027,7 +1027,7 @@ class TestBatteryStatusRecovery:
 
         await self._send_healthy_inverter(mock_microgrid)
         await self._send_healthy_battery(mock_microgrid, timestamp)
-        assert await recv_timeout(status_receiver) == ComponentStatus(
+        assert await recv_timeout(status_receiver, 0.3) == ComponentStatus(
             BATTERY_ID, ComponentStatusEnum.NOT_WORKING
         )
 
@@ -1043,7 +1043,7 @@ class TestBatteryStatusRecovery:
 
         await self._send_healthy_battery(mock_microgrid)
         await self._send_healthy_inverter(mock_microgrid, timestamp)
-        assert await recv_timeout(status_receiver) == ComponentStatus(
+        assert await recv_timeout(status_receiver, 0.3) == ComponentStatus(
             BATTERY_ID, ComponentStatusEnum.NOT_WORKING
         )
 

--- a/tests/actor/test_battery_status.py
+++ b/tests/actor/test_battery_status.py
@@ -713,7 +713,8 @@ class TestBatteryStatus:
                 )
                 time.shift(10)
                 await asyncio.sleep(0.3)
-                assert len(status_receiver) == 0
+                with pytest.raises(asyncio.TimeoutError):
+                    await asyncio.wait_for(status_receiver.receive(), timeout=0.1)
 
                 await mock_microgrid.mock_client.send(
                     inverter_data(component_id=INVERTER_ID)

--- a/tests/actor/test_battery_status.py
+++ b/tests/actor/test_battery_status.py
@@ -162,8 +162,8 @@ class TestBatteryStatus:
         mock_microgrid = MockMicrogrid(grid_meter=True, mocker=mocker)
         mock_microgrid.add_batteries(3)
 
-        status_channel = Broadcast[ComponentStatus]("battery_status")
-        set_power_result_channel = Broadcast[SetPowerResult]("set_power_result")
+        status_channel = Broadcast[ComponentStatus](name="battery_status")
+        set_power_result_channel = Broadcast[SetPowerResult](name="set_power_result")
 
         async with (
             mock_microgrid,
@@ -333,8 +333,8 @@ class TestBatteryStatus:
         mock_microgrid = MockMicrogrid(grid_meter=True, mocker=mocker)
         mock_microgrid.add_batteries(3)
 
-        status_channel = Broadcast[ComponentStatus]("battery_status")
-        set_power_result_channel = Broadcast[SetPowerResult]("set_power_result")
+        status_channel = Broadcast[ComponentStatus](name="battery_status")
+        set_power_result_channel = Broadcast[SetPowerResult](name="set_power_result")
 
         async with (
             mock_microgrid,
@@ -474,8 +474,8 @@ class TestBatteryStatus:
         mock_microgrid = MockMicrogrid(grid_meter=True, mocker=mocker)
         mock_microgrid.add_batteries(3)
 
-        status_channel = Broadcast[ComponentStatus]("battery_status")
-        set_power_result_channel = Broadcast[SetPowerResult]("set_power_result")
+        status_channel = Broadcast[ComponentStatus](name="battery_status")
+        set_power_result_channel = Broadcast[SetPowerResult](name="set_power_result")
 
         async with (
             mock_microgrid,
@@ -525,8 +525,8 @@ class TestBatteryStatus:
         mock_microgrid = MockMicrogrid(grid_meter=True, mocker=mocker)
         mock_microgrid.add_batteries(3)
 
-        status_channel = Broadcast[ComponentStatus]("battery_status")
-        set_power_result_channel = Broadcast[SetPowerResult]("set_power_result")
+        status_channel = Broadcast[ComponentStatus](name="battery_status")
+        set_power_result_channel = Broadcast[SetPowerResult](name="set_power_result")
 
         async with (
             mock_microgrid,
@@ -589,8 +589,8 @@ class TestBatteryStatus:
         mock_microgrid = MockMicrogrid(grid_meter=True, mocker=mocker)
         mock_microgrid.add_batteries(3)
 
-        status_channel = Broadcast[ComponentStatus]("battery_status")
-        set_power_result_channel = Broadcast[SetPowerResult]("set_power_result")
+        status_channel = Broadcast[ComponentStatus](name="battery_status")
+        set_power_result_channel = Broadcast[SetPowerResult](name="set_power_result")
 
         async with (
             mock_microgrid,
@@ -655,8 +655,8 @@ class TestBatteryStatus:
         mock_microgrid = MockMicrogrid(grid_meter=True, mocker=mocker)
         mock_microgrid.add_batteries(3)
 
-        status_channel = Broadcast[ComponentStatus]("battery_status")
-        set_power_result_channel = Broadcast[SetPowerResult]("set_power_result")
+        status_channel = Broadcast[ComponentStatus](name="battery_status")
+        set_power_result_channel = Broadcast[SetPowerResult](name="set_power_result")
 
         status_receiver = status_channel.new_receiver()
         set_power_result_sender = set_power_result_channel.new_sender()
@@ -743,8 +743,8 @@ class TestBatteryStatusRecovery:
         mock_microgrid = MockMicrogrid(grid_meter=True, mocker=mocker)
         mock_microgrid.add_batteries(1)
 
-        status_channel = Broadcast[ComponentStatus]("battery_status")
-        set_power_result_channel = Broadcast[SetPowerResult]("set_power_result")
+        status_channel = Broadcast[ComponentStatus](name="battery_status")
+        set_power_result_channel = Broadcast[SetPowerResult](name="set_power_result")
 
         status_receiver = status_channel.new_receiver()
 

--- a/tests/actor/test_config_manager.py
+++ b/tests/actor/test_config_manager.py
@@ -79,7 +79,7 @@ class TestActorConfigManager:
         - the config file modifications are picked up and the new content is correct
         """
         config_channel: Broadcast[Config] = Broadcast(
-            "Config Channel", resend_latest=True
+            name="Config Channel", resend_latest=True
         )
         config_receiver = config_channel.new_receiver()
 

--- a/tests/actor/test_data_sourcing.py
+++ b/tests/actor/test_data_sourcing.py
@@ -51,7 +51,7 @@ class TestDataSourcingActor:
 
         await connection_manager.initialize("[::1]", 57899)
 
-        req_chan = Broadcast[ComponentMetricRequest]("data_sourcing_requests")
+        req_chan = Broadcast[ComponentMetricRequest](name="data_sourcing_requests")
         req_sender = req_chan.new_sender()
 
         registry = ChannelRegistry(name="test-registry")

--- a/tests/actor/test_resampling.py
+++ b/tests/actor/test_resampling.py
@@ -113,9 +113,9 @@ async def test_single_request(
 ) -> None:
     """Run main functions that initializes and creates everything."""
     channel_registry = ChannelRegistry(name="test")
-    data_source_req_chan = Broadcast[ComponentMetricRequest]("data-source-req")
+    data_source_req_chan = Broadcast[ComponentMetricRequest](name="data-source-req")
     data_source_req_recv = data_source_req_chan.new_receiver()
-    resampling_req_chan = Broadcast[ComponentMetricRequest]("resample-req")
+    resampling_req_chan = Broadcast[ComponentMetricRequest](name="resample-req")
     resampling_req_sender = resampling_req_chan.new_sender()
 
     async with ComponentMetricsResamplingActor(
@@ -156,9 +156,9 @@ async def test_duplicate_request(
 ) -> None:
     """Run main functions that initializes and creates everything."""
     channel_registry = ChannelRegistry(name="test")
-    data_source_req_chan = Broadcast[ComponentMetricRequest]("data-source-req")
+    data_source_req_chan = Broadcast[ComponentMetricRequest](name="data-source-req")
     data_source_req_recv = data_source_req_chan.new_receiver()
-    resampling_req_chan = Broadcast[ComponentMetricRequest]("resample-req")
+    resampling_req_chan = Broadcast[ComponentMetricRequest](name="resample-req")
     resampling_req_sender = resampling_req_chan.new_sender()
 
     async with ComponentMetricsResamplingActor(

--- a/tests/timeseries/mock_resampler.py
+++ b/tests/timeseries/mock_resampler.py
@@ -43,7 +43,7 @@ class MockResampler:
 
         self._channel_registry = self._data_pipeline._channel_registry
         self._resampler_request_channel = Broadcast[ComponentMetricRequest](
-            "resampler-request"
+            name="resampler-request"
         )
         self._input_channels_receivers: dict[str, list[Receiver[Sample[Quantity]]]] = {}
 
@@ -80,7 +80,7 @@ class MockResampler:
                 self._input_channels_receivers[name] = [
                     self._channel_registry.get_or_create(
                         Sample[Quantity], name
-                    ).new_receiver(name)
+                    ).new_receiver(name=name)
                     for _ in range(namespaces)
                 ]
             return senders

--- a/tests/timeseries/test_formula_engine.py
+++ b/tests/timeseries/test_formula_engine.py
@@ -61,7 +61,7 @@ class TestFormulaEngine:
         for token in Tokenizer(formula):
             if token.type == TokenType.COMPONENT_METRIC:
                 if token.value not in channels:
-                    channels[token.value] = Broadcast(token.value)
+                    channels[token.value] = Broadcast(name=token.value)
                 builder.push_metric(
                     f"#{token.value}",
                     channels[token.value].new_receiver(),
@@ -352,7 +352,9 @@ class TestFormulaEngineComposition:
         nones_are_zeros: bool = False,
     ) -> None:
         """Run a test with the specs provided."""
-        channels = [Broadcast[Sample[Quantity]](str(ctr)) for ctr in range(num_items)]
+        channels = [
+            Broadcast[Sample[Quantity]](name=str(ctr)) for ctr in range(num_items)
+        ]
         l1_engines = [
             self.make_engine(ctr, channels[ctr].new_receiver())
             for ctr in range(num_items)
@@ -750,8 +752,8 @@ class TestConstantValue:
 
     async def test_constant_value(self) -> None:
         """Test using constant values in formulas."""
-        channel_1 = Broadcast[Sample[Quantity]]("channel_1")
-        channel_2 = Broadcast[Sample[Quantity]]("channel_2")
+        channel_1 = Broadcast[Sample[Quantity]](name="channel_1")
+        channel_2 = Broadcast[Sample[Quantity]](name="channel_2")
 
         sender_1 = channel_1.new_sender()
         sender_2 = channel_2.new_sender()
@@ -812,8 +814,8 @@ class TestClipper:
 
     async def test_clipper(self) -> None:
         """Test the usage of clipper in formulas."""
-        channel_1 = Broadcast[Sample[Quantity]]("channel_1")
-        channel_2 = Broadcast[Sample[Quantity]]("channel_2")
+        channel_1 = Broadcast[Sample[Quantity]](name="channel_1")
+        channel_2 = Broadcast[Sample[Quantity]](name="channel_2")
 
         sender_1 = channel_1.new_sender()
         sender_2 = channel_2.new_sender()
@@ -878,8 +880,8 @@ class TestFormulaOutputTyping:
 
     async def test_types(self) -> None:
         """Test the typing of the output of formulas."""
-        channel_1 = Broadcast[Sample[Power]]("channel_1")
-        channel_2 = Broadcast[Sample[Power]]("channel_2")
+        channel_1 = Broadcast[Sample[Power]](name="channel_1")
+        channel_2 = Broadcast[Sample[Power]](name="channel_2")
 
         sender_1 = channel_1.new_sender()
         sender_2 = channel_2.new_sender()
@@ -909,7 +911,7 @@ class TestFromReceiver:
 
     async def test_from_receiver(self) -> None:
         """Test creating a formula engine from a receiver."""
-        channel = Broadcast[Sample[Power]]("channel_1")
+        channel = Broadcast[Sample[Power]](name="channel_1")
         sender = channel.new_sender()
 
         builder = FormulaBuilder("test_from_receiver", create_method=Power.from_watts)

--- a/tests/timeseries/test_formula_formatter.py
+++ b/tests/timeseries/test_formula_formatter.py
@@ -41,7 +41,7 @@ def build_formula(formula: str) -> list[FormulaStep]:
     for token in Tokenizer(formula):
         if token.type == TokenType.COMPONENT_METRIC:
             if token.value not in channels:
-                channels[token.value] = Broadcast(token.value)
+                channels[token.value] = Broadcast(name=token.value)
             builder.push_metric(
                 name=f"#{token.value}",
                 data_stream=channels[token.value].new_receiver(),

--- a/tests/timeseries/test_moving_window.py
+++ b/tests/timeseries/test_moving_window.py
@@ -60,7 +60,7 @@ def init_moving_window(
     Returns:
         tuple[MovingWindow, Sender[Sample]]: A pair of sender and `MovingWindow`.
     """
-    lm_chan = Broadcast[Sample[Quantity]]("lm_net_power")
+    lm_chan = Broadcast[Sample[Quantity]](name="lm_net_power")
     lm_tx = lm_chan.new_sender()
     window = MovingWindow(size, lm_chan.new_receiver(), timedelta(seconds=1))
     return window, lm_tx
@@ -229,7 +229,7 @@ async def test_window_size() -> None:
 # pylint: disable=redefined-outer-name
 async def test_resampling_window(fake_time: time_machine.Coordinates) -> None:
     """Test resampling in MovingWindow."""
-    channel = Broadcast[Sample[Quantity]]("net_power")
+    channel = Broadcast[Sample[Quantity]](name="net_power")
     sender = channel.new_sender()
 
     window_size = timedelta(seconds=16)

--- a/tests/timeseries/test_periodic_feature_extractor.py
+++ b/tests/timeseries/test_periodic_feature_extractor.py
@@ -58,7 +58,7 @@ async def init_feature_extractor_no_data(
         PeriodicFeatureExtractor
     """
     # We only need the moving window to initialize the PeriodicFeatureExtractor class.
-    lm_chan = Broadcast[Sample[Quantity]]("lm_net_power")
+    lm_chan = Broadcast[Sample[Quantity]](name="lm_net_power")
     moving_window = MovingWindow(
         timedelta(seconds=1), lm_chan.new_receiver(), timedelta(seconds=1)
     )

--- a/tests/timeseries/test_resampling.py
+++ b/tests/timeseries/test_resampling.py
@@ -49,7 +49,7 @@ def event_loop() -> Iterator[async_solipsism.EventLoop]:
 @pytest.fixture
 async def source_chan() -> AsyncIterator[Broadcast[Sample[Quantity]]]:
     """Create a broadcast channel of samples."""
-    chan = Broadcast[Sample[Quantity]]("test")
+    chan = Broadcast[Sample[Quantity]](name="test")
     yield chan
     await chan.close()
 

--- a/tests/utils/mock_microgrid_client.py
+++ b/tests/utils/mock_microgrid_client.py
@@ -302,7 +302,7 @@ class MockMicrogridClient:
             Receiver from the given channels.
         """
         return channels[component_id].new_receiver(
-            name="component" + str(component_id), maxsize=maxsize
+            name="component" + str(component_id), limit=maxsize
         )
 
     def _get_meter_receiver(
@@ -322,7 +322,7 @@ class MockMicrogridClient:
             Receiver from the given channels.
         """
         return channels[component_id].new_receiver(
-            name="component" + str(component_id), maxsize=maxsize
+            name="component" + str(component_id), limit=maxsize
         )
 
     def _get_ev_charger_receiver(
@@ -342,7 +342,7 @@ class MockMicrogridClient:
             Receiver from the given channels.
         """
         return channels[component_id].new_receiver(
-            name="component" + str(component_id), maxsize=maxsize
+            name="component" + str(component_id), limit=maxsize
         )
 
     def _get_inverter_receiver(
@@ -362,5 +362,5 @@ class MockMicrogridClient:
             Receiver from the given channels.
         """
         return channels[component_id].new_receiver(
-            name="component" + str(component_id), maxsize=maxsize
+            name="component" + str(component_id), limit=maxsize
         )

--- a/tests/utils/mock_microgrid_client.py
+++ b/tests/utils/mock_microgrid_client.py
@@ -177,7 +177,8 @@ class MockMicrogridClient:
         ]
 
         return {
-            bid: Broadcast[BatteryData]("battery_data_" + str(bid)) for bid in batteries
+            bid: Broadcast[BatteryData](name="battery_data_" + str(bid))
+            for bid in batteries
         }
 
     def _create_meter_channels(self) -> dict[int, Broadcast[MeterData]]:
@@ -194,7 +195,9 @@ class MockMicrogridClient:
             )
         ]
 
-        return {cid: Broadcast[MeterData]("meter_data_" + str(cid)) for cid in meters}
+        return {
+            cid: Broadcast[MeterData](name="meter_data_" + str(cid)) for cid in meters
+        }
 
     def _create_inverter_channels(self) -> dict[int, Broadcast[InverterData]]:
         """Create channels for the inverters.
@@ -211,7 +214,7 @@ class MockMicrogridClient:
         ]
 
         return {
-            cid: Broadcast[InverterData]("inverter_data_" + str(cid))
+            cid: Broadcast[InverterData](name="inverter_data_" + str(cid))
             for cid in inverters
         }
 
@@ -230,7 +233,8 @@ class MockMicrogridClient:
         ]
 
         return {
-            cid: Broadcast[EVChargerData]("meter_data_" + str(cid)) for cid in meters
+            cid: Broadcast[EVChargerData](name="meter_data_" + str(cid))
+            for cid in meters
         }
 
     def _create_mock_api(
@@ -298,7 +302,7 @@ class MockMicrogridClient:
             Receiver from the given channels.
         """
         return channels[component_id].new_receiver(
-            "component" + str(component_id), maxsize=maxsize
+            name="component" + str(component_id), maxsize=maxsize
         )
 
     def _get_meter_receiver(
@@ -318,7 +322,7 @@ class MockMicrogridClient:
             Receiver from the given channels.
         """
         return channels[component_id].new_receiver(
-            "component" + str(component_id), maxsize=maxsize
+            name="component" + str(component_id), maxsize=maxsize
         )
 
     def _get_ev_charger_receiver(
@@ -338,7 +342,7 @@ class MockMicrogridClient:
             Receiver from the given channels.
         """
         return channels[component_id].new_receiver(
-            "component" + str(component_id), maxsize=maxsize
+            name="component" + str(component_id), maxsize=maxsize
         )
 
     def _get_inverter_receiver(
@@ -358,5 +362,5 @@ class MockMicrogridClient:
             Receiver from the given channels.
         """
         return channels[component_id].new_receiver(
-            "component" + str(component_id), maxsize=maxsize
+            name="component" + str(component_id), maxsize=maxsize
         )


### PR DESCRIPTION
This version of `frequenz-channels` includes a number of improvements and a fix for a timer bug: https://github.com/frequenz-floss/frequenz-channels-python/releases/tag/v1.0.0-rc.1