### PR TITLE
Warn if duplicate `*pool` instances are being created

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -20,7 +20,7 @@
 
 ## New Features
 
-<!-- Here goes the main new features and examples or instructions on how to use them -->
+- Warning messages are logged when multiple instances of `*Pool`s are created for the same set of batteries, with the same priority values.
 
 ## Bug Fixes
 

--- a/src/frequenz/sdk/microgrid/_data_pipeline.py
+++ b/src/frequenz/sdk/microgrid/_data_pipeline.py
@@ -195,27 +195,29 @@ class _DataPipeline:  # pylint: disable=too-many-instance-attributes
             self._ev_power_wrapper.start()
 
         # We use frozenset to make a hashable key from the input set.
-        key: frozenset[int] = frozenset()
+        ref_store_key: frozenset[int] = frozenset()
         if ev_charger_ids is not None:
-            key = frozenset(ev_charger_ids)
+            ref_store_key = frozenset(ev_charger_ids)
 
-        if key not in self._ev_charger_pool_reference_stores:
-            self._ev_charger_pool_reference_stores[key] = EVChargerPoolReferenceStore(
-                channel_registry=self._channel_registry,
-                resampler_subscription_sender=self._resampling_request_sender(),
-                status_receiver=self._ev_power_wrapper.status_channel.new_receiver(
-                    limit=1
-                ),
-                power_manager_requests_sender=(
-                    self._ev_power_wrapper.proposal_channel.new_sender()
-                ),
-                power_manager_bounds_subs_sender=(
-                    self._ev_power_wrapper.bounds_subscription_channel.new_sender()
-                ),
-                component_ids=ev_charger_ids,
+        if ref_store_key not in self._ev_charger_pool_reference_stores:
+            self._ev_charger_pool_reference_stores[ref_store_key] = (
+                EVChargerPoolReferenceStore(
+                    channel_registry=self._channel_registry,
+                    resampler_subscription_sender=self._resampling_request_sender(),
+                    status_receiver=self._ev_power_wrapper.status_channel.new_receiver(
+                        limit=1
+                    ),
+                    power_manager_requests_sender=(
+                        self._ev_power_wrapper.proposal_channel.new_sender()
+                    ),
+                    power_manager_bounds_subs_sender=(
+                        self._ev_power_wrapper.bounds_subscription_channel.new_sender()
+                    ),
+                    component_ids=ev_charger_ids,
+                )
             )
         return EVChargerPool(
-            self._ev_charger_pool_reference_stores[key], name, priority
+            self._ev_charger_pool_reference_stores[ref_store_key], name, priority
         )
 
     def grid(self) -> Grid:
@@ -259,28 +261,32 @@ class _DataPipeline:  # pylint: disable=too-many-instance-attributes
             self._battery_power_wrapper.start()
 
         # We use frozenset to make a hashable key from the input set.
-        key: frozenset[int] = frozenset()
+        ref_store_key: frozenset[int] = frozenset()
         if battery_ids is not None:
-            key = frozenset(battery_ids)
+            ref_store_key = frozenset(battery_ids)
 
-        if key not in self._battery_pool_reference_stores:
-            self._battery_pool_reference_stores[key] = BatteryPoolReferenceStore(
-                channel_registry=self._channel_registry,
-                resampler_subscription_sender=self._resampling_request_sender(),
-                batteries_status_receiver=(
-                    self._battery_power_wrapper.status_channel.new_receiver(limit=1)
-                ),
-                power_manager_requests_sender=(
-                    self._battery_power_wrapper.proposal_channel.new_sender()
-                ),
-                power_manager_bounds_subscription_sender=(
-                    self._battery_power_wrapper.bounds_subscription_channel.new_sender()
-                ),
-                min_update_interval=self._resampler_config.resampling_period,
-                batteries_id=battery_ids,
+        if ref_store_key not in self._battery_pool_reference_stores:
+            self._battery_pool_reference_stores[ref_store_key] = (
+                BatteryPoolReferenceStore(
+                    channel_registry=self._channel_registry,
+                    resampler_subscription_sender=self._resampling_request_sender(),
+                    batteries_status_receiver=(
+                        self._battery_power_wrapper.status_channel.new_receiver(limit=1)
+                    ),
+                    power_manager_requests_sender=(
+                        self._battery_power_wrapper.proposal_channel.new_sender()
+                    ),
+                    power_manager_bounds_subscription_sender=(
+                        self._battery_power_wrapper.bounds_subscription_channel.new_sender()
+                    ),
+                    min_update_interval=self._resampler_config.resampling_period,
+                    batteries_id=battery_ids,
+                )
             )
 
-        return BatteryPool(self._battery_pool_reference_stores[key], name, priority)
+        return BatteryPool(
+            self._battery_pool_reference_stores[ref_store_key], name, priority
+        )
 
     def _data_sourcing_request_sender(self) -> Sender[ComponentMetricRequest]:
         """Return a Sender for sending requests to the data sourcing actor.

--- a/src/frequenz/sdk/microgrid/_data_pipeline.py
+++ b/src/frequenz/sdk/microgrid/_data_pipeline.py
@@ -445,6 +445,15 @@ def ev_charger_pool(
         When specifying priority, bigger values indicate higher priority. The default
         priority is the lowest possible value.
 
+        It is recommended to reuse the same instance of the `EVChargerPool` within the
+        same actor, unless they are managing different sets of EV chargers.
+
+        In deployments with multiple actors managing the same set of EV chargers, it is
+        recommended to use different priorities to distinguish between them.  If not,
+        a random prioritization will be imposed on them to resolve conflicts, which may
+        lead to unexpected behavior like longer duration to converge on the desired
+        power.
+
     Args:
         ev_charger_ids: Optional set of IDs of EV Chargers to be managed by the
             EVChargerPool.  If not specified, all EV Chargers available in the
@@ -472,6 +481,15 @@ def battery_pool(
     !!! note
         When specifying priority, bigger values indicate higher priority. The default
         priority is the lowest possible value.
+
+        It is recommended to reuse the same instance of the `BatteryPool` within the
+        same actor, unless they are managing different sets of batteries.
+
+        In deployments with multiple actors managing the same set of batteries, it is
+        recommended to use different priorities to distinguish between them.  If not,
+        a random prioritization will be imposed on them to resolve conflicts, which may
+        lead to unexpected behavior like longer duration to converge on the desired
+        power.
 
     Args:
         battery_ids: Optional set of IDs of batteries to be managed by the `BatteryPool`.


### PR DESCRIPTION
This is because such usage could make the power manager take longer to converge on the desired power.

This PR also improves the docs for the `microgrid.*pool()` functions.

Closes #902 