### PR TITLE
Widen the channels dependency to allow for the final 1.0.0 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
   # Make sure to update the mkdocs.yml file when
   # changing the version
   # (plugins.mkdocstrings.handlers.python.import)
-  "frequenz-channels == 1.0.0-rc1",
+  "frequenz-channels >= 1.0.0-rc1, < 2.0.0",
   "frequenz-client-microgrid >= 0.2.0, < 0.3.0",
   "google-api-python-client >= 2.71, < 3",
   "grpcio >= 1.54.2, < 2",


### PR DESCRIPTION
The channels repository is now a release candidate for 1.0.0, so no more breaking changes are expected. We can now widen the dependency to allow for the final 1.0.0 release.
