### PR TITLE
Log when no relevant samples are found for resampling

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -30,6 +30,8 @@ Another notable change is the microgrid API client being moved to its own [repos
 
 - Warning messages are logged when multiple instances of `*Pool`s are created for the same set of batteries, with the same priority values.
 
+- A warning message will now be logged if no relevant samples are found in a component for resampling.
+
 ## Bug Fixes
 
 - A bug was fixed where the grid fuse was not created properly and would end up with a `max_current` with type `float` instead of `Current`.

--- a/src/frequenz/sdk/timeseries/_resampling.py
+++ b/src/frequenz/sdk/timeseries/_resampling.py
@@ -745,6 +745,8 @@ class _ResamplingHelper:
         # So if we need more performance beyond this point, we probably need to
         # resort to some C (or similar) implementation.
         relevant_samples = list(itertools.islice(self._buffer, min_index, max_index))
+        if not relevant_samples:
+            _logger.warning("No relevant samples found for component: %s", self._name)
         value = (
             conf.resampling_function(relevant_samples, conf, props)
             if relevant_samples


### PR DESCRIPTION
These additional logs will help in understanding why certain microgrid components, such as meters, fail to provide relevant samples for resampling.