### PR TITLE
Fix reactive power retrieval

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,42 +2,16 @@
 
 ## Summary
 
-The most notable features for this release is the addition of the `PVPool` (exposed via `microgrid.pv_pool()`), which can be used to manage PV arrays as a single entity and the `EVChargerPool` (`microgrid.ev_charger_pool()`) learning to manage power for the whole pool (before it could only be used to control chargers individually).
-
-Another notable change is the microgrid API client being moved to its own [repository](https://github.com/frequenz-floss/frequenz-client-microgrid-python/).
+<!-- Here goes a general summary of what this release is about -->
 
 ## Upgrading
 
-- The SDK is now using the microgrid API client from [`frequenz-client-microgrid`](https://github.com/frequenz-floss/frequenz-client-microgrid-python/). You should update your code if you are using the microgrid API client directly.
-
-- The minimum required `frequenz-channels` version is now [`v1.0.0-rc1`](https://github.com/frequenz-floss/frequenz-channels-python/releases/tag/v1.0.0-rc.1).
-
-- The set of battery IDs managed by a battery pool are now available through `BatteryPool.component_ids`, and no longer through `BatteryPool.battery_ids`.  This is done to have a consistent interface with other `*Pool`s.
-
-- The `maxsize` parameter in calls to `BatteryPool.{soc/capacity/temperature}.new_receiver()` methods have now been renamed to `limit`, to be consistent with the channels repository.
-
-- Support for per-component interaction in `EVChargerPool` has been removed. Please use the new `propose_power()` method to manage power for the whole pool. If you still need to manage power of chargers individually, you can create one pool per charger.
-
-- PV power is now available from `microgrid.pv_pool().power`, and no longer from `microgrid.logical_meter().pv_power`.
+<!-- Here goes notes on how to upgrade from previous versions, including deprecations and what they should be replaced with -->
 
 ## New Features
 
-- `EVChargerPool`/`microgrid.ev_charger_pool()`: New `propose_power` and `power_status` methods have been added, similar to the `BatteryPool`.  These method interface with the `PowerManager` and `PowerDistributor`, which currently uses a first-come-first-serve algorithm to distribute power to EVs.
-
-- A PV pool (`PVPool`/`microgrid.pv_pool()`) was added, with `propose_power`, `power_status` and `power` methods similar to Battery and EV pools.
-
-- The microgrid API client now exposes the reactive power for inverters, meters and EV chargers.
-
-## Enhancements
-
-- Warning messages are logged when multiple instances of `*Pool`s are created for the same set of batteries, with the same priority values.
-
-- A warning message will now be logged if no relevant samples are found in a component for resampling.
+<!-- Here goes the main new features and examples or instructions on how to use them -->
 
 ## Bug Fixes
 
-- A bug was fixed where the grid fuse was not created properly and would end up with a `max_current` with type `float` instead of `Current`.
-
-- `BatteryPool.propose_discharge` now converts power values to the passive-sign convention.  Earlier it was not doing this and that was causing it to charge instead of discharge.
-
-- Fix a bug that was causing the power managing actor to crash and restart when cleaning up old proposals.
+<!-- Here goes notable bug fixes that are worth a special mention or explanation -->

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,17 +1,5 @@
 # Frequenz Python SDK Release Notes
 
-## Summary
-
-<!-- Here goes a general summary of what this release is about -->
-
-## Upgrading
-
-<!-- Here goes notes on how to upgrade from previous versions, including deprecations and what they should be replaced with -->
-
-## New Features
-
-<!-- Here goes the main new features and examples or instructions on how to use them -->
-
 ## Bug Fixes
 
-<!-- Here goes notable bug fixes that are worth a special mention or explanation -->
+- Fix getting reactive power from meters, inverters and EV chargers.

--- a/src/frequenz/sdk/actor/_data_sourcing/microgrid_api_source.py
+++ b/src/frequenz/sdk/actor/_data_sourcing/microgrid_api_source.py
@@ -38,6 +38,16 @@ _MeterDataMethods: dict[ComponentMetricId, Callable[[MeterData], float]] = {
     ComponentMetricId.VOLTAGE_PHASE_2: lambda msg: msg.voltage_per_phase[1],
     ComponentMetricId.VOLTAGE_PHASE_3: lambda msg: msg.voltage_per_phase[2],
     ComponentMetricId.FREQUENCY: lambda msg: msg.frequency,
+    ComponentMetricId.REACTIVE_POWER: lambda msg: msg.reactive_power,
+    ComponentMetricId.REACTIVE_POWER_PHASE_1: lambda msg: msg.reactive_power_per_phase[
+        0
+    ],
+    ComponentMetricId.REACTIVE_POWER_PHASE_2: lambda msg: msg.reactive_power_per_phase[
+        1
+    ],
+    ComponentMetricId.REACTIVE_POWER_PHASE_3: lambda msg: msg.reactive_power_per_phase[
+        2
+    ],
 }
 
 _BatteryDataMethods: dict[ComponentMetricId, Callable[[BatteryData], float]] = {
@@ -84,6 +94,16 @@ _InverterDataMethods: dict[ComponentMetricId, Callable[[InverterData], float]] =
     ComponentMetricId.VOLTAGE_PHASE_2: lambda msg: msg.voltage_per_phase[1],
     ComponentMetricId.VOLTAGE_PHASE_3: lambda msg: msg.voltage_per_phase[2],
     ComponentMetricId.FREQUENCY: lambda msg: msg.frequency,
+    ComponentMetricId.REACTIVE_POWER: lambda msg: msg.reactive_power,
+    ComponentMetricId.REACTIVE_POWER_PHASE_1: lambda msg: msg.reactive_power_per_phase[
+        0
+    ],
+    ComponentMetricId.REACTIVE_POWER_PHASE_2: lambda msg: msg.reactive_power_per_phase[
+        1
+    ],
+    ComponentMetricId.REACTIVE_POWER_PHASE_3: lambda msg: msg.reactive_power_per_phase[
+        2
+    ],
 }
 
 _EVChargerDataMethods: dict[ComponentMetricId, Callable[[EVChargerData], float]] = {
@@ -98,6 +118,16 @@ _EVChargerDataMethods: dict[ComponentMetricId, Callable[[EVChargerData], float]]
     ComponentMetricId.VOLTAGE_PHASE_2: lambda msg: msg.voltage_per_phase[1],
     ComponentMetricId.VOLTAGE_PHASE_3: lambda msg: msg.voltage_per_phase[2],
     ComponentMetricId.FREQUENCY: lambda msg: msg.frequency,
+    ComponentMetricId.REACTIVE_POWER: lambda msg: msg.reactive_power,
+    ComponentMetricId.REACTIVE_POWER_PHASE_1: lambda msg: msg.reactive_power_per_phase[
+        0
+    ],
+    ComponentMetricId.REACTIVE_POWER_PHASE_2: lambda msg: msg.reactive_power_per_phase[
+        1
+    ],
+    ComponentMetricId.REACTIVE_POWER_PHASE_3: lambda msg: msg.reactive_power_per_phase[
+        2
+    ],
 }
 
 

--- a/tests/actor/test_data_sourcing.py
+++ b/tests/actor/test_data_sourcing.py
@@ -65,6 +65,14 @@ class TestDataSourcingActor:
             ).new_receiver()
             await req_sender.send(active_power_request)
 
+            reactive_power_request = ComponentMetricRequest(
+                "test-namespace", 4, ComponentMetricId.REACTIVE_POWER, None
+            )
+            reactive_power_recv = registry.get_or_create(
+                Sample[Quantity], reactive_power_request.get_channel_name()
+            ).new_receiver()
+            await req_sender.send(reactive_power_request)
+
             soc_request = ComponentMetricRequest(
                 "test-namespace", 9, ComponentMetricId.SOC, None
             )


### PR DESCRIPTION
 The data sourcing actor needs to know about the new metric. This commit exposes it, adds a trivial test and updates the release notes to do a hotfix right after this is merged.
