### PR TITLE
Backport resampler log enhancement to v0.25.x

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -12,6 +12,10 @@
 
 <!-- Here goes the main new features and examples or instructions on how to use them -->
 
+## Enhancements
+
+- A warning message will now be logged if no relevant samples are found in a component for resampling.
+
 ## Bug Fixes
 
 <!-- Here goes notable bug fixes that are worth a special mention or explanation -->

--- a/src/frequenz/sdk/timeseries/_resampling.py
+++ b/src/frequenz/sdk/timeseries/_resampling.py
@@ -739,6 +739,8 @@ class _ResamplingHelper:
         # So if we need more performance beyond this point, we probably need to
         # resort to some C (or similar) implementation.
         relevant_samples = list(itertools.islice(self._buffer, min_index, max_index))
+        if not relevant_samples:
+            _logger.warning("No relevant samples found for component: %s", self._name)
         value = (
             conf.resampling_function(relevant_samples, conf, props)
             if relevant_samples


### PR DESCRIPTION
Log when no relevant samples are found for resampling.

These additional logs will help in understanding why certain microgrid components, such as meters, fail to provide relevant samples for resampling.
