### PR TITLE
Fix references to EV charger in PV inverter modules and tests

### DIFF
--- a/src/frequenz/sdk/actor/power_distributing/_component_status/_pv_inverter_status_tracker.py
+++ b/src/frequenz/sdk/actor/power_distributing/_component_status/_pv_inverter_status_tracker.py
@@ -193,7 +193,7 @@ class PVInverterStatusTracker(ComponentStatusTracker, BackgroundService):
 
             if new_status != self._last_status:
                 _logger.info(
-                    "EV charger %s status changed from %s to %s",
+                    "PV inverter %s status changed from %s to %s",
                     self._component_id,
                     self._last_status,
                     new_status,

--- a/src/frequenz/sdk/timeseries/pv_pool/_pv_pool.py
+++ b/src/frequenz/sdk/timeseries/pv_pool/_pv_pool.py
@@ -130,19 +130,19 @@ class PVPool:
 
     @property
     def power(self) -> FormulaEngine[Power]:
-        """Fetch the total power for the EV Chargers in the pool.
+        """Fetch the total power for the PV Inverters in the pool.
 
         This formula produces values that are in the Passive Sign Convention (PSC).
 
-        If a formula engine to calculate EV Charger power is not already running, it
+        If a formula engine to calculate PV Inverter power is not already running, it
         will be started.
 
         A receiver from the formula engine can be created using the `new_receiver`
         method.
 
         Returns:
-            A FormulaEngine that will calculate and stream the total power of all EV
-                Chargers.
+            A FormulaEngine that will calculate and stream the total power of all PV
+                Inverters.
         """
         engine = self._pv_pool_ref.formula_pool.from_power_formula_generator(
             "pv_power",

--- a/src/frequenz/sdk/timeseries/pv_pool/_pv_pool_reference_store.py
+++ b/src/frequenz/sdk/timeseries/pv_pool/_pv_pool_reference_store.py
@@ -98,6 +98,6 @@ class PVPoolReferenceStore:
         self.bounds_tracker.start()
 
     async def stop(self) -> None:
-        """Stop all tasks and channels owned by the EVChargerPool."""
+        """Stop all tasks and channels owned by the PVInverterPool."""
         await self.formula_pool.stop()
         await self.bounds_tracker.stop()

--- a/tests/timeseries/_pv_pool/test_pv_pool_control_methods.py
+++ b/tests/timeseries/_pv_pool/test_pv_pool_control_methods.py
@@ -49,7 +49,7 @@ async def mocks(mocker: MockerFixture) -> typing.AsyncIterator[_Mocks]:
     yield _Mocks(
         mockgrid,
         streamer,
-        dp._ev_power_wrapper.status_channel.new_sender(),
+        dp._pv_power_wrapper.status_channel.new_sender(),
     )
 
 


### PR DESCRIPTION
There were references to *EV* charger within *PV* inverter modules and tests.