### PR TITLE
dependabot: Ignore time-machine >=2.13.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,6 +30,11 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    ignore:
+      # Upgrade to time-machine 2.13.0+ breaks our tests. See:
+      # https://github.com/frequenz-floss/frequenz-sdk-python/issues/832
+      - dependency-name: "time-machine"
+        versions: [">=2.13.0"]
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
The upgrade to time-machine 2.13.0+ breaks our tests. See:

* https://github.com/frequenz-floss/frequenz-sdk-python/issues/832
