### PR TITLE
dependabot: Ignore frequenz-api-microgrid >=0.16.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,6 +35,11 @@ updates:
       # https://github.com/frequenz-floss/frequenz-sdk-python/issues/832
       - dependency-name: "time-machine"
         versions: [">=2.13.0"]
+      # Upgrading to 0.16.0+ needs a lot of changes in the code. See:
+      # https://github.com/frequenz-floss/frequenz-sdk-python/issues/844
+      - dependency-name: "frequenz-api-microgrid"
+        versions: [">=0.16.0"]
+
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
The upgrade to frequenz-api-microgrid >=0.16.0 needs a lot of changes in the code. We are not ready to do that yet, so we should ignore this dependency for now.

See:

* https://github.com/frequenz-floss/frequenz-sdk-python/issues/844
