### PR TITLE
Update release notes for rc6.post1

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,5 @@
 # Frequenz Python SDK Release Notes
 
-## Summary
+## Bug Fixes
 
-This release only fixes a `pylint` check failure that was preventing the release to be uploaded to PyPI.
+- Fix getting reactive power from meters, inverters and EV chargers.


### PR DESCRIPTION
Semver is not fully supported by setuptools_scm, so we need to use a version number that is compatible with PEP 440. This means intead of using `rc6.1` we need to use `rc6.post1`. Using pre-release versions with pre-release versions is discouraged but in this case it seems better than do the jump to `rc7`.

Because `rc6.1` (or `rc6.2`) was ever released in PyPI, we'll use `rc6.post1` and we'll include the release notes for `rc6.1` (`rc6.2` was just an attempt to fix the version number).