### PR TITLE
Always require a priority argument in calls to `microgrid.*_pool` methods

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,7 +6,9 @@
 
 ## Upgrading
 
-<!-- Here goes notes on how to upgrade from previous versions, including deprecations and what they should be replaced with -->
+- Calls to `microgrid.*_pool` methods now always need to specified a priority value, corresponding to the requirements/priority of the actor making the call.
+
+- The `microgrid.*_pool` methods would only accept keyword arguments from now on.
 
 ## New Features
 

--- a/benchmarks/power_distribution/power_distributor.py
+++ b/benchmarks/power_distribution/power_distributor.py
@@ -50,7 +50,7 @@ async def send_requests(batteries: set[int], request_num: int) -> list[Result]:
     Returns:
         List of the results from the PowerDistributingActor.
     """
-    battery_pool = microgrid.battery_pool(batteries)
+    battery_pool = microgrid.battery_pool(priority=5, component_ids=batteries)
     results_rx = battery_pool.power_status.new_receiver()
     result: list[Any] = []
     for _ in range(request_num):

--- a/examples/battery_pool.py
+++ b/examples/battery_pool.py
@@ -28,7 +28,7 @@ async def main() -> None:
         resampler_config=ResamplerConfig(resampling_period=timedelta(seconds=1.0)),
     )
 
-    battery_pool = microgrid.battery_pool()
+    battery_pool = microgrid.battery_pool(priority=5)
     receivers = [
         battery_pool.soc.new_receiver(limit=1),
         battery_pool.capacity.new_receiver(limit=1),

--- a/src/frequenz/sdk/actor/_power_managing/_power_managing_actor.py
+++ b/src/frequenz/sdk/actor/_power_managing/_power_managing_actor.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import sys
 import typing
 from datetime import datetime, timedelta, timezone
 
@@ -146,16 +147,22 @@ class PowerManagingActor(Actor):
         bounds_receiver: Receiver[SystemBounds]
         # pylint: disable=protected-access
         if self._component_category is ComponentCategory.BATTERY:
-            battery_pool = microgrid.battery_pool(component_ids)
+            battery_pool = microgrid.battery_pool(
+                priority=-sys.maxsize - 1, component_ids=component_ids
+            )
             bounds_receiver = battery_pool._system_power_bounds.new_receiver()
         elif self._component_category is ComponentCategory.EV_CHARGER:
-            ev_charger_pool = microgrid.ev_charger_pool(component_ids)
+            ev_charger_pool = microgrid.ev_charger_pool(
+                priority=-sys.maxsize - 1, component_ids=component_ids
+            )
             bounds_receiver = ev_charger_pool._system_power_bounds.new_receiver()
         elif (
             self._component_category is ComponentCategory.INVERTER
             and self._component_type is InverterType.SOLAR
         ):
-            pv_pool = microgrid.pv_pool(component_ids)
+            pv_pool = microgrid.pv_pool(
+                priority=-sys.maxsize - 1, component_ids=component_ids
+            )
             bounds_receiver = pv_pool._system_power_bounds.new_receiver()
         # pylint: enable=protected-access
         else:

--- a/src/frequenz/sdk/microgrid/_data_pipeline.py
+++ b/src/frequenz/sdk/microgrid/_data_pipeline.py
@@ -185,7 +185,7 @@ class _DataPipeline:  # pylint: disable=too-many-instance-attributes
 
     def ev_charger_pool(
         self,
-        ev_charger_ids: abc.Set[int] | None = None,
+        component_ids: abc.Set[int] | None = None,
         name: str | None = None,
         priority: int = -sys.maxsize - 1,
     ) -> EVChargerPool:
@@ -195,7 +195,7 @@ class _DataPipeline:  # pylint: disable=too-many-instance-attributes
         created and returned.
 
         Args:
-            ev_charger_ids: Optional set of IDs of EV Chargers to be managed by the
+            component_ids: Optional set of IDs of EV Chargers to be managed by the
                 EVChargerPool.
             name: An optional name used to identify this instance of the pool or a
                 corresponding actor in the logs.
@@ -214,8 +214,8 @@ class _DataPipeline:  # pylint: disable=too-many-instance-attributes
 
         # We use frozenset to make a hashable key from the input set.
         ref_store_key: frozenset[int] = frozenset()
-        if ev_charger_ids is not None:
-            ref_store_key = frozenset(ev_charger_ids)
+        if component_ids is not None:
+            ref_store_key = frozenset(component_ids)
 
         pool_key = f"{ref_store_key}-{priority}"
         if pool_key in self._known_pool_keys:
@@ -226,7 +226,7 @@ class _DataPipeline:  # pylint: disable=too-many-instance-attributes
                 "consider reusing the same instance."
                 "\n  Hint: If the instances are created from different actors, "
                 "consider using different priorities to distinguish them.",
-                ev_charger_ids,
+                component_ids,
                 priority,
             )
         else:
@@ -246,7 +246,7 @@ class _DataPipeline:  # pylint: disable=too-many-instance-attributes
                     power_manager_bounds_subs_sender=(
                         self._ev_power_wrapper.bounds_subscription_channel.new_sender()
                     ),
-                    component_ids=ev_charger_ids,
+                    component_ids=component_ids,
                 )
             )
         return EVChargerPool(
@@ -255,7 +255,7 @@ class _DataPipeline:  # pylint: disable=too-many-instance-attributes
 
     def pv_pool(
         self,
-        pv_inverter_ids: abc.Set[int] | None = None,
+        component_ids: abc.Set[int] | None = None,
         name: str | None = None,
         priority: int = -sys.maxsize - 1,
     ) -> PVPool:
@@ -265,7 +265,7 @@ class _DataPipeline:  # pylint: disable=too-many-instance-attributes
         exist, a new one is created and used for creating the `PVPool`.
 
         Args:
-            pv_inverter_ids: Optional set of IDs of PV inverters to be managed by the
+            component_ids: Optional set of IDs of PV inverters to be managed by the
                 `PVPool`.
             name: An optional name used to identify this instance of the pool or a
                 corresponding actor in the logs.
@@ -282,8 +282,8 @@ class _DataPipeline:  # pylint: disable=too-many-instance-attributes
 
         # We use frozenset to make a hashable key from the input set.
         ref_store_key: frozenset[int] = frozenset()
-        if pv_inverter_ids is not None:
-            ref_store_key = frozenset(pv_inverter_ids)
+        if component_ids is not None:
+            ref_store_key = frozenset(component_ids)
 
         pool_key = f"{ref_store_key}-{priority}"
         if pool_key in self._known_pool_keys:
@@ -294,7 +294,7 @@ class _DataPipeline:  # pylint: disable=too-many-instance-attributes
                 "consider reusing the same instance."
                 "\n  Hint: If the instances are created from different actors, "
                 "consider using different priorities to distinguish them.",
-                pv_inverter_ids,
+                component_ids,
                 priority,
             )
         else:
@@ -313,7 +313,7 @@ class _DataPipeline:  # pylint: disable=too-many-instance-attributes
                 power_manager_bounds_subs_sender=(
                     self._pv_power_wrapper.bounds_subscription_channel.new_sender()
                 ),
-                component_ids=pv_inverter_ids,
+                component_ids=component_ids,
             )
 
         return PVPool(self._pv_pool_reference_stores[ref_store_key], name, priority)
@@ -331,17 +331,17 @@ class _DataPipeline:  # pylint: disable=too-many-instance-attributes
 
     def battery_pool(
         self,
-        battery_ids: abc.Set[int] | None = None,
+        component_ids: abc.Set[int] | None = None,
         name: str | None = None,
         priority: int = -sys.maxsize - 1,
     ) -> BatteryPool:
         """Return a new `BatteryPool` instance for the given ids.
 
-        If a `BatteryPoolReferenceStore` instance for the given battery ids doesn't exist,
-        a new one is created and used for creating the `BatteryPool`.
+        If a `BatteryPoolReferenceStore` instance for the given battery ids doesn't
+        exist, a new one is created and used for creating the `BatteryPool`.
 
         Args:
-            battery_ids: Optional set of IDs of batteries to be managed by the
+            component_ids: Optional set of IDs of batteries to be managed by the
                 `BatteryPool`.
             name: An optional name used to identify this instance of the pool or a
                 corresponding actor in the logs.
@@ -360,8 +360,8 @@ class _DataPipeline:  # pylint: disable=too-many-instance-attributes
 
         # We use frozenset to make a hashable key from the input set.
         ref_store_key: frozenset[int] = frozenset()
-        if battery_ids is not None:
-            ref_store_key = frozenset(battery_ids)
+        if component_ids is not None:
+            ref_store_key = frozenset(component_ids)
 
         pool_key = f"{ref_store_key}-{priority}"
         if pool_key in self._known_pool_keys:
@@ -372,7 +372,7 @@ class _DataPipeline:  # pylint: disable=too-many-instance-attributes
                 "consider reusing the same instance."
                 "\n  Hint: If the instances are created from different actors, "
                 "consider using different priorities to distinguish them.",
-                battery_ids,
+                component_ids,
                 priority,
             )
         else:
@@ -393,7 +393,7 @@ class _DataPipeline:  # pylint: disable=too-many-instance-attributes
                         self._battery_power_wrapper.bounds_subscription_channel.new_sender()
                     ),
                     min_update_interval=self._resampler_config.resampling_period,
-                    batteries_id=battery_ids,
+                    batteries_id=component_ids,
                 )
             )
 
@@ -505,7 +505,7 @@ def producer() -> Producer:
 
 
 def ev_charger_pool(
-    ev_charger_ids: abc.Set[int] | None = None,
+    component_ids: abc.Set[int] | None = None,
     name: str | None = None,
     priority: int = -sys.maxsize - 1,
 ) -> EVChargerPool:
@@ -528,7 +528,7 @@ def ev_charger_pool(
         power.
 
     Args:
-        ev_charger_ids: Optional set of IDs of EV Chargers to be managed by the
+        component_ids: Optional set of IDs of EV Chargers to be managed by the
             EVChargerPool.  If not specified, all EV Chargers available in the
             component graph are used.
         name: An optional name used to identify this instance of the pool or a
@@ -538,11 +538,11 @@ def ev_charger_pool(
     Returns:
         An `EVChargerPool` instance.
     """
-    return _get().ev_charger_pool(ev_charger_ids, name, priority)
+    return _get().ev_charger_pool(component_ids, name, priority)
 
 
 def battery_pool(
-    battery_ids: abc.Set[int] | None = None,
+    component_ids: abc.Set[int] | None = None,
     name: str | None = None,
     priority: int = -sys.maxsize - 1,
 ) -> BatteryPool:
@@ -565,8 +565,9 @@ def battery_pool(
         power.
 
     Args:
-        battery_ids: Optional set of IDs of batteries to be managed by the `BatteryPool`.
-            If not specified, all batteries available in the component graph are used.
+        component_ids: Optional set of IDs of batteries to be managed by the
+            `BatteryPool`.  If not specified, all batteries available in the component
+            graph are used.
         name: An optional name used to identify this instance of the pool or a
             corresponding actor in the logs.
         priority: The priority of the actor making the call.
@@ -574,11 +575,11 @@ def battery_pool(
     Returns:
         A `BatteryPool` instance.
     """
-    return _get().battery_pool(battery_ids, name, priority)
+    return _get().battery_pool(component_ids, name, priority)
 
 
 def pv_pool(
-    pv_inverter_ids: abc.Set[int] | None = None,
+    component_ids: abc.Set[int] | None = None,
     name: str | None = None,
     priority: int = -sys.maxsize - 1,
 ) -> PVPool:
@@ -601,7 +602,7 @@ def pv_pool(
         power.
 
     Args:
-        pv_inverter_ids: Optional set of IDs of PV inverters to be managed by the
+        component_ids: Optional set of IDs of PV inverters to be managed by the
             `PVPool`. If not specified, all PV inverters available in the component
             graph are used.
         name: An optional name used to identify this instance of the pool or a
@@ -611,7 +612,7 @@ def pv_pool(
     Returns:
         A `PVPool` instance.
     """
-    return _get().pv_pool(pv_inverter_ids, name, priority)
+    return _get().pv_pool(component_ids, name, priority)
 
 
 def grid() -> Grid:

--- a/src/frequenz/sdk/microgrid/_data_pipeline.py
+++ b/src/frequenz/sdk/microgrid/_data_pipeline.py
@@ -11,7 +11,6 @@ ResamplingActor.
 from __future__ import annotations
 
 import logging
-import sys
 import typing
 from collections import abc
 from dataclasses import dataclass
@@ -185,9 +184,9 @@ class _DataPipeline:  # pylint: disable=too-many-instance-attributes
 
     def ev_charger_pool(
         self,
+        priority: int,
         component_ids: abc.Set[int] | None = None,
         name: str | None = None,
-        priority: int = -sys.maxsize - 1,
     ) -> EVChargerPool:
         """Return the corresponding EVChargerPool instance for the given ids.
 
@@ -195,11 +194,11 @@ class _DataPipeline:  # pylint: disable=too-many-instance-attributes
         created and returned.
 
         Args:
+            priority: The priority of the actor making the call.
             component_ids: Optional set of IDs of EV Chargers to be managed by the
                 EVChargerPool.
             name: An optional name used to identify this instance of the pool or a
                 corresponding actor in the logs.
-            priority: The priority of the actor making the call.
 
         Returns:
             An EVChargerPool instance.
@@ -255,9 +254,9 @@ class _DataPipeline:  # pylint: disable=too-many-instance-attributes
 
     def pv_pool(
         self,
+        priority: int,
         component_ids: abc.Set[int] | None = None,
         name: str | None = None,
-        priority: int = -sys.maxsize - 1,
     ) -> PVPool:
         """Return a new `PVPool` instance for the given ids.
 
@@ -265,11 +264,11 @@ class _DataPipeline:  # pylint: disable=too-many-instance-attributes
         exist, a new one is created and used for creating the `PVPool`.
 
         Args:
+            priority: The priority of the actor making the call.
             component_ids: Optional set of IDs of PV inverters to be managed by the
                 `PVPool`.
             name: An optional name used to identify this instance of the pool or a
                 corresponding actor in the logs.
-            priority: The priority of the actor making the call.
 
         Returns:
             A `PVPool` instance.
@@ -331,9 +330,9 @@ class _DataPipeline:  # pylint: disable=too-many-instance-attributes
 
     def battery_pool(
         self,
+        priority: int,
         component_ids: abc.Set[int] | None = None,
         name: str | None = None,
-        priority: int = -sys.maxsize - 1,
     ) -> BatteryPool:
         """Return a new `BatteryPool` instance for the given ids.
 
@@ -341,11 +340,11 @@ class _DataPipeline:  # pylint: disable=too-many-instance-attributes
         exist, a new one is created and used for creating the `BatteryPool`.
 
         Args:
+            priority: The priority of the actor making the call.
             component_ids: Optional set of IDs of batteries to be managed by the
                 `BatteryPool`.
             name: An optional name used to identify this instance of the pool or a
                 corresponding actor in the logs.
-            priority: The priority of the actor making the call.
 
         Returns:
             A `BatteryPool` instance.
@@ -505,9 +504,9 @@ def producer() -> Producer:
 
 
 def ev_charger_pool(
+    priority: int,
     component_ids: abc.Set[int] | None = None,
     name: str | None = None,
-    priority: int = -sys.maxsize - 1,
 ) -> EVChargerPool:
     """Return a new `EVChargerPool` instance for the given parameters.
 
@@ -528,23 +527,23 @@ def ev_charger_pool(
         power.
 
     Args:
+        priority: The priority of the actor making the call.
         component_ids: Optional set of IDs of EV Chargers to be managed by the
             EVChargerPool.  If not specified, all EV Chargers available in the
             component graph are used.
         name: An optional name used to identify this instance of the pool or a
             corresponding actor in the logs.
-        priority: The priority of the actor making the call.
 
     Returns:
         An `EVChargerPool` instance.
     """
-    return _get().ev_charger_pool(component_ids, name, priority)
+    return _get().ev_charger_pool(priority, component_ids, name)
 
 
 def battery_pool(
+    priority: int,
     component_ids: abc.Set[int] | None = None,
     name: str | None = None,
-    priority: int = -sys.maxsize - 1,
 ) -> BatteryPool:
     """Return a new `BatteryPool` instance for the given parameters.
 
@@ -565,23 +564,23 @@ def battery_pool(
         power.
 
     Args:
+        priority: The priority of the actor making the call.
         component_ids: Optional set of IDs of batteries to be managed by the
             `BatteryPool`.  If not specified, all batteries available in the component
             graph are used.
         name: An optional name used to identify this instance of the pool or a
             corresponding actor in the logs.
-        priority: The priority of the actor making the call.
 
     Returns:
         A `BatteryPool` instance.
     """
-    return _get().battery_pool(component_ids, name, priority)
+    return _get().battery_pool(priority, component_ids, name)
 
 
 def pv_pool(
+    priority: int,
     component_ids: abc.Set[int] | None = None,
     name: str | None = None,
-    priority: int = -sys.maxsize - 1,
 ) -> PVPool:
     """Return a new `PVPool` instance for the given parameters.
 
@@ -602,17 +601,17 @@ def pv_pool(
         power.
 
     Args:
+        priority: The priority of the actor making the call.
         component_ids: Optional set of IDs of PV inverters to be managed by the
             `PVPool`. If not specified, all PV inverters available in the component
             graph are used.
         name: An optional name used to identify this instance of the pool or a
             corresponding actor in the logs.
-        priority: The priority of the actor making the call.
 
     Returns:
         A `PVPool` instance.
     """
-    return _get().pv_pool(component_ids, name, priority)
+    return _get().pv_pool(priority, component_ids, name)
 
 
 def grid() -> Grid:

--- a/src/frequenz/sdk/microgrid/_data_pipeline.py
+++ b/src/frequenz/sdk/microgrid/_data_pipeline.py
@@ -184,6 +184,7 @@ class _DataPipeline:  # pylint: disable=too-many-instance-attributes
 
     def ev_charger_pool(
         self,
+        *,
         priority: int,
         component_ids: abc.Set[int] | None = None,
         name: str | None = None,
@@ -254,6 +255,7 @@ class _DataPipeline:  # pylint: disable=too-many-instance-attributes
 
     def pv_pool(
         self,
+        *,
         priority: int,
         component_ids: abc.Set[int] | None = None,
         name: str | None = None,
@@ -330,6 +332,7 @@ class _DataPipeline:  # pylint: disable=too-many-instance-attributes
 
     def battery_pool(
         self,
+        *,
         priority: int,
         component_ids: abc.Set[int] | None = None,
         name: str | None = None,
@@ -504,6 +507,7 @@ def producer() -> Producer:
 
 
 def ev_charger_pool(
+    *,
     priority: int,
     component_ids: abc.Set[int] | None = None,
     name: str | None = None,
@@ -537,10 +541,13 @@ def ev_charger_pool(
     Returns:
         An `EVChargerPool` instance.
     """
-    return _get().ev_charger_pool(priority, component_ids, name)
+    return _get().ev_charger_pool(
+        priority=priority, component_ids=component_ids, name=name
+    )
 
 
 def battery_pool(
+    *,
     priority: int,
     component_ids: abc.Set[int] | None = None,
     name: str | None = None,
@@ -574,10 +581,13 @@ def battery_pool(
     Returns:
         A `BatteryPool` instance.
     """
-    return _get().battery_pool(priority, component_ids, name)
+    return _get().battery_pool(
+        priority=priority, component_ids=component_ids, name=name
+    )
 
 
 def pv_pool(
+    *,
     priority: int,
     component_ids: abc.Set[int] | None = None,
     name: str | None = None,
@@ -611,7 +621,7 @@ def pv_pool(
     Returns:
         A `PVPool` instance.
     """
-    return _get().pv_pool(priority, component_ids, name)
+    return _get().pv_pool(priority=priority, component_ids=component_ids, name=name)
 
 
 def grid() -> Grid:

--- a/src/frequenz/sdk/timeseries/battery_pool/_result_types.py
+++ b/src/frequenz/sdk/timeseries/battery_pool/_result_types.py
@@ -66,7 +66,9 @@ class BatteryPoolReport(Report):
             ```python
             from frequenz.sdk import microgrid
 
-            power_status_rx = microgrid.battery_pool().power_status.new_receiver()
+            power_status_rx = microgrid.battery_pool(
+                priority=5,
+            ).power_status.new_receiver()
             power_status = await power_status_rx.receive()
             desired_power = Power.from_watts(1000.0)
 

--- a/src/frequenz/sdk/timeseries/formula_engine/_formula_engine.py
+++ b/src/frequenz/sdk/timeseries/formula_engine/_formula_engine.py
@@ -253,7 +253,7 @@ class FormulaEngine(
     ```python
     from frequenz.sdk import microgrid
 
-    battery_pool = microgrid.battery_pool()
+    battery_pool = microgrid.battery_pool(priority=5)
 
     async for power in battery_pool.power.new_receiver():
         print(f"{power=}")
@@ -277,8 +277,8 @@ class FormulaEngine(
     from frequenz.sdk import microgrid
 
     logical_meter = microgrid.logical_meter()
-    battery_pool = microgrid.battery_pool()
-    ev_charger_pool = microgrid.ev_charger_pool()
+    battery_pool = microgrid.battery_pool(priority=5)
+    ev_charger_pool = microgrid.ev_charger_pool(priority=5)
     grid = microgrid.grid()
 
     # apply operations on formula engines to create a formula engine that would
@@ -459,7 +459,7 @@ class FormulaEngine3Phase(
     ```python
     from frequenz.sdk import microgrid
 
-    ev_charger_pool = microgrid.ev_charger_pool()
+    ev_charger_pool = microgrid.ev_charger_pool(priority=5)
 
     async for sample in ev_charger_pool.current.new_receiver():
         print(f"Current: {sample}")
@@ -474,7 +474,7 @@ class FormulaEngine3Phase(
     from frequenz.sdk import microgrid
 
     logical_meter = microgrid.logical_meter()
-    ev_charger_pool = microgrid.ev_charger_pool()
+    ev_charger_pool = microgrid.ev_charger_pool(priority=5)
     grid = microgrid.grid()
 
     # Calculate grid consumption current that's not used by the EV chargers

--- a/src/frequenz/sdk/timeseries/logical_meter/_logical_meter.py
+++ b/src/frequenz/sdk/timeseries/logical_meter/_logical_meter.py
@@ -42,7 +42,7 @@ class LogicalMeter:
         )
 
         logical_meter = microgrid.logical_meter()
-        pv_pool = microgrid.pv_pool()
+        pv_pool = microgrid.pv_pool(priority=5)
         grid = microgrid.grid()
 
         # Get a receiver for a builtin formula

--- a/tests/microgrid/test_datapipeline.py
+++ b/tests/microgrid/test_datapipeline.py
@@ -71,7 +71,7 @@ async def test_actors_started(
     )
     mock_client.initialize(mocker)
 
-    datapipeline.battery_pool()
+    datapipeline.battery_pool(priority=5)
 
     assert datapipeline._battery_power_wrapper._power_distributing_actor is not None
     await asyncio.sleep(1)

--- a/tests/timeseries/_battery_pool/test_battery_pool.py
+++ b/tests/timeseries/_battery_pool/test_battery_pool.py
@@ -588,7 +588,7 @@ async def test_battery_pool_power_incomplete_bat_request(mocker: MockerFixture) 
     with pytest.raises(FormulaGenerationError):
         # Request only two of the three batteries behind the inverters
         battery_pool = microgrid.battery_pool(
-            battery_ids=set([bats[1].component_id, bats[0].component_id])
+            component_ids=set([bats[1].component_id, bats[0].component_id])
         )
         power_receiver = battery_pool.power.new_receiver()
         await mockgrid.mock_resampler.send_bat_inverter_power([2.0])

--- a/tests/timeseries/_battery_pool/test_battery_pool.py
+++ b/tests/timeseries/_battery_pool/test_battery_pool.py
@@ -158,7 +158,7 @@ async def setup_all_batteries(mocker: MockerFixture) -> AsyncIterator[SetupArgs]
     # the scope of this tests. This tests should cover BatteryPool only.
     # We use our own battery status channel, where we easily control set of working
     # batteries.
-    battery_pool = microgrid.battery_pool()
+    battery_pool = microgrid.battery_pool(priority=5)
 
     dp = microgrid._data_pipeline._DATA_PIPELINE
     assert dp is not None
@@ -212,7 +212,9 @@ async def setup_batteries_pool(mocker: MockerFixture) -> AsyncIterator[SetupArgs
     # batteries.
     all_batteries = list(get_components(mock_microgrid, ComponentCategory.BATTERY))
 
-    battery_pool = microgrid.battery_pool(set(all_batteries[:2]))
+    battery_pool = microgrid.battery_pool(
+        priority=5, component_ids=set(all_batteries[:2])
+    )
 
     dp = microgrid._data_pipeline._DATA_PIPELINE
     assert dp is not None
@@ -548,7 +550,7 @@ async def test_batter_pool_power_no_batteries(mocker: MockerFixture) -> None:
         )
     )
     await mockgrid.start(mocker)
-    battery_pool = microgrid.battery_pool()
+    battery_pool = microgrid.battery_pool(priority=5)
     power_receiver = battery_pool.power.new_receiver()
 
     await mockgrid.mock_resampler.send_non_existing_component_value()
@@ -565,7 +567,7 @@ async def test_battery_pool_power_with_no_inverters(mocker: MockerFixture) -> No
     await mockgrid.start(mocker)
 
     with pytest.raises(RuntimeError):
-        microgrid.battery_pool()
+        microgrid.battery_pool(priority=5)
 
 
 async def test_battery_pool_power_incomplete_bat_request(mocker: MockerFixture) -> None:
@@ -588,7 +590,7 @@ async def test_battery_pool_power_incomplete_bat_request(mocker: MockerFixture) 
     with pytest.raises(FormulaGenerationError):
         # Request only two of the three batteries behind the inverters
         battery_pool = microgrid.battery_pool(
-            component_ids=set([bats[1].component_id, bats[0].component_id])
+            priority=5, component_ids=set([bats[1].component_id, bats[0].component_id])
         )
         power_receiver = battery_pool.power.new_receiver()
         await mockgrid.mock_resampler.send_bat_inverter_power([2.0])
@@ -597,7 +599,7 @@ async def test_battery_pool_power_incomplete_bat_request(mocker: MockerFixture) 
 
 async def _test_battery_pool_power(mockgrid: MockMicrogrid) -> None:
     async with mockgrid:
-        battery_pool = microgrid.battery_pool()
+        battery_pool = microgrid.battery_pool(priority=5)
         power_receiver = battery_pool.power.new_receiver()
 
         await mockgrid.mock_resampler.send_bat_inverter_power([2.0, 3.0])

--- a/tests/timeseries/_battery_pool/test_battery_pool_control_methods.py
+++ b/tests/timeseries/_battery_pool/test_battery_pool_control_methods.py
@@ -188,7 +188,7 @@ class TestBatteryPoolControl:
         await self._init_data_for_batteries(mocks)
         await self._init_data_for_inverters(mocks)
 
-        battery_pool = microgrid.battery_pool()
+        battery_pool = microgrid.battery_pool(priority=5)
 
         bounds_rx = battery_pool.power_status.new_receiver()
 
@@ -283,9 +283,13 @@ class TestBatteryPoolControl:
         await self._init_data_for_batteries(mocks)
         await self._init_data_for_inverters(mocks)
 
-        battery_pool_1 = microgrid.battery_pool(set(mocks.microgrid.battery_ids[:2]))
+        battery_pool_1 = microgrid.battery_pool(
+            priority=5, component_ids=set(mocks.microgrid.battery_ids[:2])
+        )
         bounds_1_rx = battery_pool_1.power_status.new_receiver()
-        battery_pool_2 = microgrid.battery_pool(set(mocks.microgrid.battery_ids[2:]))
+        battery_pool_2 = microgrid.battery_pool(
+            priority=5, component_ids=set(mocks.microgrid.battery_ids[2:])
+        )
         bounds_2_rx = battery_pool_2.power_status.new_receiver()
 
         self._assert_report(
@@ -389,7 +393,7 @@ class TestBatteryPoolControl:
         await self._init_data_for_batteries(mocks, exclusion_bounds=(-100.0, 100.0))
         await self._init_data_for_inverters(mocks)
 
-        battery_pool = microgrid.battery_pool()
+        battery_pool = microgrid.battery_pool(priority=5)
         bounds_rx = battery_pool.power_status.new_receiver()
 
         self._assert_report(

--- a/tests/timeseries/_ev_charger_pool/test_ev_charger_pool.py
+++ b/tests/timeseries/_ev_charger_pool/test_ev_charger_pool.py
@@ -23,7 +23,7 @@ class TestEVChargerPool:
         mockgrid.add_ev_chargers(3)
 
         async with mockgrid:
-            ev_pool = microgrid.ev_charger_pool()
+            ev_pool = microgrid.ev_charger_pool(priority=5)
             power_receiver = ev_pool.power.new_receiver()
 
             await mockgrid.mock_resampler.send_evc_power([2.0, 4.0, 10.0])

--- a/tests/timeseries/_ev_charger_pool/test_ev_charger_pool_control_methods.py
+++ b/tests/timeseries/_ev_charger_pool/test_ev_charger_pool_control_methods.py
@@ -214,7 +214,7 @@ class TestEVChargerPoolControl:
 
         await self._init_ev_chargers(mocks)
         await self._patch_data_pipeline(mocker)
-        ev_charger_pool = microgrid.ev_charger_pool()
+        ev_charger_pool = microgrid.ev_charger_pool(priority=5)
         await self._patch_ev_pool_status(mocks, mocker)
         await self._patch_power_distributing_actor(mocker)
 

--- a/tests/timeseries/_formula_engine/test_formula_composition.py
+++ b/tests/timeseries/_formula_engine/test_formula_composition.py
@@ -35,10 +35,10 @@ class TestFormulaComposition:
             logical_meter = microgrid.logical_meter()
             stack.push_async_callback(logical_meter.stop)
 
-            battery_pool = microgrid.battery_pool()
+            battery_pool = microgrid.battery_pool(priority=5)
             stack.push_async_callback(battery_pool.stop)
 
-            pv_pool = microgrid.pv_pool()
+            pv_pool = microgrid.pv_pool(priority=5)
             stack.push_async_callback(pv_pool.stop)
 
             grid = microgrid.grid()
@@ -113,10 +113,10 @@ class TestFormulaComposition:
 
         count = 0
         async with mockgrid, AsyncExitStack() as stack:
-            battery_pool = microgrid.battery_pool()
+            battery_pool = microgrid.battery_pool(priority=5)
             stack.push_async_callback(battery_pool.stop)
 
-            pv_pool = microgrid.pv_pool()
+            pv_pool = microgrid.pv_pool(priority=5)
             stack.push_async_callback(pv_pool.stop)
 
             logical_meter = microgrid.logical_meter()
@@ -155,10 +155,10 @@ class TestFormulaComposition:
 
         count = 0
         async with mockgrid, AsyncExitStack() as stack:
-            battery_pool = microgrid.battery_pool()
+            battery_pool = microgrid.battery_pool(priority=5)
             stack.push_async_callback(battery_pool.stop)
 
-            pv_pool = microgrid.pv_pool()
+            pv_pool = microgrid.pv_pool(priority=5)
             stack.push_async_callback(pv_pool.stop)
 
             logical_meter = microgrid.logical_meter()
@@ -395,7 +395,7 @@ class TestFormulaComposition:
             logical_meter = microgrid.logical_meter()
             stack.push_async_callback(logical_meter.stop)
 
-            ev_pool = microgrid.ev_charger_pool()
+            ev_pool = microgrid.ev_charger_pool(priority=5)
             stack.push_async_callback(ev_pool.stop)
 
             grid = microgrid.grid()

--- a/tests/timeseries/_pv_pool/test_pv_pool_control_methods.py
+++ b/tests/timeseries/_pv_pool/test_pv_pool_control_methods.py
@@ -143,7 +143,7 @@ class TestPVPoolControl:
 
         await self._init_pv_inverters(mocks)
         await self._patch_data_pipeline(mocker)
-        pv_pool = microgrid.pv_pool()
+        pv_pool = microgrid.pv_pool(priority=5)
         bounds_rx = pv_pool.power_status.new_receiver()
         await self._recv_reports_until(
             bounds_rx,

--- a/tests/timeseries/test_formula_formatter.py
+++ b/tests/timeseries/test_formula_formatter.py
@@ -123,7 +123,7 @@ class TestFormulaFormatter:
             logical_meter = microgrid.logical_meter()
             stack.push_async_callback(logical_meter.stop)
 
-            pv_pool = microgrid.pv_pool()
+            pv_pool = microgrid.pv_pool(priority=5)
             stack.push_async_callback(pv_pool.stop)
 
             grid = microgrid.grid()

--- a/tests/timeseries/test_logical_meter.py
+++ b/tests/timeseries/test_logical_meter.py
@@ -44,7 +44,7 @@ class TestLogicalMeter:  # pylint: disable=too-many-public-methods
         mockgrid.add_solar_inverters(2)
 
         async with mockgrid, AsyncExitStack() as stack:
-            pv_pool = microgrid.pv_pool()
+            pv_pool = microgrid.pv_pool(priority=5)
             stack.push_async_callback(pv_pool.stop)
             pv_power_receiver = pv_pool.power.new_receiver()
 
@@ -57,7 +57,7 @@ class TestLogicalMeter:  # pylint: disable=too-many-public-methods
         mockgrid.add_solar_inverters(2, no_meter=True)
 
         async with mockgrid, AsyncExitStack() as stack:
-            pv_pool = microgrid.pv_pool()
+            pv_pool = microgrid.pv_pool(priority=5)
             stack.push_async_callback(pv_pool.stop)
             pv_power_receiver = pv_pool.power.new_receiver()
 
@@ -70,7 +70,7 @@ class TestLogicalMeter:  # pylint: disable=too-many-public-methods
             MockMicrogrid(grid_meter=True, mocker=mocker) as mockgrid,
             AsyncExitStack() as stack,
         ):
-            pv_pool = microgrid.pv_pool()
+            pv_pool = microgrid.pv_pool(priority=5)
             stack.push_async_callback(pv_pool.stop)
             pv_power_receiver = pv_pool.power.new_receiver()
 


### PR DESCRIPTION
This PR also makes the methods accept only keyword arguments.

Closes #916 