### PR TITLE
Set zero power for PV inverters not neccessary to reach target power

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -16,4 +16,4 @@
 
 ## Bug Fixes
 
-<!-- Here goes notable bug fixes that are worth a special mention or explanation -->
+- When the PowerDistributor receives a zero power request for PV inverters, it now correctly sets zero power to the inverters, and no longer crashes.

--- a/src/frequenz/sdk/actor/power_distributing/_component_managers/_pv_inverter_manager/_pv_inverter_manager.py
+++ b/src/frequenz/sdk/actor/power_distributing/_component_managers/_pv_inverter_manager/_pv_inverter_manager.py
@@ -136,7 +136,8 @@ class PVManager(ComponentManager):
             if remaining_power > Power.zero() or is_close_to_zero(
                 remaining_power.as_watts()
             ):
-                break
+                allocations[inv_id] = Power.zero()
+                continue
             distribution = remaining_power / float(num_components - idx)
             inv_data = self._component_data_caches[inv_id]
             if not inv_data.has_value():


### PR DESCRIPTION
If desired power is already reached without the need to use some inverters, their powers need to be set to zero.

If not, their original powers would remain and the target powers would be wrong.

In case the requested power is zero, this was also leading to crashes because there were no allocations.  This change also fixes that issue.

Closes #933 