### PR TITLE
Support power requests from shifting actors in the PowerManager

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -12,7 +12,7 @@
 
 ## New Features
 
-<!-- Here goes the main new features and examples or instructions on how to use them -->
+- Calls to `microgrid.*_pool` methods now accept an optional `in_shifting_group` parameter.  Power requests sent to `*_pool` instances that have the `in_shifting_group` flag set, will get resolved separately, and their target power will be added to the target power calculated from regular actors, if any, which would, in effect, shift the zero for the regular actors by the target power from the shifting group.
 
 ## Bug Fixes
 

--- a/src/frequenz/sdk/actor/_power_managing/_base_classes.py
+++ b/src/frequenz/sdk/actor/_power_managing/_base_classes.py
@@ -293,6 +293,21 @@ class BaseAlgorithm(abc.ABC):
                 didn't change.
         """
 
+    @abc.abstractmethod
+    def get_target_power(
+        self,
+        component_ids: frozenset[int],
+    ) -> Power | None:
+        """Get the target power for the given components.
+
+        Args:
+            component_ids: The component IDs to get the target power for.
+
+        Returns:
+            The target power for the given components, or `None` if there is no target
+                power.
+        """
+
     # The arguments for this method are tightly coupled to the `Matryoshka` algorithm.
     # It can be loosened up when more algorithms are added.
     @abc.abstractmethod

--- a/src/frequenz/sdk/actor/_power_managing/_base_classes.py
+++ b/src/frequenz/sdk/actor/_power_managing/_base_classes.py
@@ -33,6 +33,9 @@ class ReportRequest:
     priority: int
     """The priority of the actor ."""
 
+    in_shifting_group: bool
+    """Whether the proposal gets sent to the shifting group of the power manager."""
+
     def get_channel_name(self) -> str:
         """Get the channel name for the report request.
 
@@ -215,6 +218,9 @@ class Proposal:
 
     request_timeout: datetime.timedelta = datetime.timedelta(seconds=5.0)
     """The maximum amount of time to wait for the request to be fulfilled."""
+
+    in_shifting_group: bool
+    """Whether the proposal gets sent to the shifting group of the power manager."""
 
     def __lt__(self, other: Proposal) -> bool:
         """Compare two proposals by their priority.

--- a/src/frequenz/sdk/actor/_power_managing/_matryoshka.py
+++ b/src/frequenz/sdk/actor/_power_managing/_matryoshka.py
@@ -152,6 +152,21 @@ class Matryoshka(BaseAlgorithm):
                     )
         return True
 
+    def get_target_power(
+        self,
+        component_ids: frozenset[int],
+    ) -> Power | None:
+        """Get the target power for the given components.
+
+        Args:
+            component_ids: The component IDs to get the target power for.
+
+        Returns:
+            The target power for the given components, or `None` if there is no target
+                power.
+        """
+        return self._target_power.get(component_ids)
+
     @override
     def calculate_target_power(
         self,

--- a/src/frequenz/sdk/actor/_power_managing/_power_managing_actor.py
+++ b/src/frequenz/sdk/actor/_power_managing/_power_managing_actor.py
@@ -130,7 +130,7 @@ class PowerManagingActor(Actor):
             await self._send_updated_target_power(component_ids, None)
             await self._send_reports(component_ids)
 
-    def _add_bounds_tracker(self, component_ids: frozenset[int]) -> None:
+    def _add_system_bounds_tracker(self, component_ids: frozenset[int]) -> None:
         """Add a bounds tracker.
 
         Args:
@@ -225,7 +225,7 @@ class PowerManagingActor(Actor):
             if selected_from(selected, self._proposals_receiver):
                 proposal = selected.message
                 if proposal.component_ids not in self._bound_tracker_tasks:
-                    self._add_bounds_tracker(proposal.component_ids)
+                    self._add_system_bounds_tracker(proposal.component_ids)
 
                 # TODO: must_send=True forces a new request to # pylint: disable=fixme
                 # be sent to the PowerDistributor, even if there's no change in power.
@@ -260,7 +260,7 @@ class PowerManagingActor(Actor):
                     )
 
                 if sub.component_ids not in self._bound_tracker_tasks:
-                    self._add_bounds_tracker(sub.component_ids)
+                    self._add_system_bounds_tracker(sub.component_ids)
 
             elif selected_from(selected, self._power_distributing_results_receiver):
                 from .. import (  # pylint: disable=import-outside-toplevel

--- a/src/frequenz/sdk/actor/_power_managing/_power_managing_actor.py
+++ b/src/frequenz/sdk/actor/_power_managing/_power_managing_actor.py
@@ -16,7 +16,8 @@ from frequenz.channels.timer import SkipMissedAndDrift, Timer
 from frequenz.client.microgrid import ComponentCategory, ComponentType, InverterType
 from typing_extensions import override
 
-from ...timeseries._base_types import SystemBounds
+from ...timeseries import Power
+from ...timeseries._base_types import Bounds, SystemBounds
 from .._actor import Actor
 from .._channel_registry import ChannelRegistry
 from ._base_classes import Algorithm, BaseAlgorithm, Proposal, ReportRequest, _Report
@@ -28,7 +29,7 @@ if typing.TYPE_CHECKING:
     from .. import power_distributing
 
 
-class PowerManagingActor(Actor):
+class PowerManagingActor(Actor):  # pylint: disable=too-many-instance-attributes
     """The power manager."""
 
     def __init__(  # pylint: disable=too-many-arguments
@@ -84,10 +85,18 @@ class PowerManagingActor(Actor):
 
         self._system_bounds: dict[frozenset[int], SystemBounds] = {}
         self._bound_tracker_tasks: dict[frozenset[int], asyncio.Task[None]] = {}
-        self._subscriptions: dict[frozenset[int], dict[int, Sender[_Report]]] = {}
+        self._non_shifting_subscriptions: dict[
+            frozenset[int], dict[int, Sender[_Report]]
+        ] = {}
+        self._shifting_subscriptions: dict[
+            frozenset[int], dict[int, Sender[_Report]]
+        ] = {}
         self._distribution_results: dict[frozenset[int], power_distributing.Result] = {}
 
-        self._algorithm: BaseAlgorithm = Matryoshka(
+        self._non_shifting_group: BaseAlgorithm = Matryoshka(
+            max_proposal_age=timedelta(seconds=60.0)
+        )
+        self._shifting_group: BaseAlgorithm = Matryoshka(
             max_proposal_age=timedelta(seconds=60.0)
         )
 
@@ -104,11 +113,26 @@ class PowerManagingActor(Actor):
         if bounds is None:
             _logger.warning("PowerManagingActor: No bounds for %s", component_ids)
             return
-        for priority, sender in self._subscriptions.get(component_ids, {}).items():
-            status = self._algorithm.get_status(
+        for priority, sender in self._shifting_subscriptions.get(
+            component_ids, {}
+        ).items():
+            status = self._shifting_group.get_status(
                 component_ids,
                 priority,
                 bounds,
+                self._distribution_results.get(component_ids),
+            )
+            await sender.send(status)
+        for priority, sender in self._non_shifting_subscriptions.get(
+            component_ids, {}
+        ).items():
+            status = self._non_shifting_group.get_status(
+                component_ids,
+                priority,
+                self._calculate_remaining_bounds(
+                    bounds,
+                    self._shifting_group.get_target_power(component_ids),
+                ),
                 self._distribution_results.get(component_ids),
             )
             await sender.send(status)
@@ -184,6 +208,116 @@ class PowerManagingActor(Actor):
             self._bounds_tracker(component_ids, bounds_receiver)
         )
 
+    def _calculate_remaining_bounds(
+        self, bounds: SystemBounds, target_power: Power | None
+    ) -> SystemBounds:
+        """Calculate the remaining bounds after a target power is applied.
+
+        This is the values that can be added to the target power and still remain within
+        the actual system bounds.
+
+          | system bounds |     shifting |    shifted |
+          |               | target power |     bounds |
+          |---------------+--------------+------------|
+          | -100 to 100   |           70 | -170 to 30 |
+          | -100 to 100   |          -50 | -50 to 150 |
+
+        Args:
+            bounds: The bounds to calculate the remaining bounds from.
+            target_power: The target power to apply.
+
+        Returns:
+            The remaining bounds.
+        """
+        if target_power is None:
+            return bounds
+
+        inclusion_bounds: Bounds[Power] | None = None
+        if bounds.inclusion_bounds is not None:
+            inclusion_bounds = Bounds(
+                bounds.inclusion_bounds.lower - target_power,
+                bounds.inclusion_bounds.upper - target_power,
+            )
+        return SystemBounds(
+            timestamp=bounds.timestamp,
+            inclusion_bounds=inclusion_bounds,
+            exclusion_bounds=bounds.exclusion_bounds,
+        )
+
+    def _calculate_target_power(
+        self,
+        component_ids: frozenset[int],
+        proposal: Proposal | None,
+        must_send: bool = False,
+    ) -> Power | None:
+        """Calculate the target power for a set of components.
+
+        This is the power from the non-shifting group, shifted by the power from the
+        shifting group.
+
+        Args:
+            component_ids: The component IDs for which to calculate the target power.
+            proposal: The proposal to calculate the target power for.
+            must_send: If `True`, a new request will be sent to the PowerDistributor,
+                even if there's no change in power.
+
+        Returns:
+            The target power.
+        """
+        tgt_power_shift: Power | None = None
+        tgt_power_no_shift: Power | None = None
+        if proposal is not None:
+            if proposal.in_shifting_group:
+                tgt_power_shift = self._shifting_group.calculate_target_power(
+                    component_ids,
+                    proposal,
+                    self._system_bounds[component_ids],
+                    must_send,
+                )
+                tgt_power_no_shift = self._non_shifting_group.calculate_target_power(
+                    component_ids,
+                    None,
+                    self._calculate_remaining_bounds(
+                        self._system_bounds[component_ids], tgt_power_shift
+                    ),
+                    must_send,
+                )
+            else:
+                tgt_power_no_shift = self._non_shifting_group.calculate_target_power(
+                    component_ids,
+                    proposal,
+                    self._system_bounds[component_ids],
+                    must_send,
+                )
+                tgt_power_shift = self._shifting_group.calculate_target_power(
+                    component_ids,
+                    None,
+                    self._calculate_remaining_bounds(
+                        self._system_bounds[component_ids], tgt_power_no_shift
+                    ),
+                    must_send,
+                )
+        else:
+            tgt_power_no_shift = self._non_shifting_group.calculate_target_power(
+                component_ids,
+                None,
+                self._system_bounds[component_ids],
+                must_send,
+            )
+            tgt_power_shift = self._shifting_group.calculate_target_power(
+                component_ids,
+                None,
+                self._calculate_remaining_bounds(
+                    self._system_bounds[component_ids], tgt_power_no_shift
+                ),
+                must_send,
+            )
+        if tgt_power_shift is not None and tgt_power_no_shift is not None:
+            return tgt_power_shift + tgt_power_no_shift
+        if tgt_power_shift is not None:
+            return tgt_power_shift
+        return tgt_power_no_shift
+
     async def _send_updated_target_power(
         self,
         component_ids: frozenset[int],
@@ -192,10 +326,9 @@ class PowerManagingActor(Actor):
     ) -> None:
         from .. import power_distributing  # pylint: disable=import-outside-toplevel
 
-        target_power = self._algorithm.calculate_target_power(
+        target_power = self._calculate_target_power(
             component_ids,
             proposal,
-            self._system_bounds[component_ids],
             must_send,
         )
         request_timeout = (
@@ -245,22 +378,29 @@ class PowerManagingActor(Actor):
                 sub = selected.message
                 component_ids = sub.component_ids
                 priority = sub.priority
+                in_shifting_group = sub.in_shifting_group
 
-                if component_ids not in self._subscriptions:
-                    self._subscriptions[component_ids] = {
+                subs_set = (
+                    self._shifting_subscriptions
+                    if in_shifting_group
+                    else self._non_shifting_subscriptions
+                )
+
+                if component_ids not in subs_set:
+                    subs_set[component_ids] = {
                         priority: self._channel_registry.get_or_create(
                             _Report, sub.get_channel_name()
                         ).new_sender()
                     }
-                elif priority not in self._subscriptions[component_ids]:
-                    self._subscriptions[component_ids][priority] = (
+                elif priority not in subs_set[component_ids]:
+                    subs_set[component_ids][priority] = (
                         self._channel_registry.get_or_create(
                             _Report, sub.get_channel_name()
                         ).new_sender()
                     )
 
-                if sub.component_ids not in self._bound_tracker_tasks:
-                    self._add_system_bounds_tracker(sub.component_ids)
+                if component_ids not in self._bound_tracker_tasks:
+                    self._add_system_bounds_tracker(component_ids)
 
             elif selected_from(selected, self._power_distributing_results_receiver):
                 from .. import (  # pylint: disable=import-outside-toplevel
@@ -287,4 +427,7 @@ class PowerManagingActor(Actor):
                 await self._send_reports(frozenset(result.request.component_ids))
 
             elif selected_from(selected, drop_old_proposals_timer):
-                self._algorithm.drop_old_proposals(asyncio.get_event_loop().time())
+                self._non_shifting_group.drop_old_proposals(
+                    asyncio.get_event_loop().time()
+                )
+                self._shifting_group.drop_old_proposals(asyncio.get_event_loop().time())

--- a/src/frequenz/sdk/actor/_power_managing/_power_managing_actor.py
+++ b/src/frequenz/sdk/actor/_power_managing/_power_managing_actor.py
@@ -129,7 +129,7 @@ class PowerManagingActor(Actor):  # pylint: disable=too-many-instance-attributes
             status = self._non_shifting_group.get_status(
                 component_ids,
                 priority,
-                self._calculate_remaining_bounds(
+                self._calculate_shifted_bounds(
                     bounds,
                     self._shifting_group.get_target_power(component_ids),
                 ),
@@ -208,13 +208,13 @@ class PowerManagingActor(Actor):  # pylint: disable=too-many-instance-attributes
             self._bounds_tracker(component_ids, bounds_receiver)
         )
 
-    def _calculate_remaining_bounds(
+    def _calculate_shifted_bounds(
         self, bounds: SystemBounds, target_power: Power | None
     ) -> SystemBounds:
-        """Calculate the remaining bounds after a target power is applied.
+        """Calculate the shifted bounds corresponding to shifting group's target power.
 
-        This is the values that can be added to the target power and still remain within
-        the actual system bounds.
+        Any value regular actors choose within these bounds can be shifted by the
+        shifting power and still remain within the actual system bounds.
 
           | system bounds |     shifting |    shifted |
           |               | target power |     bounds |
@@ -277,7 +277,7 @@ class PowerManagingActor(Actor):  # pylint: disable=too-many-instance-attributes
                 tgt_power_no_shift = self._non_shifting_group.calculate_target_power(
                     component_ids,
                     None,
-                    self._calculate_remaining_bounds(
+                    self._calculate_shifted_bounds(
                         self._system_bounds[component_ids], tgt_power_shift
                     ),
                     must_send,
@@ -292,7 +292,7 @@ class PowerManagingActor(Actor):  # pylint: disable=too-many-instance-attributes
                 tgt_power_shift = self._shifting_group.calculate_target_power(
                     component_ids,
                     None,
-                    self._calculate_remaining_bounds(
+                    self._calculate_shifted_bounds(
                         self._system_bounds[component_ids], tgt_power_no_shift
                     ),
                     must_send,
@@ -307,7 +307,7 @@ class PowerManagingActor(Actor):  # pylint: disable=too-many-instance-attributes
             tgt_power_shift = self._shifting_group.calculate_target_power(
                 component_ids,
                 None,
-                self._calculate_remaining_bounds(
+                self._calculate_shifted_bounds(
                     self._system_bounds[component_ids], tgt_power_no_shift
                 ),
                 must_send,

--- a/src/frequenz/sdk/microgrid/__init__.py
+++ b/src/frequenz/sdk/microgrid/__init__.py
@@ -187,6 +187,43 @@ The algorithm used for resolving power conflicts based on actor priority can be
 found in the documentation for any of the
 [`propose_power`][frequenz.sdk.timeseries.battery_pool.BatteryPool.propose_power]
 methods.
+
+### Shifting the target power by an offset
+
+There are cases where the target power needs to be shifted by a certain amount, for
+example, to make adjustments to the operating point.  This can be done by designating
+some actors to be part of the `shifting_group`.
+
+When creating a `*Pool` instance using the above-mentioned constructors, an optional
+`in_shifting_group` parameter can be passed to specify that this actor is special, and
+the target power of the regular actors will be shifted by the target power of all
+shifting actors together.
+
+In a location with 2 regular actors and 1 shifting actor, here's how things
+would play out:
+
+1. When only non-shifting actors have made proposals, the power bounds available
+   from the batteries are available to them exactly.
+
+   | actor priority | in shifting group? | proposed power/bounds | available bounds |
+   |----------------|--------------------|-----------------------|------------------|
+   | 3              | No                 | 1000, -4000..2500     | -3000..3000      |
+   | 2              | No                 | 2500                  | -3000..2500      |
+   | 1              | Yes                | None                  | -3000..3000      |
+
+   Power actually distributed to the batteries: 2500W
+
+2. When the shifting actor has made proposals, the bounds available to the
+   regular actors gets shifted, and the final power that actually gets
+   distributed to the batteries is also shifted.
+
+   | actor priority | in shifting group? | proposed power/bounds | available bounds |
+   |----------------|--------------------|-----------------------|------------------|
+   | 3              | No                 | 1000, -4000..2500     | -2000..4000      |
+   | 2              | No                 | 2500                  | -2000..2500      |
+   | 1              | Yes                | -1000                 | -3000..3000      |
+
+   Power actually distributed to the batteries: 1500W
 """  # noqa: D205, D400
 
 from ..actor import ResamplerConfig

--- a/src/frequenz/sdk/microgrid/__init__.py
+++ b/src/frequenz/sdk/microgrid/__init__.py
@@ -143,11 +143,9 @@ only charging.
 The SDK provides a unified interface for interacting with sets of Batteries, EV
 chargers and PV arrays, through their corresponding `Pool`s.
 
-| pool type     | constructor                                                         |
-|---------------|---------------------------------------------------------------------|
-| BatteryPool   | [microgrid.battery_pool][frequenz.sdk.microgrid.battery_pool]       |
-| EVChargerPool | [microgrid.ev_charger_pool][frequenz.sdk.microgrid.ev_charger_pool] |
-| PVPool        | [microgrid.pv_pool][frequenz.sdk.microgrid.pv_pool]                 |
+* [Battery pool][frequenz.sdk.microgrid.battery_pool]
+* [EV charger pool][frequenz.sdk.microgrid.ev_charger_pool]
+* [PV pool][frequenz.sdk.microgrid.pv_pool]
 
 All of them provide support for streaming aggregated data and for setting the
 power values of the components.

--- a/src/frequenz/sdk/microgrid/__init__.py
+++ b/src/frequenz/sdk/microgrid/__init__.py
@@ -137,6 +137,56 @@ The `ev_charger_pool` also provides a control method
 [`propose_power`][frequenz.sdk.timeseries.ev_charger_pool.EVChargerPool.propose_power],
 which accepts values in the {{glossary("psc", "Passive Sign Convention")}} and supports
 only charging.
+
+# Component pools
+
+The SDK provides a unified interface for interacting with sets of Batteries, EV
+chargers and PV arrays, through their corresponding `Pool`s.
+
+| pool type     | constructor                                                         |
+|---------------|---------------------------------------------------------------------|
+| BatteryPool   | [microgrid.battery_pool][frequenz.sdk.microgrid.battery_pool]       |
+| EVChargerPool | [microgrid.ev_charger_pool][frequenz.sdk.microgrid.ev_charger_pool] |
+| PVPool        | [microgrid.pv_pool][frequenz.sdk.microgrid.pv_pool]                 |
+
+All of them provide support for streaming aggregated data and for setting the
+power values of the components.
+
+## Streaming component data
+
+All pools have a `power` property, which is a
+[`FormulaEngine`][frequenz.sdk.timeseries.formula_engine.FormulaEngine] that can
+
+- provide a stream of resampled power values, which correspond to the sum of the
+power measured from all the components in the pool together.
+
+- be composed with other power streams to for composite formulas.
+
+In addition, the battery pool has some additional properties that can be used as
+streams for metrics specific to batteries:
+[`soc`][frequenz.sdk.timeseries.battery_pool.BatteryPool.soc],
+[`capacity`][frequenz.sdk.timeseries.battery_pool.BatteryPool.capacity] and
+[`temperature`][frequenz.sdk.timeseries.battery_pool.BatteryPool.temperature].
+
+## Setting power
+
+All pools provide a `propose_power` method for setting power for the pool.  This
+would then be distributed to the individual components in the pool, using an
+algorithm that's suitable for the category of the components.  For example, when
+controlling batteries, power could be distributed based on the `SoC` of the
+individual batteries, to keep the batteries in balance.
+
+### Resolving conflicting power proposals
+
+When there are multiple actors trying to control the same set of batteries, a
+target power is calculated based on the priorities of the actors making the
+requests.  Actors need to specify their priorities as parameters when creating
+the `*Pool` instances using the constructors mentioned above.
+
+The algorithm used for resolving power conflicts based on actor priority can be
+found in the documentation for any of the
+[`propose_power`][frequenz.sdk.timeseries.battery_pool.BatteryPool.propose_power]
+methods.
 """  # noqa: D205, D400
 
 from ..actor import ResamplerConfig

--- a/src/frequenz/sdk/microgrid/_data_pipeline.py
+++ b/src/frequenz/sdk/microgrid/_data_pipeline.py
@@ -199,6 +199,7 @@ class _DataPipeline:  # pylint: disable=too-many-instance-attributes
         priority: int,
         component_ids: abc.Set[int] | None = None,
         name: str | None = None,
+        in_shifting_group: bool = False,
     ) -> EVChargerPool:
         """Return the corresponding EVChargerPool instance for the given ids.
 
@@ -211,6 +212,8 @@ class _DataPipeline:  # pylint: disable=too-many-instance-attributes
                 EVChargerPool.
             name: An optional name used to identify this instance of the pool or a
                 corresponding actor in the logs.
+            in_shifting_group: Whether the power requests get sent to the shifting group
+                in the PowerManager or not.
 
         Returns:
             An EVChargerPool instance.
@@ -264,6 +267,7 @@ class _DataPipeline:  # pylint: disable=too-many-instance-attributes
             pool_ref_store=self._ev_charger_pool_reference_stores[ref_store_key],
             name=name,
             priority=priority,
+            in_shifting_group=in_shifting_group,
         )
 
     def pv_pool(
@@ -272,6 +276,7 @@ class _DataPipeline:  # pylint: disable=too-many-instance-attributes
         priority: int,
         component_ids: abc.Set[int] | None = None,
         name: str | None = None,
+        in_shifting_group: bool = False,
     ) -> PVPool:
         """Return a new `PVPool` instance for the given ids.
 
@@ -284,6 +289,8 @@ class _DataPipeline:  # pylint: disable=too-many-instance-attributes
                 `PVPool`.
             name: An optional name used to identify this instance of the pool or a
                 corresponding actor in the logs.
+            in_shifting_group: Whether the power requests get sent to the shifting group
+                in the PowerManager or not.
 
         Returns:
             A `PVPool` instance.
@@ -334,6 +341,7 @@ class _DataPipeline:  # pylint: disable=too-many-instance-attributes
             pool_ref_store=self._pv_pool_reference_stores[ref_store_key],
             name=name,
             priority=priority,
+            in_shifting_group=in_shifting_group,
         )
 
     def battery_pool(
@@ -342,6 +350,7 @@ class _DataPipeline:  # pylint: disable=too-many-instance-attributes
         priority: int,
         component_ids: abc.Set[int] | None = None,
         name: str | None = None,
+        in_shifting_group: bool = False,
     ) -> BatteryPool:
         """Return a new `BatteryPool` instance for the given ids.
 
@@ -354,6 +363,8 @@ class _DataPipeline:  # pylint: disable=too-many-instance-attributes
                 `BatteryPool`.
             name: An optional name used to identify this instance of the pool or a
                 corresponding actor in the logs.
+            in_shifting_group: Whether the power requests get sent to the shifting group
+                in the PowerManager or not.
 
         Returns:
             A `BatteryPool` instance.
@@ -409,6 +420,7 @@ class _DataPipeline:  # pylint: disable=too-many-instance-attributes
             pool_ref_store=self._battery_pool_reference_stores[ref_store_key],
             name=name,
             priority=priority,
+            in_shifting_group=in_shifting_group,
         )
 
     def _data_sourcing_request_sender(self) -> Sender[ComponentMetricRequest]:
@@ -519,6 +531,7 @@ def ev_charger_pool(
     priority: int,
     component_ids: abc.Set[int] | None = None,
     name: str | None = None,
+    in_shifting_group: bool = False,
 ) -> EVChargerPool:
     """Return a new `EVChargerPool` instance for the given parameters.
 
@@ -544,12 +557,17 @@ def ev_charger_pool(
             component graph are used.
         name: An optional name used to identify this instance of the pool or a
             corresponding actor in the logs.
+        in_shifting_group: Whether the power requests get sent to the shifting group
+            in the PowerManager or not.
 
     Returns:
         An `EVChargerPool` instance.
     """
     return _get().ev_charger_pool(
-        priority=priority, component_ids=component_ids, name=name
+        priority=priority,
+        component_ids=component_ids,
+        name=name,
+        in_shifting_group=in_shifting_group,
     )
 
 
@@ -558,6 +576,7 @@ def battery_pool(
     priority: int,
     component_ids: abc.Set[int] | None = None,
     name: str | None = None,
+    in_shifting_group: bool = False,
 ) -> BatteryPool:
     """Return a new `BatteryPool` instance for the given parameters.
 
@@ -583,12 +602,17 @@ def battery_pool(
             graph are used.
         name: An optional name used to identify this instance of the pool or a
             corresponding actor in the logs.
+        in_shifting_group: Whether the power requests get sent to the shifting group
+            in the PowerManager or not.
 
     Returns:
         A `BatteryPool` instance.
     """
     return _get().battery_pool(
-        priority=priority, component_ids=component_ids, name=name
+        priority=priority,
+        component_ids=component_ids,
+        name=name,
+        in_shifting_group=in_shifting_group,
     )
 
 
@@ -597,6 +621,7 @@ def pv_pool(
     priority: int,
     component_ids: abc.Set[int] | None = None,
     name: str | None = None,
+    in_shifting_group: bool = False,
 ) -> PVPool:
     """Return a new `PVPool` instance for the given parameters.
 
@@ -622,11 +647,18 @@ def pv_pool(
             graph are used.
         name: An optional name used to identify this instance of the pool or a
             corresponding actor in the logs.
+        in_shifting_group: Whether the power requests get sent to the shifting group
+            in the PowerManager or not.
 
     Returns:
         A `PVPool` instance.
     """
-    return _get().pv_pool(priority=priority, component_ids=component_ids, name=name)
+    return _get().pv_pool(
+        priority=priority,
+        component_ids=component_ids,
+        name=name,
+        in_shifting_group=in_shifting_group,
+    )
 
 
 def grid() -> Grid:

--- a/src/frequenz/sdk/timeseries/battery_pool/_battery_pool.py
+++ b/src/frequenz/sdk/timeseries/battery_pool/_battery_pool.py
@@ -59,6 +59,7 @@ class BatteryPool:
         pool_ref_store: BatteryPoolReferenceStore,
         name: str | None,
         priority: int,
+        in_shifting_group: bool,
     ):
         """Create a BatteryPool instance.
 
@@ -72,11 +73,14 @@ class BatteryPool:
             name: An optional name used to identify this instance of the pool or a
                 corresponding actor in the logs.
             priority: The priority of the actor using this wrapper.
+            in_shifting_group: Whether the power requests get sent to the shifting group
+                in the PowerManager or not.
         """
         self._pool_ref_store = pool_ref_store
         unique_id = str(uuid.uuid4())
         self._source_id = unique_id if name is None else f"{name}-{unique_id}"
         self._priority = priority
+        self._in_shifting_group = in_shifting_group
 
     async def propose_power(
         self,
@@ -130,6 +134,7 @@ class BatteryPool:
                 priority=self._priority,
                 creation_time=asyncio.get_running_loop().time(),
                 request_timeout=request_timeout,
+                in_shifting_group=self._in_shifting_group,
             )
         )
 
@@ -176,6 +181,7 @@ class BatteryPool:
                 priority=self._priority,
                 creation_time=asyncio.get_running_loop().time(),
                 request_timeout=request_timeout,
+                in_shifting_group=self._in_shifting_group,
             )
         )
 
@@ -224,6 +230,7 @@ class BatteryPool:
                 priority=self._priority,
                 creation_time=asyncio.get_running_loop().time(),
                 request_timeout=request_timeout,
+                in_shifting_group=self._in_shifting_group,
             )
         )
 
@@ -382,6 +389,7 @@ class BatteryPool:
             source_id=self._source_id,
             priority=self._priority,
             component_ids=self._pool_ref_store._batteries,
+            in_shifting_group=self._in_shifting_group,
         )
         self._pool_ref_store._power_bounds_subs[sub.get_channel_name()] = (
             asyncio.create_task(

--- a/src/frequenz/sdk/timeseries/ev_charger_pool/_ev_charger_pool.py
+++ b/src/frequenz/sdk/timeseries/ev_charger_pool/_ev_charger_pool.py
@@ -45,6 +45,7 @@ class EVChargerPool:
         pool_ref_store: EVChargerPoolReferenceStore,
         name: str | None,
         priority: int,
+        in_shifting_group: bool,
     ) -> None:
         """Create an `EVChargerPool` instance.
 
@@ -58,11 +59,14 @@ class EVChargerPool:
             name: An optional name used to identify this instance of the pool or a
                 corresponding actor in the logs.
             priority: The priority of the actor using this wrapper.
+            in_shifting_group: Whether the power requests get sent to the shifting group
+                in the PowerManager or not.
         """
         self._pool_ref_store = pool_ref_store
         unique_id = str(uuid.uuid4())
         self._source_id = unique_id if name is None else f"{name}-{unique_id}"
         self._priority = priority
+        self._in_shifting_group = in_shifting_group
 
     async def propose_power(
         self,
@@ -128,6 +132,7 @@ class EVChargerPool:
                 priority=self._priority,
                 creation_time=asyncio.get_running_loop().time(),
                 request_timeout=request_timeout,
+                in_shifting_group=self._in_shifting_group,
             )
         )
 
@@ -210,6 +215,7 @@ class EVChargerPool:
             source_id=self._source_id,
             priority=self._priority,
             component_ids=self._pool_ref_store.component_ids,
+            in_shifting_group=self._in_shifting_group,
         )
         self._pool_ref_store.power_bounds_subs[sub.get_channel_name()] = (
             asyncio.create_task(

--- a/src/frequenz/sdk/timeseries/pv_pool/_pv_pool.py
+++ b/src/frequenz/sdk/timeseries/pv_pool/_pv_pool.py
@@ -38,6 +38,7 @@ class PVPool:
         pool_ref_store: PVPoolReferenceStore,
         name: str | None,
         priority: int,
+        in_shifting_group: bool,
     ) -> None:
         """Initialize the instance.
 
@@ -50,11 +51,14 @@ class PVPool:
             pool_ref_store: The reference store for the PV pool.
             name: The name of the PV pool.
             priority: The priority of the PV pool.
+            in_shifting_group: Whether the power requests get sent to the shifting group
+                in the PowerManager or not.
         """
         self._pool_ref_store = pool_ref_store
         unique_id = uuid.uuid4()
         self._source_id = str(unique_id) if name is None else f"{name}-{unique_id}"
         self._priority = priority
+        self._in_shifting_group = in_shifting_group
 
     async def propose_power(
         self,
@@ -117,6 +121,7 @@ class PVPool:
                 priority=self._priority,
                 creation_time=asyncio.get_running_loop().time(),
                 request_timeout=request_timeout,
+                in_shifting_group=self._in_shifting_group,
             )
         )
 
@@ -171,6 +176,7 @@ class PVPool:
             source_id=self._source_id,
             priority=self._priority,
             component_ids=self._pool_ref_store.component_ids,
+            in_shifting_group=self._in_shifting_group,
         )
         self._pool_ref_store.power_bounds_subs[sub.get_channel_name()] = (
             asyncio.create_task(

--- a/tests/actor/_power_managing/test_matryoshka.py
+++ b/tests/actor/_power_managing/test_matryoshka.py
@@ -53,6 +53,7 @@ class StatefulTester:
                     if creation_time is not None
                     else asyncio.get_event_loop().time()
                 ),
+                in_shifting_group=False,
             ),
             self._system_bounds,
             must_send,


### PR DESCRIPTION
There are cases where the target power needs to be shifted by a certain amount, for example, to make adjustments to the operating point.  This PR enables this by designating some actors to be part of the `shifting_group`.

Closes #905 