### PR TITLE
Improve the power managing actor initialization

### DIFF
--- a/src/frequenz/sdk/_internal/_channels.py
+++ b/src/frequenz/sdk/_internal/_channels.py
@@ -92,6 +92,10 @@ class LatestValueCache(typing.Generic[T_co]):
         """Stop the cache."""
         await cancel_and_await(self._task)
 
+    def __del__(self) -> None:
+        """Stop the cache when it is deleted."""
+        self._task.cancel()
+
     def __repr__(self) -> str:
         """Return a string representation of the cache."""
         return (

--- a/src/frequenz/sdk/_internal/_channels.py
+++ b/src/frequenz/sdk/_internal/_channels.py
@@ -36,15 +36,28 @@ class _Sentinel:
 class LatestValueCache(typing.Generic[T_co]):
     """A cache that stores the latest value in a receiver."""
 
-    def __init__(self, receiver: Receiver[T_co]) -> None:
+    def __init__(
+        self, receiver: Receiver[T_co], *, unique_id: str | None = None
+    ) -> None:
         """Create a new cache.
 
         Args:
             receiver: The receiver to cache.
+            unique_id: A string to help uniquely identify this instance. If not
+                provided, a unique identifier will be generated from the object's
+                [`id()`][]. It is used mostly for debugging purposes.
         """
         self._receiver = receiver
+        self._unique_id: str = hex(id(self)) if unique_id is None else unique_id
         self._latest_value: T_co | _Sentinel = _Sentinel()
-        self._task = asyncio.create_task(self._run())
+        self._task = asyncio.create_task(
+            self._run(), name=f"LatestValueCache«{self._unique_id}»"
+        )
+
+    @property
+    def unique_id(self) -> str:
+        """The unique identifier of this instance."""
+        return self._unique_id
 
     def get(self) -> T_co:
         """Return the latest value that has been received.

--- a/src/frequenz/sdk/_internal/_channels.py
+++ b/src/frequenz/sdk/_internal/_channels.py
@@ -91,3 +91,14 @@ class LatestValueCache(typing.Generic[T_co]):
     async def stop(self) -> None:
         """Stop the cache."""
         await cancel_and_await(self._task)
+
+    def __repr__(self) -> str:
+        """Return a string representation of the cache."""
+        return (
+            f"<LatestValueCache latest_value={self._latest_value!r}, "
+            f"receiver={self._receiver!r}, unique_id={self._unique_id!r}>"
+        )
+
+    def __str__(self) -> str:
+        """Return a string representation of the cache."""
+        return str(self._latest_value)

--- a/src/frequenz/sdk/actor/power_distributing/_component_managers/_battery_manager.py
+++ b/src/frequenz/sdk/actor/power_distributing/_component_managers/_battery_manager.py
@@ -191,6 +191,20 @@ class BatteryManager(ComponentManager):
         await self._create_channels()
 
     @override
+    async def wait_for_data(self) -> None:
+        """Wait until this manager receiver data for all components it manages.
+
+        Before this happens, the manager could misbehave, as it would not have all the
+        data it needs to make the appropriate decisions.
+        """
+        await asyncio.gather(
+            *[
+                *[cache.wait_for_value() for cache in self._battery_caches.values()],
+                *[cache.wait_for_value() for cache in self._inverter_caches.values()],
+            ]
+        )
+
+    @override
     async def stop(self) -> None:
         """Stop the battery data manager."""
         for bat_cache in self._battery_caches.values():

--- a/src/frequenz/sdk/actor/power_distributing/_component_managers/_battery_manager.py
+++ b/src/frequenz/sdk/actor/power_distributing/_component_managers/_battery_manager.py
@@ -315,13 +315,19 @@ class BatteryManager(ComponentManager):
     async def _create_channels(self) -> None:
         """Create channels to get data of components in microgrid."""
         api = connection_manager.get().api_client
+        manager_id = f"{type(self).__name__}»{hex(id(self))}»"
         for battery_id, inverter_ids in self._bat_invs_map.items():
             bat_recv: Receiver[BatteryData] = await api.battery_data(battery_id)
-            self._battery_caches[battery_id] = LatestValueCache(bat_recv)
+            self._battery_caches[battery_id] = LatestValueCache(
+                bat_recv,
+                unique_id=f"{manager_id}:battery«{battery_id}»",
+            )
 
             for inverter_id in inverter_ids:
                 inv_recv: Receiver[InverterData] = await api.inverter_data(inverter_id)
-                self._inverter_caches[inverter_id] = LatestValueCache(inv_recv)
+                self._inverter_caches[inverter_id] = LatestValueCache(
+                    inv_recv, unique_id=f"{manager_id}:inverter«{inverter_id}»"
+                )
 
     def _get_bounds(
         self,

--- a/src/frequenz/sdk/actor/power_distributing/_component_managers/_component_manager.py
+++ b/src/frequenz/sdk/actor/power_distributing/_component_managers/_component_manager.py
@@ -39,6 +39,14 @@ class ComponentManager(abc.ABC):
         """Start the component data manager."""
 
     @abc.abstractmethod
+    async def wait_for_data(self) -> None:
+        """Wait until this manager receiver data for all components it manages.
+
+        Before this happens, the manager could misbehave, as it would not have all the
+        data it needs to make the appropriate decisions.
+        """
+
+    @abc.abstractmethod
     async def distribute_power(self, request: Request) -> None:
         """Distribute the requested power to the components.
 

--- a/src/frequenz/sdk/actor/power_distributing/_component_managers/_ev_charger_manager/_ev_charger_manager.py
+++ b/src/frequenz/sdk/actor/power_distributing/_component_managers/_ev_charger_manager/_ev_charger_manager.py
@@ -85,6 +85,14 @@ class EVChargerManager(ComponentManager):
             self._task = asyncio.create_task(self._run_forever())
 
     @override
+    async def wait_for_data(self) -> None:
+        """Wait until this manager receiver data for all components it manages.
+
+        Before this happens, the manager could misbehave, as it would not have all the
+        data it needs to make the appropriate decisions.
+        """
+
+    @override
     async def distribute_power(self, request: Request) -> None:
         """Distribute the requested power to the ev chargers.
 

--- a/src/frequenz/sdk/actor/power_distributing/_component_managers/_ev_charger_manager/_ev_charger_manager.py
+++ b/src/frequenz/sdk/actor/power_distributing/_component_managers/_ev_charger_manager/_ev_charger_manager.py
@@ -55,7 +55,8 @@ class EVChargerManager(ComponentManager):
         self._ev_charger_ids = self._get_ev_charger_ids()
         self._evc_states = EvcStates()
         self._voltage_cache: LatestValueCache[Sample3Phase[Voltage]] = LatestValueCache(
-            microgrid.voltage().new_receiver()
+            microgrid.voltage().new_receiver(),
+            unique_id=f"{type(self).__name__}«{hex(id(self))}»:voltage_cache",
         )
         self._config = EVDistributionConfig(component_ids=self._ev_charger_ids)
         self._component_pool_status_tracker = ComponentPoolStatusTracker(

--- a/src/frequenz/sdk/actor/power_distributing/_component_managers/_pv_inverter_manager/_pv_inverter_manager.py
+++ b/src/frequenz/sdk/actor/power_distributing/_component_managers/_pv_inverter_manager/_pv_inverter_manager.py
@@ -76,7 +76,8 @@ class PVManager(ComponentManager):
         """Start the PV inverter manager."""
         self._component_data_caches = {
             inv_id: LatestValueCache(
-                await connection_manager.get().api_client.inverter_data(inv_id)
+                await connection_manager.get().api_client.inverter_data(inv_id),
+                unique_id=f"{type(self).__name__}«{hex(id(self))}»:inverter«{inv_id}»",
             )
             for inv_id in self._pv_inverter_ids
         }

--- a/src/frequenz/sdk/actor/power_distributing/_component_managers/_pv_inverter_manager/_pv_inverter_manager.py
+++ b/src/frequenz/sdk/actor/power_distributing/_component_managers/_pv_inverter_manager/_pv_inverter_manager.py
@@ -83,6 +83,17 @@ class PVManager(ComponentManager):
         }
 
     @override
+    async def wait_for_data(self) -> None:
+        """Wait until this manager receiver data for all components it manages.
+
+        Before this happens, the manager could misbehave, as it would not have all the
+        data it needs to make the appropriate decisions.
+        """
+        await asyncio.gather(
+            *[cache.wait_for_value() for cache in self._component_data_caches.values()],
+        )
+
+    @override
     async def stop(self) -> None:
         """Stop the PV inverter manager."""
         await asyncio.gather(

--- a/src/frequenz/sdk/actor/power_distributing/power_distributing.py
+++ b/src/frequenz/sdk/actor/power_distributing/power_distributing.py
@@ -16,6 +16,7 @@ import asyncio
 
 from frequenz.channels import Receiver, Sender
 from frequenz.client.microgrid import ComponentCategory, ComponentType, InverterType
+from typing_extensions import override
 
 from ...actor._actor import Actor
 from ._component_managers import (
@@ -119,6 +120,7 @@ class PowerDistributingActor(Actor):
                 f"PowerDistributor doesn't support controlling: {component_category}"
             )
 
+    @override
     async def _run(self) -> None:  # pylint: disable=too-many-locals
         """Run actor main function.
 
@@ -136,6 +138,7 @@ class PowerDistributingActor(Actor):
         async for request in self._requests_receiver:
             await self._component_manager.distribute_power(request)
 
+    @override
     async def stop(self, msg: str | None = None) -> None:
         """Stop this actor.
 

--- a/src/frequenz/sdk/timeseries/ev_charger_pool/_set_current_bounds.py
+++ b/src/frequenz/sdk/timeseries/ev_charger_pool/_set_current_bounds.py
@@ -99,8 +99,10 @@ class BoundsSetter:
             _logger.error(err)
             raise RuntimeError(err)
 
+        meter_id = next(iter(meters)).component_id
         self._meter_data_cache = LatestValueCache(
-            await api_client.meter_data(next(iter(meters)).component_id)
+            await api_client.meter_data(meter_id),
+            unique_id=f"{type(self).__name__}«{hex(id(self))}»:meter«{meter_id}»",
         )
         latest_bound: dict[int, ComponentCurrentLimit] = {}
 


### PR DESCRIPTION
This PR was done while chasing an issue with tests complaining that some tasks were pending while the loop was destroyed.

I guess the issue is in the `pytest_asyncio` plugin, because those tasks seem to be properly cancelled according to my debugging, and we had similar issues with `pytest-asyncio` before.  The weird thing is that the errors show up in a different test from the one that actually creates the tasks, which makes me think that the plugin is not properly cleaning up after itself.

In any case, while debugging this, I found a few things that could be improved in the code in terms of synchoronization during initialization and cleanup.

This PR:

- **Adds a `unique_id` to `LatestValueCache`** to improve the debugging experience (using the new name `unique_id` instead of `name`, as suggested in frequenz-floss/frequenz-core-python#7).
- **Adds `__str__` and `__repr__` to `LatestValueCache`** to use this `unique_id`
- **Cancels `LatestValueCache`'s task if deleted** (just in case)
- **Adds a `wait_for_value()` method to `LatestValueCache`** so we can wait for the cache to be filled with data
- **Adds a `wait_for_data()` method to `ComponentManager`** to wait for all caches to be filled with data
- **Add `@override` to `PowerDistributingActor`** (because why not?)
- **Improve waiting for data in the `PowerDistributingActor`** by using the new `wait_for_data()` method instead of blidly wait for the whole wait time
