### PR TITLE
Rename parameter `in_shifting_group` → `set_operating_point`

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -24,7 +24,7 @@
 
 ## New Features
 
-- Calls to `microgrid.*_pool` methods now accept an optional `in_shifting_group` parameter.  Power requests sent to `*_pool` instances that have the `in_shifting_group` flag set, will get resolved separately, and their target power will be added to the target power calculated from regular actors, if any, which would, in effect, shift the zero for the regular actors by the target power from the shifting group.
+- Calls to `microgrid.*_pool` methods now accept an optional `set_operating_point` parameter, for setting an operating point for the other actors.  This would shift the target power by the operating point before actually applying it to the components.
 
 ## Bug Fixes
 

--- a/src/frequenz/sdk/actor/_power_managing/_base_classes.py
+++ b/src/frequenz/sdk/actor/_power_managing/_base_classes.py
@@ -33,8 +33,8 @@ class ReportRequest:
     priority: int
     """The priority of the actor ."""
 
-    in_shifting_group: bool
-    """Whether the proposal gets sent to the shifting group of the power manager."""
+    set_operating_point: bool
+    """Whether this proposal sets the operating point power or the normal power."""
 
     def get_channel_name(self) -> str:
         """Get the channel name for the report request.
@@ -219,8 +219,8 @@ class Proposal:
     request_timeout: datetime.timedelta = datetime.timedelta(seconds=5.0)
     """The maximum amount of time to wait for the request to be fulfilled."""
 
-    in_shifting_group: bool
-    """Whether the proposal gets sent to the shifting group of the power manager."""
+    set_operating_point: bool
+    """Whether this proposal sets the operating point power or the normal power."""
 
     def __lt__(self, other: Proposal) -> bool:
         """Compare two proposals by their priority.

--- a/src/frequenz/sdk/microgrid/__init__.py
+++ b/src/frequenz/sdk/microgrid/__init__.py
@@ -186,40 +186,39 @@ found in the documentation for any of the
 [`propose_power`][frequenz.sdk.timeseries.battery_pool.BatteryPool.propose_power]
 methods.
 
-### Shifting the target power by an offset
+### Shifting the target power by an Operating Point power
 
-There are cases where the target power needs to be shifted by a certain amount, for
-example, to make adjustments to the operating point.  This can be done by designating
-some actors to be part of the `shifting_group`.
+There are cases where the target power needs to be shifted by an operating point.  This
+can be done by designating some actors to be able to set only the operating point power.
 
 When creating a `*Pool` instance using the above-mentioned constructors, an optional
-`in_shifting_group` parameter can be passed to specify that this actor is special, and
-the target power of the regular actors will be shifted by the target power of all
-shifting actors together.
+`set_operating_point` parameter can be passed to specify that this actor is special, and
+the target power of the regular actors will be shifted by the target power of all actors
+with `set_operating_point` together.
 
-In a location with 2 regular actors and 1 shifting actor, here's how things
+In a location with 2 regular actors and 1 `set_operating_point` actor, here's how things
 would play out:
 
-1. When only non-shifting actors have made proposals, the power bounds available
-   from the batteries are available to them exactly.
+1. When only regular actors have made proposals, the power bounds available from the
+   batteries are available to them exactly.
 
-   | actor priority | in shifting group? | proposed power/bounds | available bounds |
-   |----------------|--------------------|-----------------------|------------------|
-   | 3              | No                 | 1000, -4000..2500     | -3000..3000      |
-   | 2              | No                 | 2500                  | -3000..2500      |
-   | 1              | Yes                | None                  | -3000..3000      |
+   | actor priority | in op group? | proposed power/bounds | available bounds |
+   |----------------|--------------|-----------------------|------------------|
+   | 3              | No           | 1000, -4000..2500     | -3000..3000      |
+   | 2              | No           | 2500                  | -3000..2500      |
+   | 1              | Yes          | None                  | -3000..3000      |
 
    Power actually distributed to the batteries: 2500W
 
-2. When the shifting actor has made proposals, the bounds available to the
-   regular actors gets shifted, and the final power that actually gets
-   distributed to the batteries is also shifted.
+2. When the `set_operating_point` actor has made proposals, the bounds available to the
+   regular actors gets shifted, and the final power that actually gets distributed to
+   the batteries is also shifted.
 
-   | actor priority | in shifting group? | proposed power/bounds | available bounds |
-   |----------------|--------------------|-----------------------|------------------|
-   | 3              | No                 | 1000, -4000..2500     | -2000..4000      |
-   | 2              | No                 | 2500                  | -2000..2500      |
-   | 1              | Yes                | -1000                 | -3000..3000      |
+   | actor priority | in op group? | proposed power/bounds | available bounds |
+   |----------------|--------------|-----------------------|------------------|
+   | 3              | No           | 1000, -4000..2500     | -2000..4000      |
+   | 2              | No           | 2500                  | -2000..2500      |
+   | 1              | Yes          | -1000                 | -3000..3000      |
 
    Power actually distributed to the batteries: 1500W
 """  # noqa: D205, D400

--- a/src/frequenz/sdk/microgrid/_data_pipeline.py
+++ b/src/frequenz/sdk/microgrid/_data_pipeline.py
@@ -199,7 +199,7 @@ class _DataPipeline:  # pylint: disable=too-many-instance-attributes
         priority: int,
         component_ids: abc.Set[int] | None = None,
         name: str | None = None,
-        in_shifting_group: bool = False,
+        set_operating_point: bool = False,
     ) -> EVChargerPool:
         """Return the corresponding EVChargerPool instance for the given ids.
 
@@ -212,8 +212,8 @@ class _DataPipeline:  # pylint: disable=too-many-instance-attributes
                 EVChargerPool.
             name: An optional name used to identify this instance of the pool or a
                 corresponding actor in the logs.
-            in_shifting_group: Whether the power requests get sent to the shifting group
-                in the PowerManager or not.
+            set_operating_point: Whether this instance sets the operating point power or
+                the normal power for the components.
 
         Returns:
             An EVChargerPool instance.
@@ -267,7 +267,7 @@ class _DataPipeline:  # pylint: disable=too-many-instance-attributes
             pool_ref_store=self._ev_charger_pool_reference_stores[ref_store_key],
             name=name,
             priority=priority,
-            in_shifting_group=in_shifting_group,
+            set_operating_point=set_operating_point,
         )
 
     def pv_pool(
@@ -276,7 +276,7 @@ class _DataPipeline:  # pylint: disable=too-many-instance-attributes
         priority: int,
         component_ids: abc.Set[int] | None = None,
         name: str | None = None,
-        in_shifting_group: bool = False,
+        set_operating_point: bool = False,
     ) -> PVPool:
         """Return a new `PVPool` instance for the given ids.
 
@@ -289,8 +289,8 @@ class _DataPipeline:  # pylint: disable=too-many-instance-attributes
                 `PVPool`.
             name: An optional name used to identify this instance of the pool or a
                 corresponding actor in the logs.
-            in_shifting_group: Whether the power requests get sent to the shifting group
-                in the PowerManager or not.
+            set_operating_point: Whether this instance sets the operating point power or
+                the normal power for the components.
 
         Returns:
             A `PVPool` instance.
@@ -341,7 +341,7 @@ class _DataPipeline:  # pylint: disable=too-many-instance-attributes
             pool_ref_store=self._pv_pool_reference_stores[ref_store_key],
             name=name,
             priority=priority,
-            in_shifting_group=in_shifting_group,
+            set_operating_point=set_operating_point,
         )
 
     def battery_pool(
@@ -350,7 +350,7 @@ class _DataPipeline:  # pylint: disable=too-many-instance-attributes
         priority: int,
         component_ids: abc.Set[int] | None = None,
         name: str | None = None,
-        in_shifting_group: bool = False,
+        set_operating_point: bool = False,
     ) -> BatteryPool:
         """Return a new `BatteryPool` instance for the given ids.
 
@@ -363,8 +363,8 @@ class _DataPipeline:  # pylint: disable=too-many-instance-attributes
                 `BatteryPool`.
             name: An optional name used to identify this instance of the pool or a
                 corresponding actor in the logs.
-            in_shifting_group: Whether the power requests get sent to the shifting group
-                in the PowerManager or not.
+            set_operating_point: Whether this instance sets the operating point power or
+                the normal power for the components.
 
         Returns:
             A `BatteryPool` instance.
@@ -420,7 +420,7 @@ class _DataPipeline:  # pylint: disable=too-many-instance-attributes
             pool_ref_store=self._battery_pool_reference_stores[ref_store_key],
             name=name,
             priority=priority,
-            in_shifting_group=in_shifting_group,
+            set_operating_point=set_operating_point,
         )
 
     def _data_sourcing_request_sender(self) -> Sender[ComponentMetricRequest]:
@@ -531,7 +531,7 @@ def ev_charger_pool(
     priority: int,
     component_ids: abc.Set[int] | None = None,
     name: str | None = None,
-    in_shifting_group: bool = False,
+    set_operating_point: bool = False,
 ) -> EVChargerPool:
     """Return a new `EVChargerPool` instance for the given parameters.
 
@@ -557,8 +557,8 @@ def ev_charger_pool(
             component graph are used.
         name: An optional name used to identify this instance of the pool or a
             corresponding actor in the logs.
-        in_shifting_group: Whether the power requests get sent to the shifting group
-            in the PowerManager or not.
+        set_operating_point: Whether this instance sets the operating point power or the
+            normal power for the components.
 
     Returns:
         An `EVChargerPool` instance.
@@ -567,7 +567,7 @@ def ev_charger_pool(
         priority=priority,
         component_ids=component_ids,
         name=name,
-        in_shifting_group=in_shifting_group,
+        set_operating_point=set_operating_point,
     )
 
 
@@ -576,7 +576,7 @@ def battery_pool(
     priority: int,
     component_ids: abc.Set[int] | None = None,
     name: str | None = None,
-    in_shifting_group: bool = False,
+    set_operating_point: bool = False,
 ) -> BatteryPool:
     """Return a new `BatteryPool` instance for the given parameters.
 
@@ -602,8 +602,8 @@ def battery_pool(
             graph are used.
         name: An optional name used to identify this instance of the pool or a
             corresponding actor in the logs.
-        in_shifting_group: Whether the power requests get sent to the shifting group
-            in the PowerManager or not.
+        set_operating_point: Whether this instance sets the operating point power or the
+            normal power for the components.
 
     Returns:
         A `BatteryPool` instance.
@@ -612,7 +612,7 @@ def battery_pool(
         priority=priority,
         component_ids=component_ids,
         name=name,
-        in_shifting_group=in_shifting_group,
+        set_operating_point=set_operating_point,
     )
 
 
@@ -621,7 +621,7 @@ def pv_pool(
     priority: int,
     component_ids: abc.Set[int] | None = None,
     name: str | None = None,
-    in_shifting_group: bool = False,
+    set_operating_point: bool = False,
 ) -> PVPool:
     """Return a new `PVPool` instance for the given parameters.
 
@@ -647,8 +647,8 @@ def pv_pool(
             graph are used.
         name: An optional name used to identify this instance of the pool or a
             corresponding actor in the logs.
-        in_shifting_group: Whether the power requests get sent to the shifting group
-            in the PowerManager or not.
+        set_operating_point: Whether this instance sets the operating point power or the
+            normal power for the components.
 
     Returns:
         A `PVPool` instance.
@@ -657,7 +657,7 @@ def pv_pool(
         priority=priority,
         component_ids=component_ids,
         name=name,
-        in_shifting_group=in_shifting_group,
+        set_operating_point=set_operating_point,
     )
 
 

--- a/src/frequenz/sdk/timeseries/battery_pool/_battery_pool.py
+++ b/src/frequenz/sdk/timeseries/battery_pool/_battery_pool.py
@@ -59,7 +59,7 @@ class BatteryPool:
         pool_ref_store: BatteryPoolReferenceStore,
         name: str | None,
         priority: int,
-        in_shifting_group: bool,
+        set_operating_point: bool,
     ):
         """Create a BatteryPool instance.
 
@@ -73,14 +73,14 @@ class BatteryPool:
             name: An optional name used to identify this instance of the pool or a
                 corresponding actor in the logs.
             priority: The priority of the actor using this wrapper.
-            in_shifting_group: Whether the power requests get sent to the shifting group
-                in the PowerManager or not.
+            set_operating_point: Whether this instance sets the operating point power or
+                the normal power for the components.
         """
         self._pool_ref_store = pool_ref_store
         unique_id = str(uuid.uuid4())
         self._source_id = unique_id if name is None else f"{name}-{unique_id}"
         self._priority = priority
-        self._in_shifting_group = in_shifting_group
+        self._set_operating_point = set_operating_point
 
     async def propose_power(
         self,
@@ -134,7 +134,7 @@ class BatteryPool:
                 priority=self._priority,
                 creation_time=asyncio.get_running_loop().time(),
                 request_timeout=request_timeout,
-                in_shifting_group=self._in_shifting_group,
+                set_operating_point=self._set_operating_point,
             )
         )
 
@@ -181,7 +181,7 @@ class BatteryPool:
                 priority=self._priority,
                 creation_time=asyncio.get_running_loop().time(),
                 request_timeout=request_timeout,
-                in_shifting_group=self._in_shifting_group,
+                set_operating_point=self._set_operating_point,
             )
         )
 
@@ -230,7 +230,7 @@ class BatteryPool:
                 priority=self._priority,
                 creation_time=asyncio.get_running_loop().time(),
                 request_timeout=request_timeout,
-                in_shifting_group=self._in_shifting_group,
+                set_operating_point=self._set_operating_point,
             )
         )
 
@@ -389,7 +389,7 @@ class BatteryPool:
             source_id=self._source_id,
             priority=self._priority,
             component_ids=self._pool_ref_store._batteries,
-            in_shifting_group=self._in_shifting_group,
+            set_operating_point=self._set_operating_point,
         )
         self._pool_ref_store._power_bounds_subs[sub.get_channel_name()] = (
             asyncio.create_task(

--- a/src/frequenz/sdk/timeseries/ev_charger_pool/_ev_charger_pool.py
+++ b/src/frequenz/sdk/timeseries/ev_charger_pool/_ev_charger_pool.py
@@ -45,7 +45,7 @@ class EVChargerPool:
         pool_ref_store: EVChargerPoolReferenceStore,
         name: str | None,
         priority: int,
-        in_shifting_group: bool,
+        set_operating_point: bool,
     ) -> None:
         """Create an `EVChargerPool` instance.
 
@@ -59,14 +59,14 @@ class EVChargerPool:
             name: An optional name used to identify this instance of the pool or a
                 corresponding actor in the logs.
             priority: The priority of the actor using this wrapper.
-            in_shifting_group: Whether the power requests get sent to the shifting group
-                in the PowerManager or not.
+            set_operating_point: Whether this instance sets the operating point power or
+                the normal power for the components.
         """
         self._pool_ref_store = pool_ref_store
         unique_id = str(uuid.uuid4())
         self._source_id = unique_id if name is None else f"{name}-{unique_id}"
         self._priority = priority
-        self._in_shifting_group = in_shifting_group
+        self._set_operating_point = set_operating_point
 
     async def propose_power(
         self,
@@ -132,7 +132,7 @@ class EVChargerPool:
                 priority=self._priority,
                 creation_time=asyncio.get_running_loop().time(),
                 request_timeout=request_timeout,
-                in_shifting_group=self._in_shifting_group,
+                set_operating_point=self._set_operating_point,
             )
         )
 
@@ -215,7 +215,7 @@ class EVChargerPool:
             source_id=self._source_id,
             priority=self._priority,
             component_ids=self._pool_ref_store.component_ids,
-            in_shifting_group=self._in_shifting_group,
+            set_operating_point=self._set_operating_point,
         )
         self._pool_ref_store.power_bounds_subs[sub.get_channel_name()] = (
             asyncio.create_task(

--- a/src/frequenz/sdk/timeseries/pv_pool/_pv_pool.py
+++ b/src/frequenz/sdk/timeseries/pv_pool/_pv_pool.py
@@ -38,7 +38,7 @@ class PVPool:
         pool_ref_store: PVPoolReferenceStore,
         name: str | None,
         priority: int,
-        in_shifting_group: bool,
+        set_operating_point: bool,
     ) -> None:
         """Initialize the instance.
 
@@ -51,14 +51,14 @@ class PVPool:
             pool_ref_store: The reference store for the PV pool.
             name: The name of the PV pool.
             priority: The priority of the PV pool.
-            in_shifting_group: Whether the power requests get sent to the shifting group
-                in the PowerManager or not.
+            set_operating_point: Whether this instance sets the operating point power or
+                the normal power for the components.
         """
         self._pool_ref_store = pool_ref_store
         unique_id = uuid.uuid4()
         self._source_id = str(unique_id) if name is None else f"{name}-{unique_id}"
         self._priority = priority
-        self._in_shifting_group = in_shifting_group
+        self._set_operating_point = set_operating_point
 
     async def propose_power(
         self,
@@ -121,7 +121,7 @@ class PVPool:
                 priority=self._priority,
                 creation_time=asyncio.get_running_loop().time(),
                 request_timeout=request_timeout,
-                in_shifting_group=self._in_shifting_group,
+                set_operating_point=self._set_operating_point,
             )
         )
 
@@ -176,7 +176,7 @@ class PVPool:
             source_id=self._source_id,
             priority=self._priority,
             component_ids=self._pool_ref_store.component_ids,
-            in_shifting_group=self._in_shifting_group,
+            set_operating_point=self._set_operating_point,
         )
         self._pool_ref_store.power_bounds_subs[sub.get_channel_name()] = (
             asyncio.create_task(

--- a/tests/actor/_power_managing/test_matryoshka.py
+++ b/tests/actor/_power_managing/test_matryoshka.py
@@ -53,7 +53,7 @@ class StatefulTester:
                     if creation_time is not None
                     else asyncio.get_event_loop().time()
                 ),
-                in_shifting_group=False,
+                set_operating_point=False,
             ),
             self._system_bounds,
             must_send,

--- a/tests/timeseries/_battery_pool/test_battery_pool_control_methods.py
+++ b/tests/timeseries/_battery_pool/test_battery_pool_control_methods.py
@@ -514,9 +514,9 @@ class TestBatteryPoolControl:
         await self._init_data_for_batteries(mocks)
         await self._init_data_for_inverters(mocks)
 
-        battery_pool_4 = microgrid.battery_pool(priority=4, in_shifting_group=True)
+        battery_pool_4 = microgrid.battery_pool(priority=4, set_operating_point=True)
         bounds_4_rx = battery_pool_4.power_status.new_receiver()
-        battery_pool_3 = microgrid.battery_pool(priority=3, in_shifting_group=True)
+        battery_pool_3 = microgrid.battery_pool(priority=3, set_operating_point=True)
         bounds_3_rx = battery_pool_3.power_status.new_receiver()
         battery_pool_2 = microgrid.battery_pool(priority=2)
         bounds_2_rx = battery_pool_2.power_status.new_receiver()


### PR DESCRIPTION
This is part of the public interface in the constructors for the
`*_pool`s in the data pipeline, but other than that, all changes are
internal, except for the documentation.

This commit updates all occurrences, docstrings, documentation and
release notes to reflect the new name.