### PR TITLE
Stop using a deprecated way to replace the event loop in tests

### DIFF
--- a/tests/actor/test_background_service.py
+++ b/tests/actor/test_background_service.py
@@ -3,7 +3,6 @@
 
 """Simple test for the BaseActor."""
 import asyncio
-from collections.abc import Iterator
 from typing import Literal, assert_never
 
 import async_solipsism
@@ -12,13 +11,10 @@ import pytest
 from frequenz.sdk.actor import BackgroundService
 
 
-# Setting 'autouse' has no effect as this method replaces the event loop for all tests in the file.
-@pytest.fixture()
-def event_loop() -> Iterator[async_solipsism.EventLoop]:
-    """Replace the loop with one that doesn't interact with the outside world."""
-    loop = async_solipsism.EventLoop()
-    yield loop
-    loop.close()
+@pytest.fixture(autouse=True)
+def event_loop_policy() -> async_solipsism.EventLoopPolicy:
+    """Return an event loop policy that uses the async solipsism event loop."""
+    return async_solipsism.EventLoopPolicy()
 
 
 class FakeService(BackgroundService):

--- a/tests/actor/test_resampling.py
+++ b/tests/actor/test_resampling.py
@@ -4,7 +4,6 @@
 """Frequenz Python SDK resampling example."""
 import asyncio
 import dataclasses
-from collections.abc import Iterator
 from datetime import datetime, timedelta, timezone
 
 import async_solipsism
@@ -22,17 +21,11 @@ from frequenz.sdk.actor import (
 from frequenz.sdk.timeseries import Sample
 from frequenz.sdk.timeseries._quantities import Quantity
 
-# pylint: disable=too-many-locals,redefined-outer-name
-#
 
-
-# Setting 'autouse' has no effect as this method replaces the event loop for all tests in the file.
-@pytest.fixture()
-def event_loop() -> Iterator[async_solipsism.EventLoop]:
-    """Replace the loop with one that doesn't interact with the outside world."""
-    loop = async_solipsism.EventLoop()
-    yield loop
-    loop.close()
+@pytest.fixture(autouse=True)
+def event_loop_policy() -> async_solipsism.EventLoopPolicy:
+    """Return an event loop policy that uses the async solipsism event loop."""
+    return async_solipsism.EventLoopPolicy()
 
 
 def _now() -> datetime:

--- a/tests/actor/test_run_utils.py
+++ b/tests/actor/test_run_utils.py
@@ -5,7 +5,6 @@
 
 import asyncio
 import time
-from collections.abc import Iterator
 
 import async_solipsism
 import pytest
@@ -14,13 +13,10 @@ import time_machine
 from frequenz.sdk.actor import Actor, run
 
 
-# Setting 'autouse' has no effect as this method replaces the event loop for all tests in the file.
-@pytest.fixture()
-def event_loop() -> Iterator[async_solipsism.EventLoop]:
-    """Replace the loop with one that doesn't interact with the outside world."""
-    loop = async_solipsism.EventLoop()
-    yield loop
-    loop.close()
+@pytest.fixture(autouse=True)
+def event_loop_policy() -> async_solipsism.EventLoopPolicy:
+    """Return an event loop policy that uses the async solipsism event loop."""
+    return async_solipsism.EventLoopPolicy()
 
 
 class FaultyActor(Actor):

--- a/tests/microgrid/test_datapipeline.py
+++ b/tests/microgrid/test_datapipeline.py
@@ -4,7 +4,6 @@
 """Basic tests for the DataPipeline."""
 
 import asyncio
-from collections.abc import Iterator
 from datetime import timedelta
 
 import async_solipsism
@@ -24,12 +23,10 @@ from frequenz.sdk.timeseries._resampling import ResamplerConfig
 from ..utils.mock_microgrid_client import MockMicrogridClient
 
 
-@pytest.fixture
-def event_loop() -> Iterator[async_solipsism.EventLoop]:
-    """Replace the loop with one that doesn't interact with the outside world."""
-    loop = async_solipsism.EventLoop()
-    yield loop
-    loop.close()
+@pytest.fixture(autouse=True)
+def event_loop_policy() -> async_solipsism.EventLoopPolicy:
+    """Return an event loop policy that uses the async solipsism event loop."""
+    return async_solipsism.EventLoopPolicy()
 
 
 # loop time is advanced but not the system time

--- a/tests/timeseries/_battery_pool/test_battery_pool.py
+++ b/tests/timeseries/_battery_pool/test_battery_pool.py
@@ -10,7 +10,7 @@ import asyncio
 import dataclasses
 import logging
 import math
-from collections.abc import AsyncIterator, Iterator
+from collections.abc import AsyncIterator
 from dataclasses import dataclass, is_dataclass, replace
 from datetime import datetime, timedelta, timezone
 from typing import Any, Generic, TypeVar
@@ -58,18 +58,11 @@ from ...utils.mock_microgrid_client import MockMicrogridClient
 
 _logger = logging.getLogger(__name__)
 
-# pylint doesn't understand fixtures. It thinks it is redefined name.
-# pylint: disable=redefined-outer-name
 
-# pylint: disable=too-many-lines
-
-
-@pytest.fixture()
-def event_loop() -> Iterator[async_solipsism.EventLoop]:
-    """Replace the loop with one that doesn't interact with the outside world."""
-    loop = async_solipsism.EventLoop()
-    yield loop
-    loop.close()
+@pytest.fixture(autouse=True)
+def event_loop_policy() -> async_solipsism.EventLoopPolicy:
+    """Return an event loop policy that uses the async solipsism event loop."""
+    return async_solipsism.EventLoopPolicy()
 
 
 def get_components(

--- a/tests/timeseries/test_moving_window.py
+++ b/tests/timeseries/test_moving_window.py
@@ -4,7 +4,7 @@
 """Tests for the moving window."""
 
 import asyncio
-from collections.abc import Iterator, Sequence
+from collections.abc import Sequence
 from datetime import datetime, timedelta, timezone
 
 import async_solipsism
@@ -19,13 +19,10 @@ from frequenz.sdk.timeseries._quantities import Quantity
 from frequenz.sdk.timeseries._resampling import ResamplerConfig
 
 
-# Setting 'autouse' has no effect as this method replaces the event loop for all tests in the file.
-@pytest.fixture()
-def event_loop() -> Iterator[async_solipsism.EventLoop]:
-    """Replace the loop with one that doesn't interact with the outside world."""
-    loop = async_solipsism.EventLoop()
-    yield loop
-    loop.close()
+@pytest.fixture(autouse=True)
+def event_loop_policy() -> async_solipsism.EventLoopPolicy:
+    """Return an event loop policy that uses the async solipsism event loop."""
+    return async_solipsism.EventLoopPolicy()
 
 
 async def push_logical_meter_data(

--- a/tests/timeseries/test_resampling.py
+++ b/tests/timeseries/test_resampling.py
@@ -6,7 +6,7 @@
 
 import asyncio
 import logging
-from collections.abc import AsyncIterator, Iterator
+from collections.abc import AsyncIterator
 from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock, MagicMock
 
@@ -33,17 +33,14 @@ from frequenz.sdk.timeseries._resampling import (
 
 from ..utils import a_sequence
 
-# We relax some pylint checks as for tests they don't make a lot of sense.
-# pylint: disable=too-many-lines,disable=too-many-locals,redefined-outer-name
+# We relax some pylint checks as for tests they don't make a lot of sense for this test.
+# pylint: disable=too-many-lines,disable=too-many-locals
 
 
-# Setting 'autouse' has no effect as this method replaces the event loop for all tests in the file.
-@pytest.fixture()
-def event_loop() -> Iterator[async_solipsism.EventLoop]:
-    """Replace the loop with one that doesn't interact with the outside world."""
-    loop = async_solipsism.EventLoop()
-    yield loop
-    loop.close()
+@pytest.fixture(autouse=True)
+def event_loop_policy() -> async_solipsism.EventLoopPolicy:
+    """Return an event loop policy that uses the async solipsism event loop."""
+    return async_solipsism.EventLoopPolicy()
 
 
 @pytest.fixture


### PR DESCRIPTION
The new version of pytest-async doesn't allow overriding the event loop with a fixture as we used to, so we need to use the `event_loop_policy` fixture instead.

Fixes #975.