### PR TITLE
Rename `microgrid.*_pool` constructors to `new_*_pool`

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,7 +6,10 @@
 
 ## Upgrading
 
-<!-- Here goes notes on how to upgrade from previous versions, including deprecations and what they should be replaced with -->
+- The `frequenz.sdk.microgrid.*_pool` methods has been renamed to `new_*_pool`, to make it explicit that they create new instances of the pool classes.
+  + `battery_pool` -> `new_battery_pool`
+  + `ev_charger_pool` -> `new_ev_charger_pool`
+  + `pv_pool` -> `new_pv_pool`
 
 ## New Features
 

--- a/benchmarks/power_distribution/power_distributor.py
+++ b/benchmarks/power_distribution/power_distributor.py
@@ -50,7 +50,7 @@ async def send_requests(batteries: set[int], request_num: int) -> list[Result]:
     Returns:
         List of the results from the PowerDistributingActor.
     """
-    battery_pool = microgrid.battery_pool(priority=5, component_ids=batteries)
+    battery_pool = microgrid.new_battery_pool(priority=5, component_ids=batteries)
     results_rx = battery_pool.power_status.new_receiver()
     result: list[Any] = []
     for _ in range(request_num):

--- a/examples/battery_pool.py
+++ b/examples/battery_pool.py
@@ -30,7 +30,7 @@ async def main() -> None:
         resampler_config=ResamplerConfig(resampling_period=timedelta(seconds=1.0)),
     )
 
-    battery_pool = microgrid.battery_pool(priority=5)
+    battery_pool = microgrid.new_battery_pool(priority=5)
     receivers = [
         battery_pool.soc.new_receiver(limit=1),
         battery_pool.capacity.new_receiver(limit=1),

--- a/src/frequenz/sdk/actor/_power_managing/_power_managing_actor.py
+++ b/src/frequenz/sdk/actor/_power_managing/_power_managing_actor.py
@@ -184,7 +184,7 @@ class PowerManagingActor(Actor):  # pylint: disable=too-many-instance-attributes
             self._component_category is ComponentCategory.INVERTER
             and self._component_type is InverterType.SOLAR
         ):
-            pv_pool = microgrid.pv_pool(
+            pv_pool = microgrid.new_pv_pool(
                 priority=-sys.maxsize - 1, component_ids=component_ids
             )
             bounds_receiver = pv_pool._system_power_bounds.new_receiver()

--- a/src/frequenz/sdk/actor/_power_managing/_power_managing_actor.py
+++ b/src/frequenz/sdk/actor/_power_managing/_power_managing_actor.py
@@ -171,7 +171,7 @@ class PowerManagingActor(Actor):  # pylint: disable=too-many-instance-attributes
         bounds_receiver: Receiver[SystemBounds]
         # pylint: disable=protected-access
         if self._component_category is ComponentCategory.BATTERY:
-            battery_pool = microgrid.battery_pool(
+            battery_pool = microgrid.new_battery_pool(
                 priority=-sys.maxsize - 1, component_ids=component_ids
             )
             bounds_receiver = battery_pool._system_power_bounds.new_receiver()

--- a/src/frequenz/sdk/actor/_power_managing/_power_managing_actor.py
+++ b/src/frequenz/sdk/actor/_power_managing/_power_managing_actor.py
@@ -176,7 +176,7 @@ class PowerManagingActor(Actor):  # pylint: disable=too-many-instance-attributes
             )
             bounds_receiver = battery_pool._system_power_bounds.new_receiver()
         elif self._component_category is ComponentCategory.EV_CHARGER:
-            ev_charger_pool = microgrid.ev_charger_pool(
+            ev_charger_pool = microgrid.new_ev_charger_pool(
                 priority=-sys.maxsize - 1, component_ids=component_ids
             )
             bounds_receiver = ev_charger_pool._system_power_bounds.new_receiver()

--- a/src/frequenz/sdk/microgrid/__init__.py
+++ b/src/frequenz/sdk/microgrid/__init__.py
@@ -85,7 +85,7 @@ microgrid, the corresponding methods stream zero values.
 ## PV Arrays
 
 The total PV power production is available through
-[`pv_pool`][frequenz.sdk.microgrid.pv_pool]'s
+[`pv_pool`][frequenz.sdk.microgrid.new_pv_pool]'s
 [`power`][frequenz.sdk.timeseries.pv_pool.PVPool.power].  The PV pool by default uses
 all PV inverters available at a location, but PV pool instances can be created for
 subsets of PV inverters if necessary, by specifying the inverter ids.
@@ -143,9 +143,9 @@ only charging.
 The SDK provides a unified interface for interacting with sets of Batteries, EV
 chargers and PV arrays, through their corresponding `Pool`s.
 
-* [PV pool][frequenz.sdk.microgrid.pv_pool]
 * [Battery pool][frequenz.sdk.microgrid.new_battery_pool]
 * [EV charger pool][frequenz.sdk.microgrid.new_ev_charger_pool]
+* [PV pool][frequenz.sdk.microgrid.new_pv_pool]
 
 All of them provide support for streaming aggregated data and for setting the
 power values of the components.
@@ -232,8 +232,8 @@ from ._data_pipeline import (
     logical_meter,
     new_battery_pool,
     new_ev_charger_pool,
+    new_pv_pool,
     producer,
-    pv_pool,
     voltage,
 )
 
@@ -261,7 +261,7 @@ __all__ = [
     "logical_meter",
     "new_battery_pool",
     "new_ev_charger_pool",
+    "new_pv_pool",
     "producer",
-    "pv_pool",
     "voltage",
 ]

--- a/src/frequenz/sdk/microgrid/__init__.py
+++ b/src/frequenz/sdk/microgrid/__init__.py
@@ -123,7 +123,7 @@ charging and discharging), or through
 
 ## EV Chargers
 
-The [`ev_charger_pool`][frequenz.sdk.microgrid.ev_charger_pool] offers a
+The [`ev_charger_pool`][frequenz.sdk.microgrid.new_ev_charger_pool] offers a
 [`power`][frequenz.sdk.timeseries.ev_charger_pool.EVChargerPool.power] method that
 streams the total power measured for all the {{glossary("ev-charger", "EV Chargers")}}
 at a site.
@@ -143,9 +143,9 @@ only charging.
 The SDK provides a unified interface for interacting with sets of Batteries, EV
 chargers and PV arrays, through their corresponding `Pool`s.
 
-* [EV charger pool][frequenz.sdk.microgrid.ev_charger_pool]
 * [PV pool][frequenz.sdk.microgrid.pv_pool]
 * [Battery pool][frequenz.sdk.microgrid.new_battery_pool]
+* [EV charger pool][frequenz.sdk.microgrid.new_ev_charger_pool]
 
 All of them provide support for streaming aggregated data and for setting the
 power values of the components.
@@ -227,11 +227,11 @@ from ..actor import ResamplerConfig
 from . import _data_pipeline, connection_manager
 from ._data_pipeline import (
     consumer,
-    ev_charger_pool,
     frequency,
     grid,
     logical_meter,
     new_battery_pool,
+    new_ev_charger_pool,
     producer,
     pv_pool,
     voltage,
@@ -256,11 +256,11 @@ async def initialize(server_url: str, resampler_config: ResamplerConfig) -> None
 __all__ = [
     "initialize",
     "consumer",
-    "ev_charger_pool",
     "grid",
     "frequency",
     "logical_meter",
     "new_battery_pool",
+    "new_ev_charger_pool",
     "producer",
     "pv_pool",
     "voltage",

--- a/src/frequenz/sdk/microgrid/__init__.py
+++ b/src/frequenz/sdk/microgrid/__init__.py
@@ -101,8 +101,8 @@ production.
 
 ## Batteries
 
-The total Battery power is available through
-[`battery_pool`][frequenz.sdk.microgrid.battery_pool]'s
+The total Battery power is available through the
+[`battery_pool`][frequenz.sdk.microgrid.new_battery_pool]'s
 [`power`][frequenz.sdk.timeseries.battery_pool.BatteryPool.power].  The battery pool by
 default uses all batteries available at a location, but battery pool instances can be
 created for subsets of batteries if necessary, by specifying the battery ids.
@@ -143,9 +143,9 @@ only charging.
 The SDK provides a unified interface for interacting with sets of Batteries, EV
 chargers and PV arrays, through their corresponding `Pool`s.
 
-* [Battery pool][frequenz.sdk.microgrid.battery_pool]
 * [EV charger pool][frequenz.sdk.microgrid.ev_charger_pool]
 * [PV pool][frequenz.sdk.microgrid.pv_pool]
+* [Battery pool][frequenz.sdk.microgrid.new_battery_pool]
 
 All of them provide support for streaming aggregated data and for setting the
 power values of the components.
@@ -226,12 +226,12 @@ would play out:
 from ..actor import ResamplerConfig
 from . import _data_pipeline, connection_manager
 from ._data_pipeline import (
-    battery_pool,
     consumer,
     ev_charger_pool,
     frequency,
     grid,
     logical_meter,
+    new_battery_pool,
     producer,
     pv_pool,
     voltage,
@@ -256,11 +256,11 @@ async def initialize(server_url: str, resampler_config: ResamplerConfig) -> None
 __all__ = [
     "initialize",
     "consumer",
-    "battery_pool",
     "ev_charger_pool",
     "grid",
     "frequency",
     "logical_meter",
+    "new_battery_pool",
     "producer",
     "pv_pool",
     "voltage",

--- a/src/frequenz/sdk/microgrid/_data_pipeline.py
+++ b/src/frequenz/sdk/microgrid/_data_pipeline.py
@@ -193,7 +193,7 @@ class _DataPipeline:  # pylint: disable=too-many-instance-attributes
 
         return self._grid
 
-    def ev_charger_pool(
+    def new_ev_charger_pool(
         self,
         *,
         priority: int,
@@ -526,7 +526,7 @@ def producer() -> Producer:
     return _get().producer()
 
 
-def ev_charger_pool(
+def new_ev_charger_pool(
     *,
     priority: int,
     component_ids: abc.Set[int] | None = None,
@@ -563,7 +563,7 @@ def ev_charger_pool(
     Returns:
         An `EVChargerPool` instance.
     """
-    return _get().ev_charger_pool(
+    return _get().new_ev_charger_pool(
         priority=priority,
         component_ids=component_ids,
         name=name,

--- a/src/frequenz/sdk/microgrid/_data_pipeline.py
+++ b/src/frequenz/sdk/microgrid/_data_pipeline.py
@@ -270,7 +270,7 @@ class _DataPipeline:  # pylint: disable=too-many-instance-attributes
             set_operating_point=set_operating_point,
         )
 
-    def pv_pool(
+    def new_pv_pool(
         self,
         *,
         priority: int,
@@ -616,7 +616,7 @@ def new_battery_pool(
     )
 
 
-def pv_pool(
+def new_pv_pool(
     *,
     priority: int,
     component_ids: abc.Set[int] | None = None,
@@ -653,7 +653,7 @@ def pv_pool(
     Returns:
         A `PVPool` instance.
     """
-    return _get().pv_pool(
+    return _get().new_pv_pool(
         priority=priority,
         component_ids=component_ids,
         name=name,

--- a/src/frequenz/sdk/microgrid/_data_pipeline.py
+++ b/src/frequenz/sdk/microgrid/_data_pipeline.py
@@ -344,7 +344,7 @@ class _DataPipeline:  # pylint: disable=too-many-instance-attributes
             set_operating_point=set_operating_point,
         )
 
-    def battery_pool(
+    def new_battery_pool(
         self,
         *,
         priority: int,
@@ -571,7 +571,7 @@ def ev_charger_pool(
     )
 
 
-def battery_pool(
+def new_battery_pool(
     *,
     priority: int,
     component_ids: abc.Set[int] | None = None,
@@ -608,7 +608,7 @@ def battery_pool(
     Returns:
         A `BatteryPool` instance.
     """
-    return _get().battery_pool(
+    return _get().new_battery_pool(
         priority=priority,
         component_ids=component_ids,
         name=name,

--- a/src/frequenz/sdk/timeseries/battery_pool/_battery_pool.py
+++ b/src/frequenz/sdk/timeseries/battery_pool/_battery_pool.py
@@ -65,8 +65,8 @@ class BatteryPool:
 
         !!! note
             `BatteryPool` instances are not meant to be created directly by users.  Use
-            the [`microgrid.battery_pool`][frequenz.sdk.microgrid.battery_pool] method
-            for creating `BatteryPool` instances.
+            the [`microgrid.new_battery_pool`][frequenz.sdk.microgrid.new_battery_pool]
+            method for creating `BatteryPool` instances.
 
         Args:
             pool_ref_store: The battery pool reference store instance.

--- a/src/frequenz/sdk/timeseries/battery_pool/_result_types.py
+++ b/src/frequenz/sdk/timeseries/battery_pool/_result_types.py
@@ -66,7 +66,7 @@ class BatteryPoolReport(Report):
             ```python
             from frequenz.sdk import microgrid
 
-            power_status_rx = microgrid.battery_pool(
+            power_status_rx = microgrid.new_battery_pool(
                 priority=5,
             ).power_status.new_receiver()
             power_status = await power_status_rx.receive()

--- a/src/frequenz/sdk/timeseries/ev_charger_pool/_ev_charger_pool.py
+++ b/src/frequenz/sdk/timeseries/ev_charger_pool/_ev_charger_pool.py
@@ -50,8 +50,10 @@ class EVChargerPool:
         """Create an `EVChargerPool` instance.
 
         !!! note
+
             `EVChargerPool` instances are not meant to be created directly by users. Use
-            the [`microgrid.ev_charger_pool`][frequenz.sdk.microgrid.ev_charger_pool]
+            the
+            [`microgrid.new_ev_charger_pool`][frequenz.sdk.microgrid.new_ev_charger_pool]
             method for creating `EVChargerPool` instances.
 
         Args:

--- a/src/frequenz/sdk/timeseries/formula_engine/_formula_engine.py
+++ b/src/frequenz/sdk/timeseries/formula_engine/_formula_engine.py
@@ -253,7 +253,7 @@ class FormulaEngine(
     ```python
     from frequenz.sdk import microgrid
 
-    battery_pool = microgrid.battery_pool(priority=5)
+    battery_pool = microgrid.new_battery_pool(priority=5)
 
     async for power in battery_pool.power.new_receiver():
         print(f"{power=}")
@@ -277,8 +277,8 @@ class FormulaEngine(
     from frequenz.sdk import microgrid
 
     logical_meter = microgrid.logical_meter()
-    battery_pool = microgrid.battery_pool(priority=5)
     ev_charger_pool = microgrid.ev_charger_pool(priority=5)
+    battery_pool = microgrid.new_battery_pool(priority=5)
     grid = microgrid.grid()
 
     # apply operations on formula engines to create a formula engine that would

--- a/src/frequenz/sdk/timeseries/formula_engine/_formula_engine.py
+++ b/src/frequenz/sdk/timeseries/formula_engine/_formula_engine.py
@@ -266,8 +266,8 @@ class FormulaEngine(
 
     For example, if you're interested in a particular composite metric that can be
     calculated by subtracting
-    [`battery_pool().power`][frequenz.sdk.timeseries.battery_pool.BatteryPool.power] and
-    [`ev_charger_pool().power`][frequenz.sdk.timeseries.ev_charger_pool.EVChargerPool]
+    [`new_battery_pool().power`][frequenz.sdk.timeseries.battery_pool.BatteryPool.power] and
+    [`new_ev_charger_pool().power`][frequenz.sdk.timeseries.ev_charger_pool.EVChargerPool]
     from the
     [`grid().power`][frequenz.sdk.timeseries.grid.Grid.power],
     we can build a `FormulaEngine` that provides a stream of this calculated metric as
@@ -277,8 +277,8 @@ class FormulaEngine(
     from frequenz.sdk import microgrid
 
     logical_meter = microgrid.logical_meter()
-    ev_charger_pool = microgrid.ev_charger_pool(priority=5)
     battery_pool = microgrid.new_battery_pool(priority=5)
+    ev_charger_pool = microgrid.new_ev_charger_pool(priority=5)
     grid = microgrid.grid()
 
     # apply operations on formula engines to create a formula engine that would
@@ -459,7 +459,7 @@ class FormulaEngine3Phase(
     ```python
     from frequenz.sdk import microgrid
 
-    ev_charger_pool = microgrid.ev_charger_pool(priority=5)
+    ev_charger_pool = microgrid.new_ev_charger_pool(priority=5)
 
     async for sample in ev_charger_pool.current.new_receiver():
         print(f"Current: {sample}")
@@ -474,7 +474,7 @@ class FormulaEngine3Phase(
     from frequenz.sdk import microgrid
 
     logical_meter = microgrid.logical_meter()
-    ev_charger_pool = microgrid.ev_charger_pool(priority=5)
+    ev_charger_pool = microgrid.new_ev_charger_pool(priority=5)
     grid = microgrid.grid()
 
     # Calculate grid consumption current that's not used by the EV chargers

--- a/src/frequenz/sdk/timeseries/logical_meter/_logical_meter.py
+++ b/src/frequenz/sdk/timeseries/logical_meter/_logical_meter.py
@@ -41,7 +41,7 @@ class LogicalMeter:
         )
 
         logical_meter = microgrid.logical_meter()
-        pv_pool = microgrid.pv_pool(priority=5)
+        pv_pool = microgrid.new_pv_pool(priority=5)
         grid = microgrid.grid()
 
         # Get a receiver for a builtin formula

--- a/src/frequenz/sdk/timeseries/pv_pool/_pv_pool.py
+++ b/src/frequenz/sdk/timeseries/pv_pool/_pv_pool.py
@@ -44,8 +44,8 @@ class PVPool:
 
         !!! note
             `PVPool` instances are not meant to be created directly by users. Use the
-            [`microgrid.pv_pool`][frequenz.sdk.microgrid.pv_pool] method for creating
-            `PVPool` instances.
+            [`microgrid.new_pv_pool`][frequenz.sdk.microgrid.new_pv_pool] method for
+            creating `PVPool` instances.
 
         Args:
             pool_ref_store: The reference store for the PV pool.

--- a/tests/microgrid/test_datapipeline.py
+++ b/tests/microgrid/test_datapipeline.py
@@ -68,7 +68,7 @@ async def test_actors_started(
     )
     mock_client.initialize(mocker)
 
-    datapipeline.battery_pool(priority=5)
+    datapipeline.new_battery_pool(priority=5)
 
     assert datapipeline._battery_power_wrapper._power_distributing_actor is not None
     await asyncio.sleep(1)

--- a/tests/timeseries/_battery_pool/test_battery_pool.py
+++ b/tests/timeseries/_battery_pool/test_battery_pool.py
@@ -151,7 +151,7 @@ async def setup_all_batteries(mocker: MockerFixture) -> AsyncIterator[SetupArgs]
     # the scope of this tests. This tests should cover BatteryPool only.
     # We use our own battery status channel, where we easily control set of working
     # batteries.
-    battery_pool = microgrid.battery_pool(priority=5)
+    battery_pool = microgrid.new_battery_pool(priority=5)
 
     dp = microgrid._data_pipeline._DATA_PIPELINE
     assert dp is not None
@@ -205,7 +205,7 @@ async def setup_batteries_pool(mocker: MockerFixture) -> AsyncIterator[SetupArgs
     # batteries.
     all_batteries = list(get_components(mock_microgrid, ComponentCategory.BATTERY))
 
-    battery_pool = microgrid.battery_pool(
+    battery_pool = microgrid.new_battery_pool(
         priority=5, component_ids=set(all_batteries[:2])
     )
 
@@ -543,7 +543,7 @@ async def test_batter_pool_power_no_batteries(mocker: MockerFixture) -> None:
         )
     )
     await mockgrid.start(mocker)
-    battery_pool = microgrid.battery_pool(priority=5)
+    battery_pool = microgrid.new_battery_pool(priority=5)
     power_receiver = battery_pool.power.new_receiver()
 
     await mockgrid.mock_resampler.send_non_existing_component_value()
@@ -560,7 +560,7 @@ async def test_battery_pool_power_with_no_inverters(mocker: MockerFixture) -> No
     await mockgrid.start(mocker)
 
     with pytest.raises(RuntimeError):
-        microgrid.battery_pool(priority=5)
+        microgrid.new_battery_pool(priority=5)
 
 
 async def test_battery_pool_power_incomplete_bat_request(mocker: MockerFixture) -> None:
@@ -582,7 +582,7 @@ async def test_battery_pool_power_incomplete_bat_request(mocker: MockerFixture) 
 
     with pytest.raises(FormulaGenerationError):
         # Request only two of the three batteries behind the inverters
-        battery_pool = microgrid.battery_pool(
+        battery_pool = microgrid.new_battery_pool(
             priority=5, component_ids=set([bats[1].component_id, bats[0].component_id])
         )
         power_receiver = battery_pool.power.new_receiver()
@@ -592,7 +592,7 @@ async def test_battery_pool_power_incomplete_bat_request(mocker: MockerFixture) 
 
 async def _test_battery_pool_power(mockgrid: MockMicrogrid) -> None:
     async with mockgrid:
-        battery_pool = microgrid.battery_pool(priority=5)
+        battery_pool = microgrid.new_battery_pool(priority=5)
         power_receiver = battery_pool.power.new_receiver()
 
         await mockgrid.mock_resampler.send_bat_inverter_power([2.0, 3.0])

--- a/tests/timeseries/_battery_pool/test_battery_pool_control_methods.py
+++ b/tests/timeseries/_battery_pool/test_battery_pool_control_methods.py
@@ -193,7 +193,7 @@ class TestBatteryPoolControl:
         await self._init_data_for_batteries(mocks)
         await self._init_data_for_inverters(mocks)
 
-        battery_pool = microgrid.battery_pool(priority=5)
+        battery_pool = microgrid.new_battery_pool(priority=5)
 
         bounds_rx = battery_pool.power_status.new_receiver()
 
@@ -288,11 +288,11 @@ class TestBatteryPoolControl:
         await self._init_data_for_batteries(mocks)
         await self._init_data_for_inverters(mocks)
 
-        battery_pool_1 = microgrid.battery_pool(
+        battery_pool_1 = microgrid.new_battery_pool(
             priority=5, component_ids=set(mocks.microgrid.battery_ids[:2])
         )
         bounds_1_rx = battery_pool_1.power_status.new_receiver()
-        battery_pool_2 = microgrid.battery_pool(
+        battery_pool_2 = microgrid.new_battery_pool(
             priority=5, component_ids=set(mocks.microgrid.battery_ids[2:])
         )
         bounds_2_rx = battery_pool_2.power_status.new_receiver()
@@ -339,9 +339,9 @@ class TestBatteryPoolControl:
         await self._init_data_for_batteries(mocks)
         await self._init_data_for_inverters(mocks)
 
-        battery_pool_1 = microgrid.battery_pool(priority=2)
+        battery_pool_1 = microgrid.new_battery_pool(priority=2)
         bounds_1_rx = battery_pool_1.power_status.new_receiver()
-        battery_pool_2 = microgrid.battery_pool(priority=1)
+        battery_pool_2 = microgrid.new_battery_pool(priority=1)
         bounds_2_rx = battery_pool_2.power_status.new_receiver()
 
         self._assert_report(
@@ -398,7 +398,7 @@ class TestBatteryPoolControl:
         await self._init_data_for_batteries(mocks, exclusion_bounds=(-100.0, 100.0))
         await self._init_data_for_inverters(mocks)
 
-        battery_pool = microgrid.battery_pool(priority=5)
+        battery_pool = microgrid.new_battery_pool(priority=5)
         bounds_rx = battery_pool.power_status.new_receiver()
 
         self._assert_report(
@@ -514,13 +514,17 @@ class TestBatteryPoolControl:
         await self._init_data_for_batteries(mocks)
         await self._init_data_for_inverters(mocks)
 
-        battery_pool_4 = microgrid.battery_pool(priority=4, set_operating_point=True)
+        battery_pool_4 = microgrid.new_battery_pool(
+            priority=4, set_operating_point=True
+        )
         bounds_4_rx = battery_pool_4.power_status.new_receiver()
-        battery_pool_3 = microgrid.battery_pool(priority=3, set_operating_point=True)
+        battery_pool_3 = microgrid.new_battery_pool(
+            priority=3, set_operating_point=True
+        )
         bounds_3_rx = battery_pool_3.power_status.new_receiver()
-        battery_pool_2 = microgrid.battery_pool(priority=2)
+        battery_pool_2 = microgrid.new_battery_pool(priority=2)
         bounds_2_rx = battery_pool_2.power_status.new_receiver()
-        battery_pool_1 = microgrid.battery_pool(priority=1)
+        battery_pool_1 = microgrid.new_battery_pool(priority=1)
         bounds_1_rx = battery_pool_1.power_status.new_receiver()
 
         self._assert_report(
@@ -642,7 +646,7 @@ class TestBatteryPoolControl:
         # Creating a new non-shifting battery pool that's higher priority than the
         # shifting battery pools should still be shifted by the target power of the
         # shifting battery pools.
-        battery_pool_5 = microgrid.battery_pool(priority=5)
+        battery_pool_5 = microgrid.new_battery_pool(priority=5)
         bounds_5_rx = battery_pool_5.power_status.new_receiver()
 
         await battery_pool_5.propose_power(None)

--- a/tests/timeseries/_ev_charger_pool/test_ev_charger_pool.py
+++ b/tests/timeseries/_ev_charger_pool/test_ev_charger_pool.py
@@ -23,7 +23,7 @@ class TestEVChargerPool:
         mockgrid.add_ev_chargers(3)
 
         async with mockgrid:
-            ev_pool = microgrid.ev_charger_pool(priority=5)
+            ev_pool = microgrid.new_ev_charger_pool(priority=5)
             power_receiver = ev_pool.power.new_receiver()
 
             await mockgrid.mock_resampler.send_evc_power([2.0, 4.0, 10.0])

--- a/tests/timeseries/_ev_charger_pool/test_ev_charger_pool_control_methods.py
+++ b/tests/timeseries/_ev_charger_pool/test_ev_charger_pool_control_methods.py
@@ -206,7 +206,7 @@ class TestEVChargerPoolControl:
         )
 
         await self._init_ev_chargers(mocks)
-        ev_charger_pool = microgrid.ev_charger_pool(priority=5)
+        ev_charger_pool = microgrid.new_ev_charger_pool(priority=5)
         await self._patch_ev_pool_status(mocks, mocker)
         await self._patch_power_distributing_actor(mocker)
 

--- a/tests/timeseries/_formula_engine/test_formula_composition.py
+++ b/tests/timeseries/_formula_engine/test_formula_composition.py
@@ -38,7 +38,7 @@ class TestFormulaComposition:
             battery_pool = microgrid.new_battery_pool(priority=5)
             stack.push_async_callback(battery_pool.stop)
 
-            pv_pool = microgrid.pv_pool(priority=5)
+            pv_pool = microgrid.new_pv_pool(priority=5)
             stack.push_async_callback(pv_pool.stop)
 
             grid = microgrid.grid()
@@ -116,7 +116,7 @@ class TestFormulaComposition:
             battery_pool = microgrid.new_battery_pool(priority=5)
             stack.push_async_callback(battery_pool.stop)
 
-            pv_pool = microgrid.pv_pool(priority=5)
+            pv_pool = microgrid.new_pv_pool(priority=5)
             stack.push_async_callback(pv_pool.stop)
 
             logical_meter = microgrid.logical_meter()
@@ -158,7 +158,7 @@ class TestFormulaComposition:
             battery_pool = microgrid.new_battery_pool(priority=5)
             stack.push_async_callback(battery_pool.stop)
 
-            pv_pool = microgrid.pv_pool(priority=5)
+            pv_pool = microgrid.new_pv_pool(priority=5)
             stack.push_async_callback(pv_pool.stop)
 
             logical_meter = microgrid.logical_meter()

--- a/tests/timeseries/_formula_engine/test_formula_composition.py
+++ b/tests/timeseries/_formula_engine/test_formula_composition.py
@@ -35,7 +35,7 @@ class TestFormulaComposition:
             logical_meter = microgrid.logical_meter()
             stack.push_async_callback(logical_meter.stop)
 
-            battery_pool = microgrid.battery_pool(priority=5)
+            battery_pool = microgrid.new_battery_pool(priority=5)
             stack.push_async_callback(battery_pool.stop)
 
             pv_pool = microgrid.pv_pool(priority=5)
@@ -113,7 +113,7 @@ class TestFormulaComposition:
 
         count = 0
         async with mockgrid, AsyncExitStack() as stack:
-            battery_pool = microgrid.battery_pool(priority=5)
+            battery_pool = microgrid.new_battery_pool(priority=5)
             stack.push_async_callback(battery_pool.stop)
 
             pv_pool = microgrid.pv_pool(priority=5)
@@ -155,7 +155,7 @@ class TestFormulaComposition:
 
         count = 0
         async with mockgrid, AsyncExitStack() as stack:
-            battery_pool = microgrid.battery_pool(priority=5)
+            battery_pool = microgrid.new_battery_pool(priority=5)
             stack.push_async_callback(battery_pool.stop)
 
             pv_pool = microgrid.pv_pool(priority=5)

--- a/tests/timeseries/_formula_engine/test_formula_composition.py
+++ b/tests/timeseries/_formula_engine/test_formula_composition.py
@@ -395,7 +395,7 @@ class TestFormulaComposition:
             logical_meter = microgrid.logical_meter()
             stack.push_async_callback(logical_meter.stop)
 
-            ev_pool = microgrid.ev_charger_pool(priority=5)
+            ev_pool = microgrid.new_ev_charger_pool(priority=5)
             stack.push_async_callback(ev_pool.stop)
 
             grid = microgrid.grid()

--- a/tests/timeseries/_pv_pool/test_pv_pool_control_methods.py
+++ b/tests/timeseries/_pv_pool/test_pv_pool_control_methods.py
@@ -131,7 +131,7 @@ class TestPVPoolControl:
         )
 
         await self._init_pv_inverters(mocks)
-        pv_pool = microgrid.pv_pool(priority=5)
+        pv_pool = microgrid.new_pv_pool(priority=5)
         bounds_rx = pv_pool.power_status.new_receiver()
         await self._recv_reports_until(
             bounds_rx,

--- a/tests/timeseries/test_formula_formatter.py
+++ b/tests/timeseries/test_formula_formatter.py
@@ -123,7 +123,7 @@ class TestFormulaFormatter:
             logical_meter = microgrid.logical_meter()
             stack.push_async_callback(logical_meter.stop)
 
-            pv_pool = microgrid.pv_pool(priority=5)
+            pv_pool = microgrid.new_pv_pool(priority=5)
             stack.push_async_callback(pv_pool.stop)
 
             grid = microgrid.grid()

--- a/tests/timeseries/test_logical_meter.py
+++ b/tests/timeseries/test_logical_meter.py
@@ -44,7 +44,7 @@ class TestLogicalMeter:  # pylint: disable=too-many-public-methods
         mockgrid.add_solar_inverters(2)
 
         async with mockgrid, AsyncExitStack() as stack:
-            pv_pool = microgrid.pv_pool(priority=5)
+            pv_pool = microgrid.new_pv_pool(priority=5)
             stack.push_async_callback(pv_pool.stop)
             pv_power_receiver = pv_pool.power.new_receiver()
 
@@ -57,7 +57,7 @@ class TestLogicalMeter:  # pylint: disable=too-many-public-methods
         mockgrid.add_solar_inverters(2, no_meter=True)
 
         async with mockgrid, AsyncExitStack() as stack:
-            pv_pool = microgrid.pv_pool(priority=5)
+            pv_pool = microgrid.new_pv_pool(priority=5)
             stack.push_async_callback(pv_pool.stop)
             pv_power_receiver = pv_pool.power.new_receiver()
 
@@ -70,7 +70,7 @@ class TestLogicalMeter:  # pylint: disable=too-many-public-methods
             MockMicrogrid(grid_meter=True, mocker=mocker) as mockgrid,
             AsyncExitStack() as stack,
         ):
-            pv_pool = microgrid.pv_pool(priority=5)
+            pv_pool = microgrid.new_pv_pool(priority=5)
             stack.push_async_callback(pv_pool.stop)
             pv_power_receiver = pv_pool.power.new_receiver()
 


### PR DESCRIPTION
This makes it explicit that each call to these functions create a new
instance of the `*Pool` class, which would hopefully encourage users
to hold on to references to the created objects, rather than create
and discard after each use.