### PR TITLE
Properly keep references and await for concurrent tasks

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -18,3 +18,4 @@
 ## Bug Fixes
 
 - Fixed a typing issue that occurs in some cases when composing formulas with constants.
+- Fixed a bug where sending tasks in the data sourcing actor might have not been properly awaited.


### PR DESCRIPTION
The data sourcing actor is parallelizing the sending of samples to the stream senders, but it was not properly keeping references to the tasks and awaiting for them to finish.

References were probably kept by `gather()`, but `gather()` wasn't awaited, so it can potentially not run at all (although it seems it did, because things were working).

This commit uses a `TaskGroup` to keep references to the tasks in `process_msg()` and then makes each `process_msg()` call a task too, but we don't use a task group here because we don't want to await until a batch of messages is sent before receiving the next one. Instead, we want to keep sending messages in the background. But we still need to clean up these tasks as soon as they are done.

This replaces the event used to wait until there are no more pending messages to be sent, as it is enough to synchronize awaiting for the (pending) tasks to finish.

This was discovered while looking at warnings in the tests (#982).
