### PR TITLE
Expose `ComponentMetricId` in the public API

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -38,3 +38,4 @@
 - Updated the logical meter documentation to reflect the latest changes.
 - Fixed a bug in the code examples in the getting-started tutorial.
 - Fixed a bug in `ConfigManagingActor` that was not properly comparing the event path to the config file path when the config file is a relative path.
+- Re-expose `ComponentMetricId` to the docs.

--- a/src/frequenz/sdk/actor/__init__.py
+++ b/src/frequenz/sdk/actor/__init__.py
@@ -598,7 +598,7 @@ from ._actor import Actor
 from ._background_service import BackgroundService
 from ._channel_registry import ChannelRegistry
 from ._config_managing import ConfigManagingActor
-from ._data_sourcing import ComponentMetricRequest, DataSourcingActor
+from ._data_sourcing import ComponentMetricId, ComponentMetricRequest, DataSourcingActor
 from ._resampling import ComponentMetricsResamplingActor
 from ._run_utils import run
 
@@ -606,6 +606,7 @@ __all__ = [
     "Actor",
     "BackgroundService",
     "ChannelRegistry",
+    "ComponentMetricId",
     "ComponentMetricRequest",
     "ComponentMetricsResamplingActor",
     "ConfigManagingActor",

--- a/src/frequenz/sdk/actor/_data_sourcing/__init__.py
+++ b/src/frequenz/sdk/actor/_data_sourcing/__init__.py
@@ -3,10 +3,11 @@
 
 """The DataSourcingActor."""
 
-from ._component_metric_request import ComponentMetricRequest
+from ._component_metric_request import ComponentMetricId, ComponentMetricRequest
 from .data_sourcing import DataSourcingActor
 
 __all__ = [
+    "ComponentMetricId",
     "ComponentMetricRequest",
     "DataSourcingActor",
 ]

--- a/src/frequenz/sdk/actor/_data_sourcing/_component_metric_request.py
+++ b/src/frequenz/sdk/actor/_data_sourcing/_component_metric_request.py
@@ -8,6 +8,8 @@ from datetime import datetime
 
 from frequenz.client.microgrid import ComponentMetricId
 
+__all__ = ["ComponentMetricRequest", "ComponentMetricId"]
+
 
 @dataclass
 class ComponentMetricRequest:

--- a/src/frequenz/sdk/timeseries/logical_meter/_logical_meter.py
+++ b/src/frequenz/sdk/timeseries/logical_meter/_logical_meter.py
@@ -7,9 +7,8 @@
 import uuid
 
 from frequenz.channels import Sender
-from frequenz.client.microgrid import ComponentMetricId
 
-from ...actor import ChannelRegistry, ComponentMetricRequest
+from ...actor import ChannelRegistry, ComponentMetricId, ComponentMetricRequest
 from .._quantities import Power, Quantity
 from ..formula_engine import FormulaEngine
 from ..formula_engine._formula_engine_pool import FormulaEnginePool


### PR DESCRIPTION
This was moved to the microgrid API client, so it wasn't exposed any more in the SDK. This commit exposes it again.

Fixes #985.