### PR TITLE
Remove dependency to polars

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,6 @@ dev-flake8 = [
   "pydoclint == 0.4.1",
   "pydocstyle == 6.3.0",
 ]
-dev-examples = ["polars == 0.20.31"]
 dev-formatting = ["black == 24.4.2", "isort == 5.13.2"]
 dev-mkdocs = [
   "black == 24.4.2",
@@ -83,8 +82,6 @@ dev-pytest = [
   "pytest-asyncio == 0.23.7",
   "time-machine == 2.12.0",
   "async-solipsism == 0.6",
-  # For checking docstring code examples
-  "frequenz-sdk[dev-examples]",
   "hypothesis == 6.103.1",
 ]
 dev = [

--- a/src/frequenz/sdk/timeseries/_moving_window.py
+++ b/src/frequenz/sdk/timeseries/_moving_window.py
@@ -93,7 +93,6 @@ class MovingWindow(BackgroundService):
     Example: Create a polars data frame from a `MovingWindow`
 
         ```python
-        import polars as pl
         from datetime import datetime, timedelta, timezone
 
         async def send_mock_data(sender: Sender[Sample]) -> None:
@@ -118,10 +117,12 @@ class MovingWindow(BackgroundService):
                 # wait for one full day until the buffer is filled
                 await asyncio.sleep(60*60*24)
 
-                # create a polars series with one full day of data
                 time_start = datetime(2023, 1, 1, tzinfo=timezone.utc)
                 time_end = datetime(2023, 1, 2, tzinfo=timezone.utc)
-                series = pl.Series("Jan_1", window[time_start:time_end])
+
+                # You can now create a polars series with one full day of data by
+                # passing the window slice, like:
+                # series = pl.Series("Jan_1", window[time_start:time_end])
 
         asyncio.run(run())
         ```


### PR DESCRIPTION
It is just too big (28MB) to have only to validate one code example.

Instead we leave the line that uses polars as a comment.
