### PR TITLE
Remove power distribution results from `Report` objects

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -19,6 +19,8 @@
 
 * Passing a `request_timeout` in calls to `*_pool.propose_power` is no longer supported.  It may be specified at application startup, through the new optional `api_power_request_timeout` parameter in the `microgrid.initialize()` method.
 
+- Power distribution results are no longer available through the `power_status` streams in the `*Pool`s.    They can now be accessed as a stream from a separate property `power_distribution_results`, which is available from all the `*Pool`s.
+
 ## New Features
 
 - Classes `Bounds` and `SystemBounds` now implement the `__contains__` method, allowing the use of the `in` operator to check whether a value falls within the bounds or not.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
   # changing the version
   # (plugins.mkdocstrings.handlers.python.import)
   "frequenz-client-microgrid >= 0.4.0, < 0.5.0",
-  "frequenz-channels >= 1.0.0-rc1, < 2.0.0",
+  "frequenz-channels >= 1.1.0, < 2.0.0",
   "networkx >= 2.8, < 4",
   "numpy >= 1.26.4, < 2",
   "typing_extensions >= 4.6.1, < 5",

--- a/src/frequenz/sdk/_internal/_channels.py
+++ b/src/frequenz/sdk/_internal/_channels.py
@@ -12,6 +12,7 @@ from frequenz.channels import Receiver
 from ._asyncio import cancel_and_await
 
 T_co = typing.TypeVar("T_co", covariant=True)
+U_co = typing.TypeVar("U_co", covariant=True)
 
 
 class ReceiverFetcher(typing.Generic[T_co], typing.Protocol):
@@ -27,6 +28,36 @@ class ReceiverFetcher(typing.Generic[T_co], typing.Protocol):
         Returns:
             A receiver instance.
         """
+
+
+class MappingReceiverFetcher(typing.Generic[T_co, U_co]):
+    """A receiver fetcher that can manipulate receivers before returning them."""
+
+    def __init__(
+        self,
+        fetcher: ReceiverFetcher[T_co],
+        mapping_function: typing.Callable[[Receiver[T_co]], Receiver[U_co]],
+    ) -> None:
+        """Initialize this instance.
+
+        Args:
+            fetcher: The underlying fetcher to get receivers from.
+            mapping_function: The method to be applied on new receivers before returning
+                them.
+        """
+        self._fetcher = fetcher
+        self._mapping_function = mapping_function
+
+    def new_receiver(self, *, limit: int = 50) -> Receiver[U_co]:
+        """Get a receiver from the channel.
+
+        Args:
+            limit: The maximum size of the receiver.
+
+        Returns:
+            A receiver instance.
+        """
+        return self._mapping_function(self._fetcher.new_receiver(limit=limit))
 
 
 class _Sentinel:

--- a/src/frequenz/sdk/actor/_power_managing/_base_classes.py
+++ b/src/frequenz/sdk/actor/_power_managing/_base_classes.py
@@ -16,7 +16,6 @@ from . import _bounds
 
 if typing.TYPE_CHECKING:
     from ...timeseries._base_types import SystemBounds
-    from .. import power_distributing
 
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
@@ -51,12 +50,6 @@ class _Report:
 
     target_power: Power | None
     """The currently set power for the components."""
-
-    distribution_result: power_distributing.Result | None
-    """The result of the last power distribution.
-
-    This is `None` if no power distribution has been performed yet.
-    """
 
     _inclusion_bounds: timeseries.Bounds[Power] | None
     """The available inclusion bounds for the components, for the actor's priority.
@@ -266,7 +259,6 @@ class BaseAlgorithm(abc.ABC):
         component_ids: frozenset[int],
         priority: int,
         system_bounds: SystemBounds,
-        distribution_result: power_distributing.Result | None,
     ) -> _Report:
         """Get the bounds for a set of components, for the given priority.
 
@@ -274,7 +266,6 @@ class BaseAlgorithm(abc.ABC):
             component_ids: The IDs of the components to get the bounds for.
             priority: The priority of the actor for which the bounds are requested.
             system_bounds: The system bounds for the components.
-            distribution_result: The result of the last power distribution.
 
         Returns:
             The bounds for the components.

--- a/src/frequenz/sdk/actor/_power_managing/_matryoshka.py
+++ b/src/frequenz/sdk/actor/_power_managing/_matryoshka.py
@@ -32,7 +32,6 @@ from ._base_classes import BaseAlgorithm, Proposal, _Report
 
 if typing.TYPE_CHECKING:
     from ...timeseries._base_types import SystemBounds
-    from .. import power_distributing
 
 _logger = logging.getLogger(__name__)
 
@@ -225,7 +224,6 @@ class Matryoshka(BaseAlgorithm):
         component_ids: frozenset[int],
         priority: int,
         system_bounds: SystemBounds,
-        distribution_result: power_distributing.Result | None,
     ) -> _Report:
         """Get the bounds for the algorithm.
 
@@ -233,7 +231,6 @@ class Matryoshka(BaseAlgorithm):
             component_ids: The IDs of the components to get the bounds for.
             priority: The priority of the actor for which the bounds are requested.
             system_bounds: The system bounds for the components.
-            distribution_result: The result of the last power distribution.
 
         Returns:
             The target power and the available bounds for the given components, for
@@ -245,7 +242,6 @@ class Matryoshka(BaseAlgorithm):
                 target_power=target_power,
                 _inclusion_bounds=None,
                 _exclusion_bounds=system_bounds.exclusion_bounds,
-                distribution_result=distribution_result,
             )
 
         lower_bound = system_bounds.inclusion_bounds.lower
@@ -284,7 +280,6 @@ class Matryoshka(BaseAlgorithm):
                 lower=lower_bound, upper=upper_bound
             ),
             _exclusion_bounds=system_bounds.exclusion_bounds,
-            distribution_result=distribution_result,
         )
 
     @override

--- a/src/frequenz/sdk/actor/_power_managing/_power_managing_actor.py
+++ b/src/frequenz/sdk/actor/_power_managing/_power_managing_actor.py
@@ -91,7 +91,6 @@ class PowerManagingActor(Actor):  # pylint: disable=too-many-instance-attributes
         self._set_op_power_subscriptions: dict[
             frozenset[int], dict[int, Sender[_Report]]
         ] = {}
-        self._distribution_results: dict[frozenset[int], power_distributing.Result] = {}
 
         self._set_power_group: BaseAlgorithm = Matryoshka(
             max_proposal_age=timedelta(seconds=60.0)
@@ -120,7 +119,6 @@ class PowerManagingActor(Actor):  # pylint: disable=too-many-instance-attributes
                 component_ids,
                 priority,
                 bounds,
-                self._distribution_results.get(component_ids),
             )
             await sender.send(status)
         for priority, sender in self._set_power_subscriptions.get(
@@ -133,7 +131,6 @@ class PowerManagingActor(Actor):  # pylint: disable=too-many-instance-attributes
                     bounds,
                     self._set_op_power_group.get_target_power(component_ids),
                 ),
-                self._distribution_results.get(component_ids),
             )
             await sender.send(status)
 
@@ -403,9 +400,6 @@ class PowerManagingActor(Actor):  # pylint: disable=too-many-instance-attributes
                 )
 
                 result = selected.message
-                self._distribution_results[frozenset(result.request.component_ids)] = (
-                    result
-                )
                 if not isinstance(result, power_distributing.Success):
                     _logger.warning(
                         "PowerManagingActor: PowerDistributing failed: %s", result

--- a/src/frequenz/sdk/microgrid/_data_pipeline.py
+++ b/src/frequenz/sdk/microgrid/_data_pipeline.py
@@ -420,6 +420,9 @@ class _DataPipeline:  # pylint: disable=too-many-instance-attributes
                     power_manager_bounds_subscription_sender=(
                         self._battery_power_wrapper.bounds_subscription_channel.new_sender()
                     ),
+                    power_distribution_results_fetcher=(
+                        self._battery_power_wrapper.distribution_results_fetcher()
+                    ),
                     min_update_interval=self._resampler_config.resampling_period,
                     batteries_id=component_ids,
                 )

--- a/src/frequenz/sdk/microgrid/_data_pipeline.py
+++ b/src/frequenz/sdk/microgrid/_data_pipeline.py
@@ -269,6 +269,9 @@ class _DataPipeline:  # pylint: disable=too-many-instance-attributes
                     power_manager_bounds_subs_sender=(
                         self._ev_power_wrapper.bounds_subscription_channel.new_sender()
                     ),
+                    power_distribution_results_fetcher=(
+                        self._ev_power_wrapper.distribution_results_fetcher()
+                    ),
                     component_ids=component_ids,
                 )
             )
@@ -342,6 +345,9 @@ class _DataPipeline:  # pylint: disable=too-many-instance-attributes
                 ),
                 power_manager_bounds_subs_sender=(
                     self._pv_power_wrapper.bounds_subscription_channel.new_sender()
+                ),
+                power_distribution_results_fetcher=(
+                    self._pv_power_wrapper.distribution_results_fetcher()
                 ),
                 component_ids=component_ids,
             )

--- a/src/frequenz/sdk/microgrid/_power_wrapper.py
+++ b/src/frequenz/sdk/microgrid/_power_wrapper.py
@@ -16,6 +16,8 @@ from frequenz.channels import Broadcast
 # pylint: disable=cyclic-import
 from frequenz.client.microgrid import ComponentCategory, ComponentType
 
+from .._internal._channels import ReceiverFetcher
+
 # A number of imports had to be done inside functions where they are used, to break
 # import cycles.
 #
@@ -178,3 +180,7 @@ class PowerWrapper:
             await self._power_distributing_actor.stop()
         if self._power_managing_actor:
             await self._power_managing_actor.stop()
+
+    def distribution_results_fetcher(self) -> ReceiverFetcher[Result]:
+        """Return a fetcher for the power distribution results."""
+        return self._power_distribution_results_channel

--- a/src/frequenz/sdk/timeseries/battery_pool/_battery_pool.py
+++ b/src/frequenz/sdk/timeseries/battery_pool/_battery_pool.py
@@ -13,8 +13,8 @@ import uuid
 from collections import abc
 
 from ... import timeseries
-from ..._internal._channels import ReceiverFetcher
-from ...actor import _power_managing
+from ..._internal._channels import ReceiverFetcher, ReceiverFetcherWith
+from ...actor import _power_managing, power_distributing
 from ...timeseries import Energy, Percentage, Power, Sample, Temperature
 from .._base_types import SystemBounds
 from ..formula_engine import FormulaEngine
@@ -383,6 +383,21 @@ class BatteryPool:
         channel.resend_latest = True
 
         return channel
+
+    @property
+    def power_distribution_results(self) -> ReceiverFetcher[power_distributing.Result]:
+        """Get a receiver to receive power distribution results.
+
+        Returns:
+            A receiver that will stream power distribution results for the pool's set of
+            batteries.
+        """
+        return ReceiverFetcherWith(
+            self._pool_ref_store._power_dist_results_fetcher,
+            lambda recv: recv.filter(
+                lambda x: x.request.component_ids == self._pool_ref_store._batteries
+            ),
+        )
 
     @property
     def _system_power_bounds(self) -> ReceiverFetcher[SystemBounds]:

--- a/src/frequenz/sdk/timeseries/battery_pool/_battery_pool.py
+++ b/src/frequenz/sdk/timeseries/battery_pool/_battery_pool.py
@@ -13,7 +13,7 @@ import uuid
 from collections import abc
 
 from ... import timeseries
-from ..._internal._channels import ReceiverFetcher, ReceiverFetcherWith
+from ..._internal._channels import MappingReceiverFetcher, ReceiverFetcher
 from ...actor import _power_managing, power_distributing
 from ...timeseries import Energy, Percentage, Power, Sample, Temperature
 from .._base_types import SystemBounds
@@ -392,7 +392,7 @@ class BatteryPool:
             A receiver that will stream power distribution results for the pool's set of
             batteries.
         """
-        return ReceiverFetcherWith(
+        return MappingReceiverFetcher(
             self._pool_ref_store._power_dist_results_fetcher,
             lambda recv: recv.filter(
                 lambda x: x.request.component_ids == self._pool_ref_store._batteries

--- a/src/frequenz/sdk/timeseries/battery_pool/_result_types.py
+++ b/src/frequenz/sdk/timeseries/battery_pool/_result_types.py
@@ -6,7 +6,6 @@
 import abc
 import typing
 
-from ...actor import power_distributing
 from .._base_types import Bounds
 from .._quantities import Power
 
@@ -19,13 +18,6 @@ class BatteryPoolReport(typing.Protocol):
     @property
     def target_power(self) -> Power | None:
         """The currently set power for the batteries."""
-
-    @property
-    def distribution_result(self) -> power_distributing.Result | None:
-        """The result of the last power distribution.
-
-        This is `None` if no power distribution has been performed yet.
-        """
 
     @property
     def bounds(self) -> Bounds[Power] | None:

--- a/src/frequenz/sdk/timeseries/ev_charger_pool/_ev_charger_pool.py
+++ b/src/frequenz/sdk/timeseries/ev_charger_pool/_ev_charger_pool.py
@@ -8,8 +8,8 @@ import asyncio
 import uuid
 from collections import abc
 
-from ..._internal._channels import ReceiverFetcher
-from ...actor import _power_managing
+from ..._internal._channels import MappingReceiverFetcher, ReceiverFetcher
+from ...actor import _power_managing, power_distributing
 from ...timeseries import Bounds
 from .._base_types import SystemBounds
 from .._quantities import Current, Power
@@ -226,6 +226,21 @@ class EVChargerPool:
         channel.resend_latest = True
 
         return channel
+
+    @property
+    def power_distribution_results(self) -> ReceiverFetcher[power_distributing.Result]:
+        """Get a receiver to receive power distribution results.
+
+        Returns:
+            A receiver that will stream power distribution results for the pool's set of
+            EV chargers.
+        """
+        return MappingReceiverFetcher(
+            self._pool_ref_store.power_distribution_results_fetcher,
+            lambda recv: recv.filter(
+                lambda x: x.request.component_ids == self._pool_ref_store.component_ids
+            ),
+        )
 
     async def stop(self) -> None:
         """Stop all tasks and channels owned by the EVChargerPool."""

--- a/src/frequenz/sdk/timeseries/ev_charger_pool/_ev_charger_pool_reference_store.py
+++ b/src/frequenz/sdk/timeseries/ev_charger_pool/_ev_charger_pool_reference_store.py
@@ -3,7 +3,6 @@
 
 """Manages shared state/tasks for a set of EV chargers."""
 
-
 import asyncio
 import uuid
 from collections import abc
@@ -11,9 +10,10 @@ from collections import abc
 from frequenz.channels import Broadcast, Receiver, Sender
 from frequenz.client.microgrid import ComponentCategory
 
+from ..._internal._channels import ReceiverFetcher
 from ...actor import ChannelRegistry, ComponentMetricRequest
 from ...actor._power_managing._base_classes import Proposal, ReportRequest
-from ...actor.power_distributing import ComponentPoolStatus
+from ...actor.power_distributing import ComponentPoolStatus, Result
 from ...microgrid import connection_manager
 from .._base_types import SystemBounds
 from ..formula_engine._formula_engine_pool import FormulaEnginePool
@@ -40,6 +40,7 @@ class EVChargerPoolReferenceStore:
         status_receiver: Receiver[ComponentPoolStatus],
         power_manager_requests_sender: Sender[Proposal],
         power_manager_bounds_subs_sender: Sender[ReportRequest],
+        power_distribution_results_fetcher: ReceiverFetcher[Result],
         component_ids: abc.Set[int] | None = None,
     ):
         """Create an instance of the class.
@@ -55,6 +56,8 @@ class EVChargerPoolReferenceStore:
                 requests to the power managing actor.
             power_manager_bounds_subs_sender: A Channel sender for sending power bounds
                 subscription requests to the power managing actor.
+            power_distribution_results_fetcher: A ReceiverFetcher for the results from
+                the power distributing actor.
             component_ids: An optional list of component_ids belonging to this pool.  If
                 not specified, IDs of all EV Chargers in the microgrid will be fetched
                 from the component graph.
@@ -64,6 +67,7 @@ class EVChargerPoolReferenceStore:
         self.status_receiver = status_receiver
         self.power_manager_requests_sender = power_manager_requests_sender
         self.power_manager_bounds_subs_sender = power_manager_bounds_subs_sender
+        self.power_distribution_results_fetcher = power_distribution_results_fetcher
 
         if component_ids is not None:
             self.component_ids: frozenset[int] = frozenset(component_ids)

--- a/src/frequenz/sdk/timeseries/ev_charger_pool/_result_types.py
+++ b/src/frequenz/sdk/timeseries/ev_charger_pool/_result_types.py
@@ -5,7 +5,6 @@
 
 import typing
 
-from ...actor import power_distributing
 from .._base_types import Bounds
 from .._quantities import Power
 
@@ -16,13 +15,6 @@ class EVChargerPoolReport(typing.Protocol):
     @property
     def target_power(self) -> Power | None:
         """The currently set power for the EV chargers."""
-
-    @property
-    def distribution_result(self) -> power_distributing.Result | None:
-        """The result of the last power distribution.
-
-        This is `None` if no power distribution has been performed yet.
-        """
 
     @property
     def bounds(self) -> Bounds[Power] | None:

--- a/src/frequenz/sdk/timeseries/pv_pool/_pv_pool_reference_store.py
+++ b/src/frequenz/sdk/timeseries/pv_pool/_pv_pool_reference_store.py
@@ -11,9 +11,10 @@ from collections import abc
 from frequenz.channels import Broadcast, Receiver, Sender
 from frequenz.client.microgrid import ComponentCategory, InverterType
 
+from ..._internal._channels import ReceiverFetcher
 from ...actor import ChannelRegistry, ComponentMetricRequest
 from ...actor._power_managing._base_classes import Proposal, ReportRequest
-from ...actor.power_distributing import ComponentPoolStatus
+from ...actor.power_distributing import ComponentPoolStatus, Result
 from ...microgrid import connection_manager
 from .._base_types import SystemBounds
 from ..formula_engine._formula_engine_pool import FormulaEnginePool
@@ -40,6 +41,7 @@ class PVPoolReferenceStore:
         status_receiver: Receiver[ComponentPoolStatus],
         power_manager_requests_sender: Sender[Proposal],
         power_manager_bounds_subs_sender: Sender[ReportRequest],
+        power_distribution_results_fetcher: ReceiverFetcher[Result],
         component_ids: abc.Set[int] | None = None,
     ):
         """Initialize this instance.
@@ -55,6 +57,8 @@ class PVPoolReferenceStore:
                 requests to the power managing actor.
             power_manager_bounds_subs_sender: A Channel sender for sending power bounds
                 subscription requests to the power managing actor.
+            power_distribution_results_fetcher: A ReceiverFetcher for the results from
+                the power distributing actor.
             component_ids: An optional list of component_ids belonging to this pool.  If
                 not specified, IDs of all PV inverters in the microgrid will be fetched
                 from the component graph.
@@ -64,6 +68,7 @@ class PVPoolReferenceStore:
         self.status_receiver = status_receiver
         self.power_manager_requests_sender = power_manager_requests_sender
         self.power_manager_bounds_subs_sender = power_manager_bounds_subs_sender
+        self.power_distribution_results_fetcher = power_distribution_results_fetcher
 
         if component_ids is not None:
             self.component_ids: frozenset[int] = frozenset(component_ids)

--- a/src/frequenz/sdk/timeseries/pv_pool/_result_types.py
+++ b/src/frequenz/sdk/timeseries/pv_pool/_result_types.py
@@ -5,7 +5,6 @@
 
 import typing
 
-from ...actor import power_distributing
 from .._base_types import Bounds
 from .._quantities import Power
 
@@ -16,13 +15,6 @@ class PVPoolReport(typing.Protocol):
     @property
     def target_power(self) -> Power | None:
         """The currently set power for the PV inverters."""
-
-    @property
-    def distribution_result(self) -> power_distributing.Result | None:
-        """The result of the last power distribution.
-
-        This is `None` if no power distribution has been performed yet.
-        """
 
     @property
     def bounds(self) -> Bounds[Power] | None:

--- a/tests/actor/_power_managing/test_matryoshka.py
+++ b/tests/actor/_power_managing/test_matryoshka.py
@@ -70,7 +70,7 @@ class StatefulTester:
     ) -> None:
         """Test the status report."""
         report = self.algorithm.get_status(
-            self._batteries, priority, self._system_bounds, None
+            self._batteries, priority, self._system_bounds
         )
         if expected_power is None:
             assert report.target_power is None

--- a/tests/actor/_power_managing/test_report.py
+++ b/tests/actor/_power_managing/test_report.py
@@ -34,7 +34,6 @@ class BoundsTester:
                 if exclusion_bounds is not None
                 else None
             ),
-            distribution_result=None,
         )
 
     def case(

--- a/tests/timeseries/_ev_charger_pool/test_ev_charger_pool_control_methods.py
+++ b/tests/timeseries/_ev_charger_pool/test_ev_charger_pool_control_methods.py
@@ -163,6 +163,7 @@ class TestEVChargerPoolControl:
         power: float | None,
         lower: float,
         upper: float,
+        dist_result: power_distributing.Result | None = None,
         expected_result_pred: (
             typing.Callable[[power_distributing.Result], bool] | None
         ) = None,
@@ -174,8 +175,8 @@ class TestEVChargerPoolControl:
         assert report.bounds.lower == Power.from_watts(lower)
         assert report.bounds.upper == Power.from_watts(upper)
         if expected_result_pred is not None:
-            assert report.distribution_result is not None
-            assert expected_result_pred(report.distribution_result)
+            assert dist_result is not None
+            assert expected_result_pred(dist_result)
 
     async def _get_bounds_receiver(
         self, ev_charger_pool: EVChargerPool

--- a/tests/timeseries/_pv_pool/test_pv_pool_control_methods.py
+++ b/tests/timeseries/_pv_pool/test_pv_pool_control_methods.py
@@ -92,6 +92,7 @@ class TestPVPoolControl:
         power: float | None,
         lower: float,
         upper: float,
+        dist_result: power_distributing.Result | None = None,
         expected_result_pred: (
             typing.Callable[[power_distributing.Result], bool] | None
         ) = None,
@@ -103,8 +104,8 @@ class TestPVPoolControl:
         assert report.bounds.lower == Power.from_watts(lower)
         assert report.bounds.upper == Power.from_watts(upper)
         if expected_result_pred is not None:
-            assert report.distribution_result is not None
-            assert expected_result_pred(report.distribution_result)
+            assert dist_result is not None
+            assert expected_result_pred(dist_result)
 
     async def _recv_reports_until(
         self,


### PR DESCRIPTION
Instead, this PR makes the power distribution results available directly from the `*Pool`s.

This should go some way towards reducing the frequency of `Report` objects as reported in #818 