### PR TITLE
Remove `request_timeout` parameter from `propose_power` methods

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -17,6 +17,8 @@
     * `grid.current` -> `grid.current_per_phase`
     * `ev_charger_pool.current` -> `ev_charger_pool.current_per_phase`
 
+* Passing a `request_timeout` in calls to `*_pool.propose_power` is no longer supported.  It may be specified at application startup, through the new optional `api_power_request_timeout` parameter in the `microgrid.initialize()` method.
+
 ## New Features
 
 - Classes `Bounds` and `SystemBounds` now implement the `__contains__` method, allowing the use of the `in` operator to check whether a value falls within the bounds or not.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -19,9 +19,7 @@
 
 ## New Features
 
-<!-- Here goes the main new features and examples or instructions on how to use them -->
-
-- Classes Bounds and SystemBounds now work with the `in` operator
+- Classes `Bounds` and `SystemBounds` now implement the `__contains__` method, allowing the use of the `in` operator to check whether a value falls within the bounds or not.
 
 ## Bug Fixes
 

--- a/benchmarks/power_distribution/power_distributor.py
+++ b/benchmarks/power_distribution/power_distributor.py
@@ -120,6 +120,7 @@ async def run_test(  # pylint: disable=too-many-locals
         requests_receiver=power_request_channel.new_receiver(),
         results_sender=power_result_channel.new_sender(),
         component_pool_status_sender=battery_status_channel.new_sender(),
+        api_power_request_timeout=timedelta(seconds=5.0),
     ):
         tasks: list[Coroutine[Any, Any, list[Result]]] = []
         tasks.append(send_requests(batteries, num_requests))

--- a/src/frequenz/sdk/actor/_power_managing/_base_classes.py
+++ b/src/frequenz/sdk/actor/_power_managing/_base_classes.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 
 import abc
 import dataclasses
-import datetime
 import enum
 import typing
 
@@ -163,9 +162,6 @@ class Proposal:
 
     This is used by the power manager to determine the age of the proposal.
     """
-
-    request_timeout: datetime.timedelta = datetime.timedelta(seconds=5.0)
-    """The maximum amount of time to wait for the request to be fulfilled."""
 
     set_operating_point: bool
     """Whether this proposal sets the operating point power or the normal power."""

--- a/src/frequenz/sdk/actor/_power_managing/_power_managing_actor.py
+++ b/src/frequenz/sdk/actor/_power_managing/_power_managing_actor.py
@@ -330,15 +330,11 @@ class PowerManagingActor(Actor):  # pylint: disable=too-many-instance-attributes
             proposal,
             must_send,
         )
-        request_timeout = (
-            proposal.request_timeout if proposal else timedelta(seconds=5.0)
-        )
         if target_power is not None:
             await self._power_distributing_requests_sender.send(
                 power_distributing.Request(
                     power=target_power,
                     component_ids=component_ids,
-                    request_timeout=request_timeout,
                     adjust_power=True,
                 )
             )

--- a/src/frequenz/sdk/actor/power_distributing/_component_managers/_pv_inverter_manager/_pv_inverter_manager.py
+++ b/src/frequenz/sdk/actor/power_distributing/_component_managers/_pv_inverter_manager/_pv_inverter_manager.py
@@ -38,6 +38,7 @@ class PVManager(ComponentManager):
         self,
         component_pool_status_sender: Sender[ComponentPoolStatus],
         results_sender: Sender[Result],
+        api_power_request_timeout: timedelta,
     ) -> None:
         """Initialize this instance.
 
@@ -45,8 +46,11 @@ class PVManager(ComponentManager):
             component_pool_status_sender: Channel for sending information about which
                 components are expected to be working.
             results_sender: Channel for sending results of power distribution.
+            api_power_request_timeout: Timeout to use when making power requests to
+                the microgrid API.
         """
         self._results_sender = results_sender
+        self._api_power_request_timeout = api_power_request_timeout
         self._pv_inverter_ids = self._get_pv_inverter_ids()
 
         self._component_pool_status_tracker = (
@@ -177,7 +181,7 @@ class PVManager(ComponentManager):
             )
         _, pending = await asyncio.wait(
             tasks.values(),
-            timeout=request.request_timeout.total_seconds(),
+            timeout=self._api_power_request_timeout.total_seconds(),
             return_when=asyncio.ALL_COMPLETED,
         )
         # collect the timed out tasks and cancel them while keeping the

--- a/src/frequenz/sdk/actor/power_distributing/power_distributing.py
+++ b/src/frequenz/sdk/actor/power_distributing/power_distributing.py
@@ -12,6 +12,8 @@ Purpose of this actor is to keep SoC level of each component at the equal level.
 """
 
 
+from datetime import timedelta
+
 from frequenz.channels import Receiver, Sender
 from frequenz.client.microgrid import ComponentCategory, ComponentType, InverterType
 from typing_extensions import override
@@ -60,6 +62,7 @@ class PowerDistributingActor(Actor):
         results_sender: Sender[Result],
         component_pool_status_sender: Sender[ComponentPoolStatus],
         *,
+        api_power_request_timeout: timedelta,
         component_category: ComponentCategory,
         component_type: ComponentType | None = None,
         name: str | None = None,
@@ -72,6 +75,8 @@ class PowerDistributingActor(Actor):
             results_sender: Sender for sending results to the power manager.
             component_pool_status_sender: Channel for sending information about which
                 components are expected to be working.
+            api_power_request_timeout: Timeout to use when making power requests to
+                the microgrid API.
             component_category: The category of the components that this actor is
                 responsible for.
             component_type: The type of the component of the given category that this
@@ -92,22 +97,23 @@ class PowerDistributingActor(Actor):
         self._component_type = component_type
         self._requests_receiver = requests_receiver
         self._result_sender = results_sender
+        self._api_power_request_timeout = api_power_request_timeout
 
         self._component_manager: ComponentManager
         if component_category == ComponentCategory.BATTERY:
             self._component_manager = BatteryManager(
-                component_pool_status_sender, results_sender
+                component_pool_status_sender, results_sender, api_power_request_timeout
             )
         elif component_category == ComponentCategory.EV_CHARGER:
             self._component_manager = EVChargerManager(
-                component_pool_status_sender, results_sender
+                component_pool_status_sender, results_sender, api_power_request_timeout
             )
         elif (
             component_category == ComponentCategory.INVERTER
             and component_type == InverterType.SOLAR
         ):
             self._component_manager = PVManager(
-                component_pool_status_sender, results_sender
+                component_pool_status_sender, results_sender, api_power_request_timeout
             )
         else:
             raise ValueError(

--- a/src/frequenz/sdk/actor/power_distributing/request.py
+++ b/src/frequenz/sdk/actor/power_distributing/request.py
@@ -5,7 +5,6 @@
 
 import dataclasses
 from collections import abc
-from datetime import timedelta
 
 from ...timeseries._quantities import Power
 
@@ -19,9 +18,6 @@ class Request:
 
     component_ids: abc.Set[int]
     """The component ids of the components to be used for this request."""
-
-    request_timeout: timedelta = timedelta(seconds=5.0)
-    """The maximum amount of time to wait for the request to be fulfilled."""
 
     adjust_power: bool = True
     """Whether to adjust the power to match the bounds.

--- a/src/frequenz/sdk/microgrid/_power_wrapper.py
+++ b/src/frequenz/sdk/microgrid/_power_wrapper.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import logging
 import typing
+from datetime import timedelta
 
 from frequenz.channels import Broadcast
 
@@ -38,6 +39,7 @@ class PowerWrapper:
         self,
         channel_registry: ChannelRegistry,
         *,
+        api_power_request_timeout: timedelta,
         component_category: ComponentCategory,
         component_type: ComponentType | None = None,
     ):
@@ -45,6 +47,8 @@ class PowerWrapper:
 
         Args:
             channel_registry: A channel registry for use in the actors.
+            api_power_request_timeout: Timeout to use when making power requests to
+                the microgrid API.
             component_category: The category of the components that actors started by
                 this instance of the PowerWrapper will be responsible for.
             component_type: The type of the component of the given category that this
@@ -58,6 +62,7 @@ class PowerWrapper:
         self._component_category = component_category
         self._component_type = component_type
         self._channel_registry = channel_registry
+        self._api_power_request_timeout = api_power_request_timeout
 
         self.status_channel: Broadcast[ComponentPoolStatus] = Broadcast(
             name="Component Status Channel", resend_latest=True
@@ -145,6 +150,7 @@ class PowerWrapper:
         self._power_distributing_actor = PowerDistributingActor(
             component_category=self._component_category,
             component_type=self._component_type,
+            api_power_request_timeout=self._api_power_request_timeout,
             requests_receiver=self._power_distribution_requests_channel.new_receiver(),
             results_sender=self._power_distribution_results_channel.new_sender(),
             component_pool_status_sender=self.status_channel.new_sender(),

--- a/src/frequenz/sdk/timeseries/battery_pool/_battery_pool.py
+++ b/src/frequenz/sdk/timeseries/battery_pool/_battery_pool.py
@@ -11,7 +11,6 @@ their individual priorities with each request.
 import asyncio
 import uuid
 from collections import abc
-from datetime import timedelta
 
 from ... import timeseries
 from ..._internal._channels import ReceiverFetcher
@@ -85,7 +84,6 @@ class BatteryPool:
         self,
         power: Power | None,
         *,
-        request_timeout: timedelta = timedelta(seconds=5.0),
         bounds: timeseries.Bounds[Power | None] = timeseries.Bounds(None, None),
     ) -> None:
         """Send a proposal to the power manager for the pool's set of batteries.
@@ -117,7 +115,6 @@ class BatteryPool:
                 proposal will not have any effect on the target power, unless bounds are
                 specified.  If both are `None`, it is equivalent to not having a
                 proposal or withdrawing a previous one.
-            request_timeout: The timeout for the request.
             bounds: The power bounds for the proposal.  These bounds will apply to
                 actors with a lower priority, and can be overridden by bounds from
                 actors with a higher priority.  If None, the power bounds will be set
@@ -132,17 +129,11 @@ class BatteryPool:
                 component_ids=self._pool_ref_store._batteries,
                 priority=self._priority,
                 creation_time=asyncio.get_running_loop().time(),
-                request_timeout=request_timeout,
                 set_operating_point=self._set_operating_point,
             )
         )
 
-    async def propose_charge(
-        self,
-        power: Power | None,
-        *,
-        request_timeout: timedelta = timedelta(seconds=5.0),
-    ) -> None:
+    async def propose_charge(self, power: Power | None) -> None:
         """Set the given charge power for the batteries in the pool.
 
         Power values need to be positive values, indicating charge power.
@@ -164,7 +155,6 @@ class BatteryPool:
             power: The unsigned charge power to propose for the batteries in the pool.
                 If None, the proposed power of higher priority actors will take
                 precedence as the target power.
-            request_timeout: The timeout for the request.
 
         Raises:
             ValueError: If the given power is negative.
@@ -179,17 +169,11 @@ class BatteryPool:
                 component_ids=self._pool_ref_store._batteries,
                 priority=self._priority,
                 creation_time=asyncio.get_running_loop().time(),
-                request_timeout=request_timeout,
                 set_operating_point=self._set_operating_point,
             )
         )
 
-    async def propose_discharge(
-        self,
-        power: Power | None,
-        *,
-        request_timeout: timedelta = timedelta(seconds=5.0),
-    ) -> None:
+    async def propose_discharge(self, power: Power | None) -> None:
         """Set the given discharge power for the batteries in the pool.
 
         Power values need to be positive values, indicating discharge power.
@@ -211,7 +195,6 @@ class BatteryPool:
             power: The unsigned discharge power to propose for the batteries in the
                 pool.  If None, the proposed power of higher priority actors will take
                 precedence as the target power.
-            request_timeout: The timeout for the request.
 
         Raises:
             ValueError: If the given power is negative.
@@ -228,7 +211,6 @@ class BatteryPool:
                 component_ids=self._pool_ref_store._batteries,
                 priority=self._priority,
                 creation_time=asyncio.get_running_loop().time(),
-                request_timeout=request_timeout,
                 set_operating_point=self._set_operating_point,
             )
         )

--- a/src/frequenz/sdk/timeseries/ev_charger_pool/_ev_charger_pool.py
+++ b/src/frequenz/sdk/timeseries/ev_charger_pool/_ev_charger_pool.py
@@ -7,7 +7,6 @@
 import asyncio
 import uuid
 from collections import abc
-from datetime import timedelta
 
 from ..._internal._channels import ReceiverFetcher
 from ...actor import _power_managing
@@ -73,7 +72,6 @@ class EVChargerPool:
         self,
         power: Power | None,
         *,
-        request_timeout: timedelta = timedelta(seconds=5.0),
         bounds: Bounds[Power | None] = Bounds(None, None),
     ) -> None:
         """Send a proposal to the power manager for the pool's set of EV chargers.
@@ -110,7 +108,6 @@ class EVChargerPool:
                 this proposal will not have any effect on the target power, unless
                 bounds are specified.  If both are `None`, it is equivalent to not
                 having a proposal or withdrawing a previous one.
-            request_timeout: The timeout for the request.
             bounds: The power bounds for the proposal.  These bounds will apply to
                 actors with a lower priority, and can be overridden by bounds from
                 actors with a higher priority.  If None, the power bounds will be set to
@@ -132,7 +129,6 @@ class EVChargerPool:
                 component_ids=self._pool_ref_store.component_ids,
                 priority=self._priority,
                 creation_time=asyncio.get_running_loop().time(),
-                request_timeout=request_timeout,
                 set_operating_point=self._set_operating_point,
             )
         )

--- a/src/frequenz/sdk/timeseries/pv_pool/_pv_pool.py
+++ b/src/frequenz/sdk/timeseries/pv_pool/_pv_pool.py
@@ -6,7 +6,6 @@
 import asyncio
 import uuid
 from collections import abc
-from datetime import timedelta
 
 from ..._internal._channels import ReceiverFetcher
 from ...actor import _power_managing
@@ -63,7 +62,6 @@ class PVPool:
         self,
         power: Power | None,
         *,
-        request_timeout: timedelta = timedelta(seconds=5.0),
         bounds: Bounds[Power | None] = Bounds(None, None),
     ) -> None:
         """Send a proposal to the power manager for the pool's set of PV inverters.
@@ -99,7 +97,6 @@ class PVPool:
                 this proposal will not have any effect on the target power, unless
                 bounds are specified.  If both are `None`, it is equivalent to not
                 having a proposal or withdrawing a previous one.
-            request_timeout: The timeout for the request.
             bounds: The power bounds for the proposal.  These bounds will apply to
                 actors with a lower priority, and can be overridden by bounds from
                 actors with a higher priority.  If None, the power bounds will be set to
@@ -119,7 +116,6 @@ class PVPool:
                 component_ids=self._pool_ref_store.component_ids,
                 priority=self._priority,
                 creation_time=asyncio.get_running_loop().time(),
-                request_timeout=request_timeout,
                 set_operating_point=self._set_operating_point,
             )
         )

--- a/tests/actor/power_distributing/test_power_distributing.py
+++ b/tests/actor/power_distributing/test_power_distributing.py
@@ -197,7 +197,6 @@ class TestPowerDistributingActor:
         request = Request(
             power=Power.from_kilowatts(1.2),
             component_ids={9, 19},
-            request_timeout=SAFETY_TIMEOUT,
         )
 
         await self._patch_battery_pool_status(mocks, mocker, request.component_ids)
@@ -281,7 +280,6 @@ class TestPowerDistributingActor:
                 request = Request(
                     power=Power.zero(),
                     component_ids={9, 19},
-                    request_timeout=SAFETY_TIMEOUT,
                 )
 
                 await requests_channel.new_sender().send(request)
@@ -306,7 +304,6 @@ class TestPowerDistributingActor:
                 request = Request(
                     power=Power.from_watts(300.0),
                     component_ids={9, 19},
-                    request_timeout=SAFETY_TIMEOUT,
                 )
 
                 await requests_channel.new_sender().send(request)
@@ -363,7 +360,6 @@ class TestPowerDistributingActor:
                     bat_component1.component_id,
                     bat_component2.component_id,
                 },
-                request_timeout=SAFETY_TIMEOUT,
             )
 
             await self._patch_battery_pool_status(mocks, mocker, request.component_ids)
@@ -446,7 +442,6 @@ class TestPowerDistributingActor:
             request = Request(
                 power=Power.from_watts(1200.0),
                 component_ids=set(battery.component_id for battery in bat_components),
-                request_timeout=SAFETY_TIMEOUT,
             )
 
             await self._patch_battery_pool_status(mocks, mocker, request.component_ids)
@@ -502,7 +497,6 @@ class TestPowerDistributingActor:
             request = Request(
                 power=Power.from_watts(1200.0),
                 component_ids={bat_component.component_id},
-                request_timeout=SAFETY_TIMEOUT,
             )
 
             await self._patch_battery_pool_status(mocks, mocker, request.component_ids)
@@ -556,7 +550,6 @@ class TestPowerDistributingActor:
             request = Request(
                 power=Power.from_watts(1700.0),
                 component_ids={batteries[0].component_id, batteries[1].component_id},
-                request_timeout=SAFETY_TIMEOUT,
             )
 
             await self._patch_battery_pool_status(mocks, mocker, request.component_ids)
@@ -644,7 +637,6 @@ class TestPowerDistributingActor:
             request = Request(
                 power=Power.from_watts(300.0),
                 component_ids={batteries[0].component_id, batteries[1].component_id},
-                request_timeout=SAFETY_TIMEOUT,
             )
 
             await self._patch_battery_pool_status(mocks, mocker, request.component_ids)
@@ -733,7 +725,6 @@ class TestPowerDistributingActor:
             request = Request(
                 power=Power.from_watts(300.0),
                 component_ids={batteries[0].component_id, batteries[1].component_id},
-                request_timeout=SAFETY_TIMEOUT,
             )
 
             await self._patch_battery_pool_status(mocks, mocker, request.component_ids)
@@ -801,7 +792,6 @@ class TestPowerDistributingActor:
             request = Request(
                 power=Power.from_watts(600.0),
                 component_ids={batteries[0].component_id},
-                request_timeout=SAFETY_TIMEOUT,
             )
 
             await self._patch_battery_pool_status(mocks, mocker, request.component_ids)
@@ -860,7 +850,6 @@ class TestPowerDistributingActor:
             request = Request(
                 power=Power.from_kilowatts(1.2),
                 component_ids={9, 19},
-                request_timeout=SAFETY_TIMEOUT,
             )
 
             await self._patch_battery_pool_status(mocks, mocker, request.component_ids)
@@ -916,7 +905,6 @@ class TestPowerDistributingActor:
             request = Request(
                 power=Power.from_kilowatts(1.2),
                 component_ids={9, 19},
-                request_timeout=SAFETY_TIMEOUT,
             )
 
             await self._patch_battery_pool_status(mocks, mocker, request.component_ids)
@@ -992,7 +980,6 @@ class TestPowerDistributingActor:
             request = Request(
                 power=Power.from_kilowatts(1.2),
                 component_ids={9, 19},
-                request_timeout=SAFETY_TIMEOUT,
             )
 
             await self._patch_battery_pool_status(mocks, mocker, request.component_ids)
@@ -1040,7 +1027,6 @@ class TestPowerDistributingActor:
             request = Request(
                 power=Power.from_kilowatts(1.2),
                 component_ids={9, 100},
-                request_timeout=SAFETY_TIMEOUT,
             )
 
             await self._patch_battery_pool_status(mocks, mocker, request.component_ids)
@@ -1084,7 +1070,6 @@ class TestPowerDistributingActor:
             request = Request(
                 power=Power.from_kilowatts(1.2),
                 component_ids={9, 19},
-                request_timeout=SAFETY_TIMEOUT,
                 adjust_power=False,
             )
 
@@ -1133,7 +1118,6 @@ class TestPowerDistributingActor:
             request = Request(
                 power=-Power.from_kilowatts(1.2),
                 component_ids={9, 19},
-                request_timeout=SAFETY_TIMEOUT,
                 adjust_power=False,
             )
 
@@ -1182,7 +1166,6 @@ class TestPowerDistributingActor:
             request = Request(
                 power=Power.from_kilowatts(1.0),
                 component_ids={9, 19},
-                request_timeout=SAFETY_TIMEOUT,
                 adjust_power=False,
             )
 
@@ -1246,7 +1229,6 @@ class TestPowerDistributingActor:
                 request = Request(
                     power=Power.from_kilowatts(1.2),
                     component_ids=batteries,
-                    request_timeout=SAFETY_TIMEOUT,
                 )
 
                 await requests_channel.new_sender().send(request)
@@ -1302,7 +1284,6 @@ class TestPowerDistributingActor:
                 request = Request(
                     power=Power.from_kilowatts(1.70),
                     component_ids=batteries,
-                    request_timeout=SAFETY_TIMEOUT,
                 )
 
                 await requests_channel.new_sender().send(request)

--- a/tests/actor/power_distributing/test_power_distributing.py
+++ b/tests/actor/power_distributing/test_power_distributing.py
@@ -112,6 +112,7 @@ class TestPowerDistributingActor:
                 requests_receiver=requests_channel.new_receiver(),
                 results_sender=results_channel.new_sender(),
                 component_pool_status_sender=battery_status_channel.new_sender(),
+                api_power_request_timeout=SAFETY_TIMEOUT,
             ) as distributor:
                 assert isinstance(distributor._component_manager, BatteryManager)
                 assert distributor._component_manager._bat_invs_map == {
@@ -143,6 +144,7 @@ class TestPowerDistributingActor:
                 requests_receiver=requests_channel.new_receiver(),
                 results_sender=results_channel.new_sender(),
                 component_pool_status_sender=battery_status_channel.new_sender(),
+                api_power_request_timeout=SAFETY_TIMEOUT,
             ) as distributor:
                 assert isinstance(distributor._component_manager, BatteryManager)
                 assert distributor._component_manager._bat_invs_map == {
@@ -208,6 +210,7 @@ class TestPowerDistributingActor:
             requests_receiver=requests_channel.new_receiver(),
             results_sender=results_channel.new_sender(),
             component_pool_status_sender=battery_status_channel.new_sender(),
+            api_power_request_timeout=SAFETY_TIMEOUT,
         ):
             await asyncio.sleep(0.1)  # wait for actor to collect data
 
@@ -270,6 +273,7 @@ class TestPowerDistributingActor:
                 requests_receiver=requests_channel.new_receiver(),
                 results_sender=results_channel.new_sender(),
                 component_pool_status_sender=battery_status_channel.new_sender(),
+                api_power_request_timeout=SAFETY_TIMEOUT,
             ):
                 await asyncio.sleep(0.1)  # wait for actor to collect data
 
@@ -374,6 +378,7 @@ class TestPowerDistributingActor:
                 requests_receiver=requests_channel.new_receiver(),
                 component_pool_status_sender=battery_status_channel.new_sender(),
                 results_sender=results_channel.new_sender(),
+                api_power_request_timeout=SAFETY_TIMEOUT,
             ):
                 await asyncio.sleep(0.1)  # wait for actor to collect data
 
@@ -455,6 +460,7 @@ class TestPowerDistributingActor:
                 requests_receiver=requests_channel.new_receiver(),
                 component_pool_status_sender=battery_status_channel.new_sender(),
                 results_sender=results_channel.new_sender(),
+                api_power_request_timeout=SAFETY_TIMEOUT,
             ):
                 await requests_channel.new_sender().send(request)
                 result_rx = results_channel.new_receiver()
@@ -510,6 +516,7 @@ class TestPowerDistributingActor:
                 requests_receiver=requests_channel.new_receiver(),
                 component_pool_status_sender=battery_status_channel.new_sender(),
                 results_sender=results_channel.new_sender(),
+                api_power_request_timeout=SAFETY_TIMEOUT,
             ):
                 await asyncio.sleep(0.1)  # wait for actor to collect data
 
@@ -563,6 +570,7 @@ class TestPowerDistributingActor:
                 requests_receiver=requests_channel.new_receiver(),
                 component_pool_status_sender=battery_status_channel.new_sender(),
                 results_sender=results_channel.new_sender(),
+                api_power_request_timeout=SAFETY_TIMEOUT,
             ):
                 await asyncio.sleep(0.1)  # wait for actor to collect data
 
@@ -650,6 +658,7 @@ class TestPowerDistributingActor:
                 requests_receiver=requests_channel.new_receiver(),
                 component_pool_status_sender=battery_status_channel.new_sender(),
                 results_sender=results_channel.new_sender(),
+                api_power_request_timeout=SAFETY_TIMEOUT,
             ):
                 await asyncio.sleep(0.1)  # wait for actor to collect data
 
@@ -738,6 +747,7 @@ class TestPowerDistributingActor:
                 requests_receiver=requests_channel.new_receiver(),
                 component_pool_status_sender=battery_status_channel.new_sender(),
                 results_sender=results_channel.new_sender(),
+                api_power_request_timeout=SAFETY_TIMEOUT,
             ):
                 await asyncio.sleep(0.1)  # wait for actor to collect data
 
@@ -805,6 +815,7 @@ class TestPowerDistributingActor:
                 requests_receiver=requests_channel.new_receiver(),
                 component_pool_status_sender=battery_status_channel.new_sender(),
                 results_sender=results_channel.new_sender(),
+                api_power_request_timeout=SAFETY_TIMEOUT,
             ):
                 await requests_channel.new_sender().send(request)
                 result_rx = results_channel.new_receiver()
@@ -862,6 +873,7 @@ class TestPowerDistributingActor:
                 requests_receiver=requests_channel.new_receiver(),
                 results_sender=results_channel.new_sender(),
                 component_pool_status_sender=battery_status_channel.new_sender(),
+                api_power_request_timeout=SAFETY_TIMEOUT,
             ):
                 await asyncio.sleep(0.1)  # wait for actor to collect data
 
@@ -918,6 +930,7 @@ class TestPowerDistributingActor:
                 requests_receiver=requests_channel.new_receiver(),
                 results_sender=results_channel.new_sender(),
                 component_pool_status_sender=battery_status_channel.new_sender(),
+                api_power_request_timeout=SAFETY_TIMEOUT,
             ):
                 await asyncio.sleep(0.1)  # wait for actor to collect data
 
@@ -993,6 +1006,7 @@ class TestPowerDistributingActor:
                 requests_receiver=requests_channel.new_receiver(),
                 results_sender=results_channel.new_sender(),
                 component_pool_status_sender=battery_status_channel.new_sender(),
+                api_power_request_timeout=SAFETY_TIMEOUT,
             ):
                 await asyncio.sleep(0.1)  # wait for actor to collect data
 
@@ -1040,6 +1054,7 @@ class TestPowerDistributingActor:
                 requests_receiver=requests_channel.new_receiver(),
                 results_sender=results_channel.new_sender(),
                 component_pool_status_sender=battery_status_channel.new_sender(),
+                api_power_request_timeout=SAFETY_TIMEOUT,
             ):
                 await requests_channel.new_sender().send(request)
                 result_rx = results_channel.new_receiver()
@@ -1084,6 +1099,7 @@ class TestPowerDistributingActor:
                 requests_receiver=requests_channel.new_receiver(),
                 results_sender=results_channel.new_sender(),
                 component_pool_status_sender=battery_status_channel.new_sender(),
+                api_power_request_timeout=SAFETY_TIMEOUT,
             ):
                 await asyncio.sleep(0.1)  # wait for actor to collect data
 
@@ -1132,6 +1148,7 @@ class TestPowerDistributingActor:
                 requests_receiver=requests_channel.new_receiver(),
                 results_sender=results_channel.new_sender(),
                 component_pool_status_sender=battery_status_channel.new_sender(),
+                api_power_request_timeout=SAFETY_TIMEOUT,
             ):
                 await asyncio.sleep(0.1)  # wait for actor to collect data
 
@@ -1180,6 +1197,7 @@ class TestPowerDistributingActor:
                 requests_receiver=requests_channel.new_receiver(),
                 results_sender=results_channel.new_sender(),
                 component_pool_status_sender=battery_status_channel.new_sender(),
+                api_power_request_timeout=SAFETY_TIMEOUT,
             ):
                 await asyncio.sleep(0.1)  # wait for actor to collect data
 
@@ -1221,6 +1239,7 @@ class TestPowerDistributingActor:
                 requests_receiver=requests_channel.new_receiver(),
                 results_sender=results_channel.new_sender(),
                 component_pool_status_sender=battery_status_channel.new_sender(),
+                api_power_request_timeout=SAFETY_TIMEOUT,
             ):
                 await asyncio.sleep(0.1)  # wait for actor to collect data
 
@@ -1276,6 +1295,7 @@ class TestPowerDistributingActor:
                 requests_receiver=requests_channel.new_receiver(),
                 results_sender=results_channel.new_sender(),
                 component_pool_status_sender=battery_status_channel.new_sender(),
+                api_power_request_timeout=SAFETY_TIMEOUT,
             ):
                 await asyncio.sleep(0.1)  # wait for actor to collect data
 

--- a/tests/timeseries/_battery_pool/test_battery_pool_control_methods.py
+++ b/tests/timeseries/_battery_pool/test_battery_pool_control_methods.py
@@ -230,9 +230,7 @@ class TestBatteryPoolControl:
                 await asyncio.sleep(1000.0)
 
         set_power.side_effect = side_effect
-        await battery_pool.propose_power(
-            Power.from_watts(100.0), request_timeout=timedelta(seconds=0.1)
-        )
+        await battery_pool.propose_power(Power.from_watts(100.0))
         self._assert_report(
             await bounds_rx.receive(),
             power=100.0,


### PR DESCRIPTION
Before the power manager was introduced, the `request_timeout` parameter was used to specify a different timeout for the `set_power` calls made to the api service.

The `propose_power` method is much more high level and it no longer makes sense to provide a `request_timeout` parameter, because it could conflict with other proposals and it would be hard to figure out which timeout to use.

From now on, it may be specified at application startup, through the new optional `api_power_request_timeout` parameter in the `microgrid.initialize()` method.