### PR TITLE
Remove extra comma from tutorial docs

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -30,3 +30,4 @@
 - Fixed a typing issue that occurs in some cases when composing formulas with constants.
 - Fixed a bug where sending tasks in the data sourcing actor might have not been properly awaited.
 - Updated the logical meter documentation to reflect the latest changes.
+- Fixed a bug in the code examples in the getting-started tutorial.

--- a/docs/tutorials/getting_started.md
+++ b/docs/tutorials/getting_started.md
@@ -44,7 +44,7 @@ microgrid.
 ```python
 async def run() -> None:
     # This points to the default Frequenz microgrid sandbox
-    server_url = "grpc://microgrid.sandbox.api.frequenz.io:62060",
+    server_url = "grpc://microgrid.sandbox.api.frequenz.io:62060"
 
     # Initialize the microgrid
     await microgrid.initialize(
@@ -104,7 +104,7 @@ from frequenz.sdk.actor import ResamplerConfig
 
 async def run() -> None:
     # This points to the default Frequenz microgrid sandbox
-    server_url = "grpc://microgrid.sandbox.api.frequenz.io:62060",
+    server_url = "grpc://microgrid.sandbox.api.frequenz.io:62060"
 
     # Initialize the microgrid
     await microgrid.initialize(


### PR DESCRIPTION
Having a comma there means the string gets interpreted as a tuple with
one string element, which would be wrong.