### PR TITLE
Fix ConfigManagingActor to handle relative paths

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -31,4 +31,4 @@
 - Fixed a bug where sending tasks in the data sourcing actor might have not been properly awaited.
 - Updated the logical meter documentation to reflect the latest changes.
 - Fixed a bug in the code examples in the getting-started tutorial.
-- Fixed a bug in ConfigManagingActor that was not properly comparing the event path to the config file path when the config file is a relative path.
+- Fixed a bug in `ConfigManagingActor` that was not properly comparing the event path to the config file path when the config file is a relative path.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -31,3 +31,4 @@
 - Fixed a bug where sending tasks in the data sourcing actor might have not been properly awaited.
 - Updated the logical meter documentation to reflect the latest changes.
 - Fixed a bug in the code examples in the getting-started tutorial.
+- Fixed a bug in ConfigManagingActor that was not properly comparing the event path to the config file path when the config file is a relative path.

--- a/src/frequenz/sdk/actor/_config_managing.py
+++ b/src/frequenz/sdk/actor/_config_managing.py
@@ -93,7 +93,7 @@ class ConfigManagingActor(Actor):
         async for event in self._file_watcher:
             # Since we are watching the whole parent directory, we need to make sure
             # we only react to events related to the configuration file.
-            if event.path != self._config_path:
+            if not event.path.samefile(self._config_path):
                 continue
 
             match event.type:


### PR DESCRIPTION
The check that compared the event path with the config path was not working as expected when the config path was a relative path.