### PR TITLE
Use a more descriptive channel name for the resampler

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -25,6 +25,10 @@
 
 - Classes `Bounds` and `SystemBounds` now implement the `__contains__` method, allowing the use of the `in` operator to check whether a value falls within the bounds or not.
 
+## Enhancements
+
+- The resampler now shows an error message where it is easier to identify the component and metric when it can't find relevant data for the current resampling window.
+
 ## Bug Fixes
 
 - Fixed a typing issue that occurs in some cases when composing formulas with constants.

--- a/src/frequenz/sdk/actor/_data_sourcing/_component_metric_request.py
+++ b/src/frequenz/sdk/actor/_data_sourcing/_component_metric_request.py
@@ -46,6 +46,8 @@ class ComponentMetricRequest:
             A string denoting a channel name.
         """
         return (
-            f"component-stream::{self.component_id}::{self.metric_id.name}::"
-            f"{self.start_time}::{self.namespace}"
+            f"component_metric_request<namespace={self.namespace},"
+            f"component_id={self.component_id},"
+            f"metric_id={self.metric_id.name},"
+            f"start={self.start_time}>"
         )

--- a/src/frequenz/sdk/timeseries/_resampling.py
+++ b/src/frequenz/sdk/timeseries/_resampling.py
@@ -746,7 +746,7 @@ class _ResamplingHelper:
         # resort to some C (or similar) implementation.
         relevant_samples = list(itertools.islice(self._buffer, min_index, max_index))
         if not relevant_samples:
-            _logger.warning("No relevant samples found for component: %s", self._name)
+            _logger.warning("No relevant samples found for: %s", self._name)
         value = (
             conf.resampling_function(relevant_samples, conf, props)
             if relevant_samples


### PR DESCRIPTION
When trying to debug issues with the resampler not getting relevant data, the name of the channel is being used to identify the component and metric with issues, but the string contains other data, which makes it hard to identify the component and metric in the string.

This commit uses a new, more descriptive channel name for for any component metric request, which is also used by the resampler.

The previous string was: `component-stream::{component_id}::{metric_id.name}::{start_time}::{namespace}`

The new string is: `component_metric_request<namespace={namespace},component_id={component_id},metric_id={metric_id.name},start={start_time}>`
