### PR TITLE
Update sender type in ConfigManagingActor

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -21,6 +21,8 @@
 
 - Power distribution results are no longer available through the `power_status` streams in the `*Pool`s.    They can now be accessed as a stream from a separate property `power_distribution_results`, which is available from all the `*Pool`s.
 
+- The `ConfigManagingActor` now uses `collections.abc.Mapping` as the output sender type. This change indicates that the broadcasted configuration is intended to be read-only.
+
 ## New Features
 
 - Classes `Bounds` and `SystemBounds` now implement the `__contains__` method, allowing the use of the `in` operator to check whether a value falls within the bounds or not.

--- a/src/frequenz/sdk/actor/_config_managing.py
+++ b/src/frequenz/sdk/actor/_config_managing.py
@@ -32,7 +32,7 @@ class ConfigManagingActor(Actor):
     def __init__(
         self,
         config_path: pathlib.Path | str,
-        output: Sender[dict[str, Any]],
+        output: Sender[abc.Mapping[str, Any]],
         event_types: abc.Set[EventType] = frozenset(EventType),
         *,
         name: str | None = None,
@@ -58,9 +58,9 @@ class ConfigManagingActor(Actor):
         self._file_watcher: FileWatcher = FileWatcher(
             paths=[self._config_path.parent], event_types=event_types
         )
-        self._output: Sender[dict[str, Any]] = output
+        self._output: Sender[abc.Mapping[str, Any]] = output
 
-    def _read_config(self) -> dict[str, Any]:
+    def _read_config(self) -> abc.Mapping[str, Any]:
         """Read the contents of the configuration file.
 
         Returns:

--- a/tests/actor/test_config_manager.py
+++ b/tests/actor/test_config_manager.py
@@ -4,6 +4,7 @@
 """Test for ConfigManager."""
 import os
 import pathlib
+from collections.abc import Mapping
 from typing import Any
 
 import pytest
@@ -65,7 +66,7 @@ class TestActorConfigManager:
         - the initial content of the content file is correct
         - the config file modifications are picked up and the new content is correct
         """
-        config_channel: Broadcast[dict[str, Any]] = Broadcast(
+        config_channel: Broadcast[Mapping[str, Any]] = Broadcast(
             name="Config Channel", resend_latest=True
         )
         config_receiver = config_channel.new_receiver()
@@ -91,7 +92,7 @@ class TestActorConfigManager:
 
     async def test_update_relative_path(self, config_file: pathlib.Path) -> None:
         """Test ConfigManagingActor with a relative path."""
-        config_channel: Broadcast[dict[str, Any]] = Broadcast(
+        config_channel: Broadcast[Mapping[str, Any]] = Broadcast(
             name="Config Channel", resend_latest=True
         )
         config_receiver = config_channel.new_receiver()


### PR DESCRIPTION
The ConfigManagingActor now sends a `collections.abc.Mapping` type as the output sender type to indicate to the user that the broadcasted configuration is intended to be read-only. This change leverages type checkers (e.g., mypy, etc.) to help ensure that users do not attempt to modify the dictionary contents.

Note that this change won't prevent users from modifying the contents at runtime, but it will help prevent accidental modifications.