### PR TITLE
Force `grpclib` to be at least 0.4.8rc2

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,17 +1,5 @@
 # Frequenz Python SDK Release Notes
 
-## Summary
-
-<!-- Here goes a general summary of what this release is about -->
-
-## Upgrading
-
-<!-- Here goes notes on how to upgrade from previous versions, including deprecations and what they should be replaced with -->
-
-## New Features
-
-<!-- Here goes the main new features and examples or instructions on how to use them -->
-
 ## Bug Fixes
 
-<!-- Here goes notable bug fixes that are worth a special mention or explanation -->
+- Bump the `grpclib` dependency to pull a fix for using IPv6 addresses.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,27 +1,17 @@
 # Frequenz Python SDK Release Notes
 
+## Summary
+
+<!-- Here goes a general summary of what this release is about -->
+
 ## Upgrading
 
-- The `frequenz-client-microgrid` dependency was bumped to v0.4.0. If you are using the client directly in your code, you will need to upgrade too.
-
-- Calls to `microgrid.*_pool` methods now always need to specified a priority value, corresponding to the requirements/priority of the actor making the call.
-
-- The `microgrid.*_pool` methods would only accept keyword arguments from now on.
-
-- The `microgrid.initialize()` method now takes a `server_url` instead of a `host` and `port`.
-
-   The following format is expected: `grpc://hostname{:port}{?ssl=ssl}`, where the port should be an int between `0` and `65535` (defaulting to `9090`) and `ssl` should be a boolean (defaulting to `false`). For example: `grpc://localhost` or `grpc://localhost:1090?ssl=true`.
-
-   The default was also removed, so you always need to specify the server URL.
-
-   This applies to the `ConnectionManager` as well, which also now doesn't expose the `host` and `port` attributes, only the `server_url`. If you need to extract the host or port from the `server_url`, you can use the standard Python `urllib.parse.urlparse()` function.
-
-- The `Config` class was removed and the `ConfigManagingActor` now sends a plain dictionary rather than a `Config` object.
+<!-- Here goes notes on how to upgrade from previous versions, including deprecations and what they should be replaced with -->
 
 ## New Features
 
-- Calls to `microgrid.*_pool` methods now accept an optional `set_operating_point` parameter, for setting an operating point for the other actors.  This would shift the target power by the operating point before actually applying it to the components.
+<!-- Here goes the main new features and examples or instructions on how to use them -->
 
 ## Bug Fixes
 
-- When the PowerDistributor receives a zero power request for PV inverters, it now correctly sets zero power to the inverters, and no longer crashes.
+<!-- Here goes notable bug fixes that are worth a special mention or explanation -->

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
   "networkx >= 2.8, < 4",
   "numpy >= 1.26.4, < 2",
   "typing_extensions >= 4.6.1, < 5",
+  "grpclib >= 0.4.8rc2",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
This release candidate fixes an important bug when using IPv6 addresses.

Fixes #1003.
