### PR TITLE
Fix PowerDistributor: exclude inverters that didn't send any data

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -40,3 +40,4 @@
 - Fixed a bug in `ConfigManagingActor` that was not properly comparing the event path to the config file path when the config file is a relative path.
 - Re-expose `ComponentMetricId` to the docs.
 - Fixed typing ambiguities when building composite formulas on streaming data.
+- Fix PowerDistributor: Distribution now excludes inverters that haven't sent any data since the application started.


### PR DESCRIPTION
PowerDistrubor crashed because it tried to get data from component that didn't send any data since the application startup.