### PR TITLE
Fix PV power distribution

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,4 +2,4 @@
 
 ## Bug Fixes
 
-- Fix getting reactive power from meters, inverters and EV chargers.
+- Fix PV power distribution excluding inverters that haven't sent any data since the application started.

--- a/src/frequenz/sdk/actor/power_distributing/_component_managers/_pv_inverter_manager/_pv_inverter_manager.py
+++ b/src/frequenz/sdk/actor/power_distributing/_component_managers/_pv_inverter_manager/_pv_inverter_manager.py
@@ -113,11 +113,19 @@ class PVManager(ComponentManager):
             raise ValueError(
                 "Cannot distribute power to PV inverters without any inverters"
             )
-        working_components = list(
-            self._component_pool_status_tracker.get_working_components(
-                request.component_ids
-            )
-        )
+
+        working_components: list[int] = []
+        for inv_id in self._component_pool_status_tracker.get_working_components(
+            request.component_ids
+        ):
+            if self._component_data_caches[inv_id].has_value():
+                working_components.append(inv_id)
+            else:
+                _logger.warning(
+                    "Exclude inverter %s from distribution, because it didn't "
+                    "send any data since the application startup.",
+                    inv_id,
+                )
 
         # When sorting by lower bounds, which are negative for PV inverters, we have to
         # reverse the order, so that the inverters with the higher bounds i.e., the
@@ -130,6 +138,10 @@ class PVManager(ComponentManager):
         )
 
         num_components = len(working_components)
+        if num_components == 0:
+            _logger.error("No inverters available for power distribution. Aborting.")
+            return
+
         for idx, inv_id in enumerate(working_components):
             # Request powers are negative for PV inverters.  When remaining power is
             # greater than 0.0, we can stop allocating further.

--- a/src/frequenz/sdk/actor/power_distributing/_component_managers/_pv_inverter_manager/_pv_inverter_manager.py
+++ b/src/frequenz/sdk/actor/power_distributing/_component_managers/_pv_inverter_manager/_pv_inverter_manager.py
@@ -148,7 +148,8 @@ class PVManager(ComponentManager):
             if remaining_power > Power.zero() or is_close_to_zero(
                 remaining_power.as_watts()
             ):
-                break
+                allocations[inv_id] = Power.zero()
+                continue
             distribution = remaining_power / float(num_components - idx)
             inv_data = self._component_data_caches[inv_id]
             if not inv_data.has_value():


### PR DESCRIPTION
To exclude PV inverters that didn't send any data. The power distributor crashes because it tried to get data from a component that didn't send any data since the application startup.