### PR TITLE
Change consumer power formula to add 0 if meter is not sending data

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,3 +3,4 @@
 ## Bug Fixes
 
 - Fix PV power distribution excluding inverters that haven't sent any data since the application started.
+- Change consumer power formula to use 0 instead of None if any component is not sending data. Now power is sum of power in all working components.

--- a/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_consumer_power_formula.py
+++ b/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_consumer_power_formula.py
@@ -181,7 +181,7 @@ class ConsumerPowerFormula(FormulaGenerator[Power]):
 
             builder.push_component_metric(
                 component.component_id,
-                nones_are_zeros=component.category != ComponentCategory.METER,
+                nones_are_zeros=True,
             )
 
         return builder.build()


### PR DESCRIPTION
Previously if any meter stopped working, we get None from whole formula.
We need to keep application working even if meter is not sending data.
This field should be configurable in the future.
Another feature might be to fallback to successor components.