### PR TITLE
Prevent stacking of power requests

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -43,3 +43,4 @@
 - Fixed a bug that was causing the `PowerDistributor` to exit if power requests to PV inverters or EV chargers timeout.
 - Fix handling of cancelled tasks in the data sourcing and resampling actor.
 - Fix PV power distribution excluding inverters that haven't sent any data since startup.
+- Prevent stacking of power requests to avoid delays in processing when the power requests frequency exceeds the processing time.

--- a/src/frequenz/sdk/actor/power_distributing/power_distributing.py
+++ b/src/frequenz/sdk/actor/power_distributing/power_distributing.py
@@ -153,7 +153,7 @@ class PowerDistributingActor(Actor):
 
             if req_id in self._processing_tasks:
                 if pending_request := self._pending_requests.get(req_id):
-                    _logger.warning(
+                    _logger.debug(
                         "Pending request: %s, overwritten with request: %s",
                         pending_request,
                         request,

--- a/tests/timeseries/_battery_pool/test_battery_pool_control_methods.py
+++ b/tests/timeseries/_battery_pool/test_battery_pool_control_methods.py
@@ -213,6 +213,7 @@ class TestBatteryPoolControl:
             await bounds_rx.receive(), power=1000.0, lower=-4000.0, upper=4000.0
         )
 
+        await asyncio.sleep(0.0)  # Wait for the power to be distributed.
         assert set_power.call_count == 4
         assert sorted(set_power.call_args_list) == [
             mocker.call(inv_id, 250.0)
@@ -248,6 +249,7 @@ class TestBatteryPoolControl:
                 result, power_distributing.Success
             ),
         )
+        await asyncio.sleep(0.0)  # Wait for the power to be distributed.
         assert set_power.call_count == 4
         assert sorted(set_power.call_args_list) == [
             mocker.call(inv_id, 25.0) for inv_id in mocks.microgrid.battery_inverter_ids
@@ -267,6 +269,7 @@ class TestBatteryPoolControl:
 
         # There should be an automatic retry.
         set_power.side_effect = None
+        await asyncio.sleep(0.0)  # Wait for the power to be distributed.
         assert set_power.call_count == 4
         assert sorted(set_power.call_args_list) == [
             mocker.call(inv_id, 25.0) for inv_id in mocks.microgrid.battery_inverter_ids
@@ -318,6 +321,7 @@ class TestBatteryPoolControl:
         self._assert_report(
             await bounds_1_rx.receive(), power=1000.0, lower=-2000.0, upper=2000.0
         )
+        await asyncio.sleep(0.0)  # Wait for the power to be distributed.
         assert set_power.call_count == 2
         assert sorted(set_power.call_args_list) == [
             mocker.call(inv_id, 500.0)
@@ -331,6 +335,7 @@ class TestBatteryPoolControl:
         if not latest_dist_result_2.has_value():
             bounds = await bounds_2_rx.receive()
         self._assert_report(bounds, power=1000.0, lower=-2000.0, upper=2000.0)
+        await asyncio.sleep(0.0)  # Wait for the power to be distributed.
         assert set_power.call_count == 2
         assert sorted(set_power.call_args_list) == [
             mocker.call(inv_id, 500.0)
@@ -375,7 +380,7 @@ class TestBatteryPoolControl:
         self._assert_report(
             await bounds_2_rx.receive(), power=-1000.0, lower=-1000.0, upper=0.0
         )
-
+        await asyncio.sleep(0.0)  # Wait for the power to be distributed.
         assert set_power.call_count == 4
         assert sorted(set_power.call_args_list) == [
             mocker.call(inv_id, -250.0)
@@ -394,7 +399,7 @@ class TestBatteryPoolControl:
         if not latest_dist_result_2.has_value():
             bounds = await bounds_2_rx.receive()
         self._assert_report(bounds, power=0.0, lower=-1000.0, upper=0.0)
-
+        await asyncio.sleep(0.0)  # Wait for the power to be distributed.
         assert set_power.call_count == 4
         assert sorted(set_power.call_args_list) == [
             mocker.call(inv_id, 0.0) for inv_id in mocks.microgrid.battery_inverter_ids
@@ -428,6 +433,7 @@ class TestBatteryPoolControl:
         self._assert_report(
             await bounds_rx.receive(), power=1000.0, lower=-4000.0, upper=4000.0
         )
+        await asyncio.sleep(0.0)  # Wait for the power to be distributed.
         assert set_power.call_count == 4
         assert sorted(set_power.call_args_list) == [
             mocker.call(inv_id, 250.0)
@@ -453,6 +459,7 @@ class TestBatteryPoolControl:
         self._assert_report(
             await bounds_rx.receive(), power=400.0, lower=-4000.0, upper=4000.0
         )
+        await asyncio.sleep(0.0)  # Wait for the power to be distributed.
         assert set_power.call_count == 4
         assert sorted(set_power.call_args_list) == [
             mocker.call(inv_id, 100.0)
@@ -477,6 +484,7 @@ class TestBatteryPoolControl:
         self._assert_report(
             await bounds_rx.receive(), power=0.0, lower=-4000.0, upper=4000.0
         )
+        await asyncio.sleep(0.0)  # Wait for the power to be distributed.
         assert set_power.call_count == 4
         assert sorted(set_power.call_args_list) == [
             mocker.call(inv_id, 0.0) for inv_id in mocks.microgrid.battery_inverter_ids
@@ -501,6 +509,7 @@ class TestBatteryPoolControl:
         self._assert_report(
             await bounds_rx.receive(), power=-400.0, lower=-4000.0, upper=4000.0
         )
+        await asyncio.sleep(0.0)  # Wait for the power to be distributed.
         assert set_power.call_count == 4
         assert sorted(set_power.call_args_list) == [
             mocker.call(inv_id, -100.0)
@@ -586,7 +595,7 @@ class TestBatteryPoolControl:
         self._assert_report(
             await bounds_1_rx.receive(), power=200.0, lower=-1000.0, upper=1500.0
         )
-
+        await asyncio.sleep(0.0)  # Wait for the power to be distributed.
         assert set_power.call_count == 4
         assert sorted(set_power.call_args_list) == [
             mocker.call(inv_id, 50.0) for inv_id in mocks.microgrid.battery_inverter_ids
@@ -624,6 +633,7 @@ class TestBatteryPoolControl:
             if dist_result.succeeded_power == Power.from_watts(720.0):
                 break
 
+        await asyncio.sleep(0.0)  # Wait for the power to be distributed.
         assert set_power.call_count == 4
         assert sorted(set_power.call_args_list) == [
             mocker.call(inv_id, 720.0 / 4)
@@ -664,6 +674,7 @@ class TestBatteryPoolControl:
             if dist_result.succeeded_power == Power.from_watts(-280.0):
                 break
 
+        await asyncio.sleep(0.0)  # Wait for the power to be distributed.
         assert set_power.call_count == 4
         assert sorted(set_power.call_args_list) == [
             mocker.call(inv_id, -280.0 / 4)


### PR DESCRIPTION
The power distributing actor processes one power request at a time to prevent multiple requests for the same components from being sent to the microgrid API concurrently. Previously, this could lead to the request channel receiver becoming full if the power request frequency was higher than the processing time. Even worse, the requests could be processed late, causing unexpected behavior for applications setting power requests. Moreover, the actor was blocking power requests with different sets of components from being processed if there was any existing request.
    
This patch ensures that the actor processes one request at a time for different sets of components and keeps track of the latest pending request if there is an existing request with the same set of components being processed. The pending request will be overwritten by the latest received request with the same set of components, and the actor will process it once the request with the same components is done processing. 
