### PR TITLE
Handle `CancelledError`s properly

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -41,3 +41,4 @@
 - Re-expose `ComponentMetricId` to the docs.
 - Fixed typing ambiguities when building composite formulas on streaming data.
 - Fixed a bug that was causing the `PowerDistributor` to exit if power requests to PV inverters or EV chargers timeout.
+- Fix handling of cancelled tasks in the data sourcing and resampling actor.

--- a/src/frequenz/sdk/actor/_data_sourcing/microgrid_api_source.py
+++ b/src/frequenz/sdk/actor/_data_sourcing/microgrid_api_source.py
@@ -413,11 +413,13 @@ class MicrogridApiSource:
             ) -> set[asyncio.Task[None]]:
                 done, pending = await asyncio.wait(sending_tasks, timeout=0)
                 for task in done:
-                    if error := task.exception():
-                        _logger.error(
+                    try:
+                        task.result()
+                    # pylint: disable-next=broad-except
+                    except (asyncio.CancelledError, Exception):
+                        _logger.exception(
                             "Error while processing message in task %s",
                             task.get_name(),
-                            exc_info=error,
                         )
                 return pending
 

--- a/tests/timeseries/mock_microgrid.py
+++ b/tests/timeseries/mock_microgrid.py
@@ -230,8 +230,12 @@ class MockMicrogrid:  # pylint: disable=too-many-instance-attributes
         self.init_mock_client(initialize_cb)
 
         def _done_callback(task: asyncio.Task[None]) -> None:
-            if exc := task.exception():
-                raise SystemExit(f"Streaming task {task.get_name()!r} failed: {exc}")
+            try:
+                task.result()
+            except (asyncio.CancelledError, Exception) as exc:
+                raise SystemExit(
+                    f"Streaming task {task.get_name()!r} failed: {exc}"
+                ) from exc
 
         for component_id, coro in self._streaming_coros:
             task = asyncio.create_task(coro, name=f"component-id:{component_id}")


### PR DESCRIPTION
The method `exception()` in `Task` doesn't return `CancelledError` if the task was cancelled, instead it raises the error, so if a task is cancelled an exception would be raised unintentionally.

Instead we want to catch `CancelledError` and treat it like any other task error for these tasks, are they are not supposed to be cancelled.

This PR also adds some improvements to the resampling actor, to avoid unnecessary restarts.

Fixes #1026.
