### PR TITLE
Fix gap in ring buffer when updating missing values

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,1 +1,5 @@
 # Frequenz Python SDK Release Notes
+
+## Bug Fixes
+
+- Fixes a bug in the ring buffer in case the updated value is missing and creates a gap in time.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,1 @@
 # Frequenz Python SDK Release Notes
-
-## Bug Fixes
-
-- Fix PV power distribution excluding inverters that haven't sent any data since the application started.

--- a/src/frequenz/sdk/timeseries/_ringbuffer/buffer.py
+++ b/src/frequenz/sdk/timeseries/_ringbuffer/buffer.py
@@ -491,8 +491,11 @@ class OrderedRingBuffer(Generic[FloatArray]):
         # New missing entry that is not already in a gap?
         if record_as_missing:
             if not found_in_gaps:
+                # If there are no gaps and the new value is not subsequent to the
+                # newest value, we need to start the new gap after the newest value
+                start_gap = min(newest + self._sampling_period, timestamp)
                 self._gaps.append(
-                    Gap(start=timestamp, end=timestamp + self._sampling_period)
+                    Gap(start=start_gap, end=timestamp + self._sampling_period)
                 )
         elif len(self._gaps) > 0:
             if found_in_gaps:

--- a/tests/timeseries/test_ringbuffer.py
+++ b/tests/timeseries/test_ringbuffer.py
@@ -277,12 +277,12 @@ def test_gaps() -> None:  # pylint: disable=too-many-statements
     assert buffer.count_covered() == 5
     assert len(buffer.gaps) == 0
 
-    # whole range gap suffers from sdk#646
+    # whole range gap
     buffer.update(Sample(dt(99), None))
-    assert buffer.oldest_timestamp == dt(95)  # bug: should be None
-    assert buffer.newest_timestamp == dt(99)  # bug: should be None
-    assert buffer.count_valid() == 4  # bug: should be 0 (whole range gap)
-    assert buffer.count_covered() == 5  # bug: should be 0
+    assert buffer.oldest_timestamp is None
+    assert buffer.newest_timestamp is None
+    assert buffer.count_valid() == 0
+    assert buffer.count_covered() == 0
     assert len(buffer.gaps) == 1
 
 


### PR DESCRIPTION
If there are no gaps in the ring buffer and the new value is missing and creates a gap in time, we need to start the new gap after the latest value from before.

Fixes #646.