### PR TITLE
Fallback components in generated formulas

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -14,6 +14,7 @@
   - PVPowerFormula
   - ProducerPowerFormula
   - BatteryPowerFormula
+  - ConsumerPowerFormula
 
 ## Bug Fixes
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -13,6 +13,7 @@
 - Fallback components are used in generated formulas. If primary components is unavailable, formula will generate metric from fallback components. Fallback formulas are implemented for:
   - PVPowerFormula
   - ProducerPowerFormula
+  - BatteryPowerFormula
 
 ## Bug Fixes
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -15,6 +15,7 @@
   - ProducerPowerFormula
   - BatteryPowerFormula
   - ConsumerPowerFormula
+  - GridPowerFormula
 
 ## Bug Fixes
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -11,7 +11,8 @@
 ## New Features
 
 - Fallback components are used in generated formulas. If primary components is unavailable, formula will generate metric from fallback components. Fallback formulas are implemented for:
-   - PVPowerFormula
+  - PVPowerFormula
+  - ProducerPowerFormula
 
 ## Bug Fixes
 
@@ -20,4 +21,3 @@
 - Allow setting `api_power_request_timeout` in `microgrid.initialize()`.
 
 - Fix an issue where in grid meters could be identified as {pv/ev/battery/chp} meters in some component graph configurations.
-

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,7 +10,8 @@
 
 ## New Features
 
-<!-- Here goes the main new features and examples or instructions on how to use them -->
+- Fallback components are used in generated formulas. If primary components is unavailable, formula will generate metric from fallback components. Fallback formulas are implemented for:
+   - PVPowerFormula
 
 ## Bug Fixes
 
@@ -19,3 +20,4 @@
 - Allow setting `api_power_request_timeout` in `microgrid.initialize()`.
 
 - Fix an issue where in grid meters could be identified as {pv/ev/battery/chp} meters in some component graph configurations.
+

--- a/src/frequenz/sdk/timeseries/battery_pool/_battery_pool.py
+++ b/src/frequenz/sdk/timeseries/battery_pool/_battery_pool.py
@@ -245,6 +245,7 @@ class BatteryPool:
             BatteryPowerFormula,
             FormulaGeneratorConfig(
                 component_ids=self._pool_ref_store._batteries,
+                allow_fallback=True,
             ),
         )
         assert isinstance(engine, FormulaEngine)

--- a/src/frequenz/sdk/timeseries/formula_engine/_formula_engine.py
+++ b/src/frequenz/sdk/timeseries/formula_engine/_formula_engine.py
@@ -27,6 +27,7 @@ from ._formula_steps import (
     ConstantValue,
     Consumption,
     Divider,
+    FallbackMetricFetcher,
     FormulaStep,
     Maximizer,
     MetricFetcher,
@@ -747,6 +748,7 @@ class FormulaBuilder(Generic[QuantityT]):
         data_stream: Receiver[Sample[QuantityT]],
         *,
         nones_are_zeros: bool,
+        fallback: FallbackMetricFetcher[QuantityT] | None = None,
     ) -> None:
         """Push a metric receiver into the engine.
 
@@ -755,9 +757,18 @@ class FormulaBuilder(Generic[QuantityT]):
             data_stream: A receiver to fetch this metric from.
             nones_are_zeros: Whether to treat None values from the stream as 0s.  If
                 False, the returned value will be a None.
+            fallback: Metric fetcher to use if primary one start sending
+                invalid data (e.g. due to a component stop). If None, the data from
+                primary metric fetcher will be used.
         """
         fetcher = self._metric_fetchers.setdefault(
-            name, MetricFetcher(name, data_stream, nones_are_zeros=nones_are_zeros)
+            name,
+            MetricFetcher(
+                name,
+                data_stream,
+                nones_are_zeros=nones_are_zeros,
+                fallback=fallback,
+            ),
         )
         self._steps.append(fetcher)
 

--- a/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_battery_power_formula.py
+++ b/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_battery_power_formula.py
@@ -92,8 +92,6 @@ class BatteryPowerFormula(FormulaGenerator[Power]):
                 "All batteries behind a set of inverters must be requested."
             )
 
-        builder.push_oper("(")
-        builder.push_oper("(")
         # Iterate over the flattened list of inverters
         for idx, comp in enumerate(
             inverter for inverters in battery_inverters for inverter in inverters

--- a/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_battery_power_formula.py
+++ b/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_battery_power_formula.py
@@ -3,18 +3,21 @@
 
 """Formula generator from component graph for Grid Power."""
 
+import itertools
 import logging
 
-from frequenz.client.microgrid import ComponentMetricId
+from frequenz.client.microgrid import Component, ComponentCategory, ComponentMetricId
 
 from ....microgrid import connection_manager
 from ..._quantities import Power
 from ...formula_engine import FormulaEngine
+from ._fallback_formula_metric_fetcher import FallbackFormulaMetricFetcher
 from ._formula_generator import (
     NON_EXISTING_COMPONENT_ID,
     ComponentNotFound,
     FormulaGenerationError,
     FormulaGenerator,
+    FormulaGeneratorConfig,
 )
 
 _logger = logging.getLogger(__name__)
@@ -48,8 +51,8 @@ class BatteryPowerFormula(FormulaGenerator[Power]):
         builder = self._get_builder(
             "battery-power", ComponentMetricId.ACTIVE_POWER, Power.from_watts
         )
-        component_ids = self._config.component_ids
-        if not component_ids:
+
+        if not self._config.component_ids:
             _logger.warning(
                 "No Battery component IDs specified. "
                 "Subscribing to the resampling actor with a non-existing "
@@ -63,41 +66,109 @@ class BatteryPowerFormula(FormulaGenerator[Power]):
             )
             return builder.build()
 
+        component_ids = set(self._config.component_ids)
         component_graph = connection_manager.get().component_graph
+        inv_bat_mapping: dict[Component, set[Component]] = {}
 
-        battery_inverters = frozenset(
-            frozenset(
+        for bat_id in component_ids:
+            inverters = set(
                 filter(
                     component_graph.is_battery_inverter,
                     component_graph.predecessors(bat_id),
                 )
             )
-            for bat_id in component_ids
-        )
-
-        if not all(battery_inverters):
-            raise ComponentNotFound(
-                "All batteries must have at least one inverter as a predecessor."
-            )
-
-        all_connected_batteries = set()
-        for inverters in battery_inverters:
-            for inverter in inverters:
-                all_connected_batteries.update(
-                    component_graph.successors(inverter.component_id)
+            if len(inverters) == 0:
+                raise ComponentNotFound(
+                    "All batteries must have at least one inverter as a predecessor."
+                    f"Battery ID {bat_id} has no inverter as a predecessor.",
                 )
 
-        if len(all_connected_batteries) != len(component_ids):
-            raise FormulaGenerationError(
-                "All batteries behind a set of inverters must be requested."
-            )
+            for inverter in inverters:
+                all_connected_batteries = component_graph.successors(
+                    inverter.component_id
+                )
+                battery_ids = set(
+                    map(lambda battery: battery.component_id, all_connected_batteries)
+                )
+                if not battery_ids.issubset(component_ids):
+                    raise FormulaGenerationError(
+                        f"Not all batteries behind inverter {inverter.component_id} "
+                        f"are requested. Missing: {battery_ids - component_ids}"
+                    )
 
-        # Iterate over the flattened list of inverters
-        for idx, comp in enumerate(
-            inverter for inverters in battery_inverters for inverter in inverters
-        ):
-            if idx > 0:
-                builder.push_oper("+")
-            builder.push_component_metric(comp.component_id, nones_are_zeros=True)
+                inv_bat_mapping[inverter] = all_connected_batteries
+
+        if self._config.allow_fallback:
+            fallbacks = self._get_fallback_formulas(inv_bat_mapping)
+
+            for idx, (primary_component, fallback_formula) in enumerate(
+                fallbacks.items()
+            ):
+                if idx > 0:
+                    builder.push_oper("+")
+
+                builder.push_component_metric(
+                    primary_component.component_id,
+                    nones_are_zeros=(
+                        primary_component.category != ComponentCategory.METER
+                    ),
+                    fallback=fallback_formula,
+                )
+        else:
+            for idx, comp in enumerate(inv_bat_mapping.keys()):
+                if idx > 0:
+                    builder.push_oper("+")
+                builder.push_component_metric(comp.component_id, nones_are_zeros=True)
 
         return builder.build()
+
+    def _get_fallback_formulas(
+        self, inv_bat_mapping: dict[Component, set[Component]]
+    ) -> dict[Component, FallbackFormulaMetricFetcher[Power] | None]:
+        """Find primary and fallback components and create fallback formulas.
+
+        The primary component is the one that will be used to calculate the battery power.
+        If it is not available, the fallback formula will be used instead.
+        Fallback formulas calculate the battery power using the fallback components.
+        Fallback formulas are wrapped in `FallbackFormulaMetricFetcher`.
+
+        Args:
+            inv_bat_mapping: A mapping from inverter to connected batteries.
+
+        Returns:
+            A dictionary mapping primary components to their FallbackFormulaMetricFetcher.
+        """
+        fallbacks = self._get_metric_fallback_components(set(inv_bat_mapping.keys()))
+
+        fallback_formulas: dict[
+            Component, FallbackFormulaMetricFetcher[Power] | None
+        ] = {}
+        for primary_component, fallback_components in fallbacks.items():
+            if len(fallback_components) == 0:
+                fallback_formulas[primary_component] = None
+                continue
+
+            battery_ids = set(
+                map(
+                    lambda battery: battery.component_id,
+                    itertools.chain.from_iterable(
+                        inv_bat_mapping[inv] for inv in fallback_components
+                    ),
+                )
+            )
+
+            generator = BatteryPowerFormula(
+                f"{self._namespace}_fallback_{battery_ids}",
+                self._channel_registry,
+                self._resampler_subscription_sender,
+                FormulaGeneratorConfig(
+                    component_ids=battery_ids,
+                    allow_fallback=False,
+                ),
+            )
+
+            fallback_formulas[primary_component] = FallbackFormulaMetricFetcher(
+                generator
+            )
+
+        return fallback_formulas

--- a/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_fallback_formula_metric_fetcher.py
+++ b/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_fallback_formula_metric_fetcher.py
@@ -34,7 +34,6 @@ class FallbackFormulaMetricFetcher(FallbackMetricFetcher[QuantityT]):
         self._formula_generator: FormulaGenerator[QuantityT] = formula_generator
         self._formula_engine: FormulaEngine[QuantityT] | None = None
         self._receiver: Receiver[Sample[QuantityT]] | None = None
-        self._latest_sample: Sample[QuantityT] | None = None
 
     @property
     def name(self) -> str:
@@ -45,15 +44,6 @@ class FallbackFormulaMetricFetcher(FallbackMetricFetcher[QuantityT]):
     def is_running(self) -> bool:
         """Check whether the formula engine is running."""
         return self._receiver is not None
-
-    @property
-    def latest_sample(self) -> Sample[QuantityT] | None:
-        """Get the latest fetched sample.
-
-        Returns:
-            The latest fetched sample, or `None` if no sample has been fetched yet.
-        """
-        return self._latest_sample
 
     def start(self) -> None:
         """Initialize the formula engine and start fetching samples."""
@@ -87,5 +77,4 @@ class FallbackFormulaMetricFetcher(FallbackMetricFetcher[QuantityT]):
             self._receiver is not None
         ), f"Fallback metric fetcher: {self.name} was not started"
 
-        self._latest_sample = self._receiver.consume()
-        return self._latest_sample
+        return self._receiver.consume()

--- a/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_fallback_formula_metric_fetcher.py
+++ b/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_fallback_formula_metric_fetcher.py
@@ -1,0 +1,91 @@
+# License: MIT
+# Copyright © 2024 Frequenz Energy-as-a-Service GmbH
+
+"""FallbackMetricFetcher implementation that uses formula generator."""
+
+from frequenz.channels import Receiver
+
+from ... import Sample
+from ..._quantities import QuantityT
+from .. import FormulaEngine
+from .._formula_steps import FallbackMetricFetcher
+from ._formula_generator import FormulaGenerator
+
+
+# This is done as a separate module to avoid circular imports.
+class FallbackFormulaMetricFetcher(FallbackMetricFetcher[QuantityT]):
+    """A metric fetcher that uses a formula generator.
+
+    The formula engine is generated lazily, meaning it is created only when
+    the `start` or `fetch_next` method is called for the first time.
+    Once the formula engine is initialized, it subscribes to its components
+    and begins calculating and sending the formula results.
+    """
+
+    def __init__(self, formula_generator: FormulaGenerator[QuantityT]):
+        """Create a `FallbackFormulaMetricFetcher` instance.
+
+        Args:
+            formula_generator: A formula generator that generates
+                a formula engine with fallback components.
+        """
+        super().__init__()
+        self._name = formula_generator.namespace
+        self._formula_generator: FormulaGenerator[QuantityT] = formula_generator
+        self._formula_engine: FormulaEngine[QuantityT] | None = None
+        self._receiver: Receiver[Sample[QuantityT]] | None = None
+        self._latest_sample: Sample[QuantityT] | None = None
+
+    @property
+    def name(self) -> str:
+        """Get the name of the fetcher."""
+        return self._name
+
+    @property
+    def is_running(self) -> bool:
+        """Check whether the formula engine is running."""
+        return self._receiver is not None
+
+    @property
+    def latest_sample(self) -> Sample[QuantityT] | None:
+        """Get the latest fetched sample.
+
+        Returns:
+            The latest fetched sample, or `None` if no sample has been fetched yet.
+        """
+        return self._latest_sample
+
+    def start(self) -> None:
+        """Initialize the formula engine and start fetching samples."""
+        engine = self._formula_generator.generate()
+        # We need this assert because generate() can return a FormulaEngine
+        # or FormulaEngine3Phase, but in this case we know it will return a
+        # FormulaEngine. This helps to silence `mypy` and also to verify our
+        # assumptions are still true at runtime
+        assert isinstance(engine, FormulaEngine)
+        self._formula_engine = engine
+        self._receiver = self._formula_engine.new_receiver()
+
+    async def ready(self) -> bool:
+        """Wait until the receiver is ready with a message or an error.
+
+        Once a call to `ready()` has finished, the message should be read with
+        a call to `consume()` (`receive()` or iterated over).
+
+        Returns:
+            Whether the receiver is still active.
+        """
+        if self._receiver is None:
+            self.start()
+
+        assert self._receiver is not None
+        return await self._receiver.ready()
+
+    def consume(self) -> Sample[QuantityT]:
+        """Return the latest message once `ready()` is complete."""
+        assert (
+            self._receiver is not None
+        ), f"Fallback metric fetcher: {self.name} was not started"
+
+        self._latest_sample = self._receiver.consume()
+        return self._latest_sample

--- a/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_formula_generator.py
+++ b/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_formula_generator.py
@@ -49,6 +49,8 @@ class FormulaGeneratorConfig:
     component_ids: abc.Set[int] | None = None
     """The component IDs to use for generating the formula."""
 
+    allow_fallback: bool = True
+
 
 class FormulaGenerator(ABC, Generic[QuantityT]):
     """A class for generating formulas from the component graph."""

--- a/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_formula_generator.py
+++ b/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_formula_generator.py
@@ -77,6 +77,11 @@ class FormulaGenerator(ABC, Generic[QuantityT]):
         self._namespace: str = namespace
         self._config: FormulaGeneratorConfig = config
 
+    @property
+    def namespace(self) -> str:
+        """Get the namespace for the formula generator."""
+        return self._namespace
+
     def _get_builder(
         self,
         name: str,
@@ -173,6 +178,7 @@ class FormulaGenerator(ABC, Generic[QuantityT]):
         """
         graph = connection_manager.get().component_graph
         fallbacks: dict[Component, set[Component]] = {}
+
         for component in components:
             if component.category == ComponentCategory.METER:
                 fallbacks[component] = self._get_meter_fallback_components(component)

--- a/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_grid_power_formula.py
+++ b/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_grid_power_formula.py
@@ -3,11 +3,17 @@
 
 """Formula generator from component graph for Grid Power."""
 
-from frequenz.client.microgrid import ComponentCategory, ComponentMetricId
+from frequenz.client.microgrid import Component, ComponentCategory, ComponentMetricId
 
 from ..._quantities import Power
 from .._formula_engine import FormulaEngine
-from ._formula_generator import FormulaGenerator
+from ._fallback_formula_metric_fetcher import FallbackFormulaMetricFetcher
+from ._formula_generator import (
+    ComponentNotFound,
+    FormulaGenerator,
+    FormulaGeneratorConfig,
+)
+from ._simple_power_formula import SimplePowerFormula
 
 
 class GridPowerFormula(FormulaGenerator[Power]):
@@ -30,6 +36,20 @@ class GridPowerFormula(FormulaGenerator[Power]):
         )
         grid_successors = self._get_grid_component_successors()
 
+        components = {
+            c
+            for c in grid_successors
+            if c.category
+            in {
+                ComponentCategory.INVERTER,
+                ComponentCategory.EV_CHARGER,
+                ComponentCategory.METER,
+            }
+        }
+
+        if not components:
+            raise ComponentNotFound("No grid successors found")
+
         # generate a formula that just adds values from all components that are
         # directly connected to the grid.  If the requested formula type is
         # `PASSIVE_SIGN_CONVENTION`, there is nothing more to do.  If the requested
@@ -41,28 +61,75 @@ class GridPowerFormula(FormulaGenerator[Power]):
         #  - `PASSIVE_SIGN_CONVENTION`: `(grid-successor-1 + grid-successor-2 + ...)`
         #  - `PRODUCTION`: `max(0, -(grid-successor-1 + grid-successor-2 + ...))`
         #  - `CONSUMPTION`: `max(0, (grid-successor-1 + grid-successor-2 + ...))`
-        for idx, comp in enumerate(grid_successors):
-            if idx > 0:
-                builder.push_oper("+")
+        if self._config.allow_fallback:
+            fallbacks = self._get_fallback_formulas(components)
 
-            # Ensure the device has an `ACTIVE_POWER` metric.  When inverters
-            # produce `None` samples, those inverters are excluded from the
-            # calculation by treating their `None` values as `0`s.
-            #
-            # This is not possible for Meters, so when they produce `None`
-            # values, those values get propagated as the output.
-            if comp.category in (
-                ComponentCategory.INVERTER,
-                ComponentCategory.EV_CHARGER,
+            for idx, (primary_component, fallback_formula) in enumerate(
+                fallbacks.items()
             ):
-                nones_are_zeros = True
-            elif comp.category == ComponentCategory.METER:
-                nones_are_zeros = False
-            else:
-                continue
+                if idx > 0:
+                    builder.push_oper("+")
 
-            builder.push_component_metric(
-                comp.component_id, nones_are_zeros=nones_are_zeros
-            )
+                # should only be the case if the component is not a meter
+                builder.push_component_metric(
+                    primary_component.component_id,
+                    nones_are_zeros=(
+                        primary_component.category != ComponentCategory.METER
+                    ),
+                    fallback=fallback_formula,
+                )
+        else:
+            for idx, comp in enumerate(components):
+                if idx > 0:
+                    builder.push_oper("+")
+
+                builder.push_component_metric(
+                    comp.component_id,
+                    nones_are_zeros=(comp.category != ComponentCategory.METER),
+                )
 
         return builder.build()
+
+    def _get_fallback_formulas(
+        self, components: set[Component]
+    ) -> dict[Component, FallbackFormulaMetricFetcher[Power] | None]:
+        """Find primary and fallback components and create fallback formulas.
+
+        The primary component is the one that will be used to calculate the producer power.
+        If it is not available, the fallback formula will be used instead.
+        Fallback formulas calculate the grid power using the fallback components.
+        Fallback formulas are wrapped in `FallbackFormulaMetricFetcher`.
+
+        Args:
+            components: The producer components.
+
+        Returns:
+            A dictionary mapping primary components to their FallbackFormulaMetricFetcher.
+        """
+        fallbacks = self._get_metric_fallback_components(components)
+
+        fallback_formulas: dict[
+            Component, FallbackFormulaMetricFetcher[Power] | None
+        ] = {}
+
+        for primary_component, fallback_components in fallbacks.items():
+            if len(fallback_components) == 0:
+                fallback_formulas[primary_component] = None
+                continue
+
+            fallback_ids = [c.component_id for c in fallback_components]
+            generator = SimplePowerFormula(
+                f"{self._namespace}_fallback_{fallback_ids}",
+                self._channel_registry,
+                self._resampler_subscription_sender,
+                FormulaGeneratorConfig(
+                    component_ids=set(fallback_ids),
+                    allow_fallback=False,
+                ),
+            )
+
+            fallback_formulas[primary_component] = FallbackFormulaMetricFetcher(
+                generator
+            )
+
+        return fallback_formulas

--- a/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_producer_power_formula.py
+++ b/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_producer_power_formula.py
@@ -4,13 +4,20 @@
 """Formula generator from component graph for Producer Power."""
 
 import logging
+from typing import Callable
 
-from frequenz.client.microgrid import ComponentCategory, ComponentMetricId
+from frequenz.client.microgrid import Component, ComponentCategory, ComponentMetricId
 
 from ....microgrid import connection_manager
 from ..._quantities import Power
 from .._formula_engine import FormulaEngine
-from ._formula_generator import NON_EXISTING_COMPONENT_ID, FormulaGenerator
+from ._fallback_formula_metric_fetcher import FallbackFormulaMetricFetcher
+from ._formula_generator import (
+    NON_EXISTING_COMPONENT_ID,
+    ComponentNotFound,
+    FormulaGenerator,
+    FormulaGeneratorConfig,
+)
 
 _logger = logging.getLogger(__name__)
 
@@ -43,35 +50,111 @@ class ProducerPowerFormula(FormulaGenerator[Power]):
         )
 
         component_graph = connection_manager.get().component_graph
-        # if in the future we support additional producers, we need to add them to the lambda
-        producer_components = component_graph.dfs(
-            self._get_grid_component(),
-            set(),
-            lambda component: component_graph.is_pv_chain(component)
-            or component_graph.is_chp_chain(component),
+        if self._config.component_ids is None:
+            # if in the future we support additional producers, we need to add them to the lambda
+            producer_components = component_graph.dfs(
+                self._get_grid_component(),
+                set(),
+                lambda component: component_graph.is_pv_chain(component)
+                or component_graph.is_chp_chain(component),
+            )
+
+            if not producer_components:
+                _logger.warning(
+                    "Unable to find any producer components in the component graph. "
+                    "Subscribing to the resampling actor with a non-existing "
+                    "component id, so that `0` values are sent from the formula."
+                )
+                # If there are no producer components, we have to send 0 values at the same
+                # frequency as the other streams.  So we subscribe with a non-existing
+                # component id, just to get a `None` message at the resampling interval.
+                builder.push_component_metric(
+                    NON_EXISTING_COMPONENT_ID, nones_are_zeros=True
+                )
+                return builder.build()
+
+        else:
+            producer_components = component_graph.components(
+                component_ids=set(self._config.component_ids)
+            )
+            if len(producer_components) != len(self._config.component_ids):
+                raise ComponentNotFound(
+                    "Unable to find all requested producer components."
+                    f"Requested {self._config.component_ids}, "
+                    f" found {producer_components}."
+                )
+
+        is_not_meter: Callable[[Component], bool] = (
+            lambda component: component.category != ComponentCategory.METER
         )
 
-        if not producer_components:
-            _logger.warning(
-                "Unable to find any producer components in the component graph. "
-                "Subscribing to the resampling actor with a non-existing "
-                "component id, so that `0` values are sent from the formula."
-            )
-            # If there are no producer components, we have to send 0 values at the same
-            # frequency as the other streams.  So we subscribe with a non-existing
-            # component id, just to get a `None` message at the resampling interval.
-            builder.push_component_metric(
-                NON_EXISTING_COMPONENT_ID, nones_are_zeros=True
-            )
-            return builder.build()
+        if self._config.allow_fallback:
+            fallbacks = self._get_fallback_formulas(producer_components)
 
-        for idx, component in enumerate(producer_components):
-            if idx > 0:
-                builder.push_oper("+")
+            for idx, (primary_component, fallback_formula) in enumerate(
+                fallbacks.items()
+            ):
+                if idx > 0:
+                    builder.push_oper("+")
 
-            builder.push_component_metric(
-                component.component_id,
-                nones_are_zeros=component.category != ComponentCategory.METER,
-            )
+                # should only be the case if the component is not a meter
+                builder.push_component_metric(
+                    primary_component.component_id,
+                    nones_are_zeros=is_not_meter(primary_component),
+                    fallback=fallback_formula,
+                )
+        else:
+            for idx, component in enumerate(producer_components):
+                if idx > 0:
+                    builder.push_oper("+")
+
+                builder.push_component_metric(
+                    component.component_id,
+                    nones_are_zeros=is_not_meter(component),
+                )
 
         return builder.build()
+
+    def _get_fallback_formulas(
+        self, components: set[Component]
+    ) -> dict[Component, FallbackFormulaMetricFetcher[Power] | None]:
+        """Find primary and fallback components and create fallback formulas.
+
+        The primary component is the one that will be used to calculate the producer power.
+        However, if it is not available, the fallback formula will be used instead.
+        Fallback formulas calculate the producer power using the fallback components.
+        Fallback formulas are wrapped in `FallbackFormulaMetricFetcher`.
+
+        Args:
+            components: The producer components.
+
+        Returns:
+            A dictionary mapping primary components to their FallbackFormulaMetricFetcher.
+        """
+        fallbacks = self._get_metric_fallback_components(components)
+
+        fallback_formulas: dict[
+            Component, FallbackFormulaMetricFetcher[Power] | None
+        ] = {}
+
+        for primary_component, fallback_components in fallbacks.items():
+            if len(fallback_components) == 0:
+                fallback_formulas[primary_component] = None
+                continue
+
+            fallback_ids = [c.component_id for c in fallback_components]
+            generator = ProducerPowerFormula(
+                f"{self._namespace}_fallback_{fallback_ids}",
+                self._channel_registry,
+                self._resampler_subscription_sender,
+                FormulaGeneratorConfig(
+                    component_ids=set(fallback_ids),
+                    allow_fallback=False,
+                ),
+            )
+
+            fallback_formulas[primary_component] = FallbackFormulaMetricFetcher(
+                generator
+            )
+
+        return fallback_formulas

--- a/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_pv_power_formula.py
+++ b/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_pv_power_formula.py
@@ -5,12 +5,17 @@
 
 import logging
 
-from frequenz.client.microgrid import ComponentCategory, ComponentMetricId
+from frequenz.client.microgrid import Component, ComponentCategory, ComponentMetricId
 
 from ....microgrid import connection_manager
 from ..._quantities import Power
 from .._formula_engine import FormulaEngine
-from ._formula_generator import NON_EXISTING_COMPONENT_ID, FormulaGenerator
+from ._fallback_formula_metric_fetcher import FallbackFormulaMetricFetcher
+from ._formula_generator import (
+    NON_EXISTING_COMPONENT_ID,
+    FormulaGenerator,
+    FormulaGeneratorConfig,
+)
 
 _logger = logging.getLogger(__name__)
 
@@ -58,18 +63,79 @@ class PVPowerFormula(FormulaGenerator[Power]):
             # frequency as the other streams.  So we subscribe with a non-existing
             # component id, just to get a `None` message at the resampling interval.
             builder.push_component_metric(
-                NON_EXISTING_COMPONENT_ID, nones_are_zeros=True
+                NON_EXISTING_COMPONENT_ID,
+                nones_are_zeros=True,
             )
             return builder.build()
 
-        for idx, component in enumerate(pv_components):
-            if idx > 0:
-                builder.push_oper("+")
+        if self._config.allow_fallback:
+            fallbacks = self._get_fallback_formulas(pv_components)
 
-            # should only be the case if the component is not a meter
-            builder.push_component_metric(
-                component.component_id,
-                nones_are_zeros=component.category != ComponentCategory.METER,
-            )
+            for idx, (primary_component, fallback_formula) in enumerate(
+                fallbacks.items()
+            ):
+                if idx > 0:
+                    builder.push_oper("+")
+
+                builder.push_component_metric(
+                    primary_component.component_id,
+                    nones_are_zeros=(
+                        primary_component.category != ComponentCategory.METER
+                    ),
+                    fallback=fallback_formula,
+                )
+        else:
+            for idx, component in enumerate(pv_components):
+                if idx > 0:
+                    builder.push_oper("+")
+
+                builder.push_component_metric(
+                    component.component_id,
+                    nones_are_zeros=component.category != ComponentCategory.METER,
+                )
 
         return builder.build()
+
+    def _get_fallback_formulas(
+        self, components: set[Component]
+    ) -> dict[Component, FallbackFormulaMetricFetcher[Power] | None]:
+        """Find primary and fallback components and create fallback formulas.
+
+        The primary component is the one that will be used to calculate the PV power.
+        If it is not available, the fallback formula will be used instead.
+        Fallback formulas calculate the PV power using the fallback components.
+        Fallback formulas are wrapped in `FallbackFormulaMetricFetcher`.
+
+        Args:
+            components: The PV components.
+
+        Returns:
+            A dictionary mapping primary components to their corresponding
+                FallbackFormulaMetricFetcher.
+        """
+        fallbacks = self._get_metric_fallback_components(components)
+
+        fallback_formulas: dict[
+            Component, FallbackFormulaMetricFetcher[Power] | None
+        ] = {}
+        for primary_component, fallback_components in fallbacks.items():
+            if len(fallback_components) == 0:
+                fallback_formulas[primary_component] = None
+                continue
+            fallback_ids = [c.component_id for c in fallback_components]
+
+            generator = PVPowerFormula(
+                f"{self._namespace}_fallback_{fallback_ids}",
+                self._channel_registry,
+                self._resampler_subscription_sender,
+                FormulaGeneratorConfig(
+                    component_ids=set(fallback_ids),
+                    allow_fallback=False,
+                ),
+            )
+
+            fallback_formulas[primary_component] = FallbackFormulaMetricFetcher(
+                generator
+            )
+
+        return fallback_formulas

--- a/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_simple_power_formula.py
+++ b/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_simple_power_formula.py
@@ -1,0 +1,67 @@
+# License: MIT
+# Copyright © 2024 Frequenz Energy-as-a-Service GmbH
+
+"""Formula generator from component graph."""
+
+from frequenz.client.microgrid import ComponentCategory, ComponentMetricId
+
+from ....microgrid import connection_manager
+from ..._quantities import Power
+from .._formula_engine import FormulaEngine
+from ._formula_generator import FormulaGenerator
+
+
+class SimplePowerFormula(FormulaGenerator[Power]):
+    """Formula generator from component graph for calculating sum of Power.
+
+    Raises:
+        RuntimeError: If no components are defined in the config or if any
+            component is not found in the component graph.
+    """
+
+    def generate(  # noqa: DOC502
+        # * ComponentNotFound is raised indirectly by _get_grid_component()
+        # * RuntimeError is raised indirectly by connection_manager.get()
+        self,
+    ) -> FormulaEngine[Power]:
+        """Generate formula for calculating producer power from the component graph.
+
+        Returns:
+            A formula engine that will calculate the producer power.
+
+        Raises:
+            ComponentNotFound: If the component graph does not contain a producer power
+                component.
+            RuntimeError: If the grid component has a single successor that is not a
+                meter.
+        """
+        builder = self._get_builder(
+            "simple_power_formula", ComponentMetricId.ACTIVE_POWER, Power.from_watts
+        )
+
+        component_graph = connection_manager.get().component_graph
+        if self._config.component_ids is None:
+            raise RuntimeError("Power formula without component ids is not supported.")
+
+        components = component_graph.components(
+            component_ids=set(self._config.component_ids)
+        )
+
+        not_found_components = self._config.component_ids - {
+            c.component_id for c in components
+        }
+        if not_found_components:
+            raise RuntimeError(
+                f"Unable to find {not_found_components} components in the component graph. ",
+            )
+
+        for idx, component in enumerate(components):
+            if idx > 0:
+                builder.push_oper("+")
+
+            builder.push_component_metric(
+                component.component_id,
+                nones_are_zeros=component.category != ComponentCategory.METER,
+            )
+
+        return builder.build()

--- a/tests/timeseries/_formula_engine/test_formula_composition.py
+++ b/tests/timeseries/_formula_engine/test_formula_composition.py
@@ -130,7 +130,7 @@ class TestFormulaComposition:
             inv_calc_recv = engine.new_receiver()
 
             for _ in range(10):
-                await mockgrid.mock_resampler.send_bat_inverter_power(
+                await mockgrid.mock_resampler.send_meter_power(
                     [10.0 + count, 12.0 + count, 14.0 + count]
                 )
                 await mockgrid.mock_resampler.send_non_existing_component_value()

--- a/tests/timeseries/_formula_engine/test_formula_composition.py
+++ b/tests/timeseries/_formula_engine/test_formula_composition.py
@@ -151,7 +151,7 @@ class TestFormulaComposition:
     async def test_formula_composition_missing_bat(self, mocker: MockerFixture) -> None:
         """Test the composition of formulas with missing battery power data."""
         mockgrid = MockMicrogrid(grid_meter=False, mocker=mocker)
-        mockgrid.add_solar_inverters(2)
+        mockgrid.add_solar_inverters(2, no_meter=True)
 
         count = 0
         async with mockgrid, AsyncExitStack() as stack:

--- a/tests/timeseries/mock_microgrid.py
+++ b/tests/timeseries/mock_microgrid.py
@@ -112,10 +112,12 @@ class MockMicrogrid:  # pylint: disable=too-many-instance-attributes
         def filter_comp(category: ComponentCategory) -> list[int]:
             if graph is None:
                 return []
-            return list(
-                map(
-                    lambda c: c.component_id,
-                    graph.components(component_categories={category}),
+            return sorted(
+                list(
+                    map(
+                        lambda c: c.component_id,
+                        graph.components(component_categories={category}),
+                    )
                 )
             )
 
@@ -123,13 +125,15 @@ class MockMicrogrid:  # pylint: disable=too-many-instance-attributes
             if graph is None:
                 return []
 
-            return [
-                c.component_id
-                for c in graph.components(
-                    component_categories={ComponentCategory.INVERTER}
-                )
-                if c.type == comp_type
-            ]
+            return sorted(
+                [
+                    c.component_id
+                    for c in graph.components(
+                        component_categories={ComponentCategory.INVERTER}
+                    )
+                    if c.type == comp_type
+                ]
+            )
 
         self.chp_ids: list[int] = filter_comp(ComponentCategory.CHP)
         self.battery_ids: list[int] = filter_comp(ComponentCategory.BATTERY)

--- a/tests/timeseries/mock_microgrid.py
+++ b/tests/timeseries/mock_microgrid.py
@@ -362,33 +362,30 @@ class MockMicrogrid:  # pylint: disable=too-many-instance-attributes
             no_meters: if True, do not add a meter for each CHP.
         """
         for _ in range(count):
-            meter_id = self._id_increment * 10 + self.meter_id_suffix
             chp_id = self._id_increment * 10 + self.chp_id_suffix
-            self._id_increment += 1
-
-            self.meter_ids.append(meter_id)
             self.chp_ids.append(chp_id)
-
-            if not no_meters:
-                self._components.add(
-                    Component(
-                        meter_id,
-                        ComponentCategory.METER,
-                    )
-                )
             self._components.add(
                 Component(
                     chp_id,
                     ComponentCategory.CHP,
                 )
             )
-
-            self._start_meter_streaming(meter_id)
             if no_meters:
                 self._connections.add(Connection(self._connect_to, chp_id))
             else:
+                meter_id = self._id_increment * 10 + self.meter_id_suffix
+                self.meter_ids.append(meter_id)
+                self._components.add(
+                    Component(
+                        meter_id,
+                        ComponentCategory.METER,
+                    )
+                )
+                self._start_meter_streaming(meter_id)
                 self._connections.add(Connection(self._connect_to, meter_id))
                 self._connections.add(Connection(meter_id, chp_id))
+
+            self._id_increment += 1
 
     def add_batteries(self, count: int, no_meter: bool = False) -> None:
         """Add batteries with connected inverters and meters to the microgrid.

--- a/tests/timeseries/mock_resampler.py
+++ b/tests/timeseries/mock_resampler.py
@@ -61,7 +61,7 @@ class MockResampler:
                 self._input_channels_receivers[name] = [
                     self._channel_registry.get_or_create(
                         Sample[Quantity], name
-                    ).new_receiver()
+                    ).new_receiver(limit=1)
                     for _ in range(namespaces)
                 ]
             return senders

--- a/tests/timeseries/mock_resampler.py
+++ b/tests/timeseries/mock_resampler.py
@@ -196,6 +196,10 @@ class MockResampler:
         task.add_done_callback(self._handle_task_done)
         self._request_handler_task = task
 
+    def next_ts(self) -> None:
+        """Increment the timestamp."""
+        self._next_ts = datetime.now()
+
     def _handle_task_done(self, task: asyncio.Task[None]) -> None:
         if task.cancelled():
             return

--- a/tests/timeseries/test_consumer.py
+++ b/tests/timeseries/test_consumer.py
@@ -66,3 +66,134 @@ class TestConsumer:
             assert (await consumer_power_receiver.receive()).value == Power.from_watts(
                 0.0
             )
+
+    async def test_consumer_power_fallback_formula_with_grid_meter(
+        self, mocker: MockerFixture
+    ) -> None:
+        """Test the consumer power formula with a grid meter."""
+        mockgrid = MockMicrogrid(grid_meter=True, mocker=mocker)
+        mockgrid.add_batteries(1)
+        mockgrid.add_solar_inverters(1)
+        mockgrid.add_solar_inverters(1, no_meter=True)
+
+        # formula is grid_meter - battery - pv1 - pv2
+
+        async with mockgrid, AsyncExitStack() as stack:
+            consumer = microgrid.consumer()
+            stack.push_async_callback(consumer.stop)
+            consumer_power_formula = consumer.power
+            print(consumer_power_formula)
+            consumer_power_receiver = consumer_power_formula.new_receiver()
+
+            # Note: ConsumerPowerFormula has a "nones-are-zero" rule, that says:
+            # * if the meter value is None, it should be treated as None.
+            # * for other components None is treated as 0.
+
+            # fmt: off
+            expected_input_output: list[
+                tuple[list[float | None], list[float | None], list[float | None], Power | None]
+            ] = [
+                # ([grid_meter, bat_meter, pv1_meter], [bat_inv], [pv1_inv, pv2_inv], expected_power) # noqa: E501
+                ([100, 100, -50], [100], [-200, -300], Power.from_watts(350)),
+                ([500, -200, -100], [100], [-200, -100], Power.from_watts(900)),
+                # Case 2: The meter is unavailable (None).
+                # Subscribe to the fallback inverter, but return None as the result,
+                # according to the "nones-are-zero" rule
+                ([500, None, -100], [100], [-200, -100], None),
+                ([500, None, -100], [100], [-200, -100], Power.from_watts(600)),
+                # Case 3: Second meter is unavailable (None).
+                ([500, None, None], [100], [-200, -100], None),
+                ([500, None, None], [100], [-200, -100], Power.from_watts(700)),
+                # Case 3: pv2_inv is unavailable (None).
+                # It has no fallback, so return 0 as its value according to
+                # the "nones-are-zero" rule.
+                ([500, None, None], [100], [-200, None], Power.from_watts(600)),
+                # Case 4: Grid meter is unavailable (None).
+                # It has no fallback, so return None according to the "nones-are-zero" rule.
+                ([None, 100, -50], [100], [-200, -300], None),
+                ([None, 200, -50], [100], [-200, -300], None),
+                ([100, 100, -50], [100], [-200, -300], Power.from_watts(350)),
+                # Case 5: Only grid meter is working
+                ([100, None, None], [None], [None, None], Power.from_watts(100)),
+                ([-500, None, None], [None], [None, None], Power.from_watts(-500)),
+                # Case 6: Nothing is working
+                ([None, None, None], [None], [None, None], None),
+            ]
+            # fmt: on
+
+            for idx, (
+                meter_power,
+                bat_inv_power,
+                pv_inv_power,
+                expected_power,
+            ) in enumerate(expected_input_output):
+                await mockgrid.mock_resampler.send_meter_power(meter_power)
+                await mockgrid.mock_resampler.send_bat_inverter_power(bat_inv_power)
+                await mockgrid.mock_resampler.send_pv_inverter_power(pv_inv_power)
+                mockgrid.mock_resampler.next_ts()
+
+                result = await consumer_power_receiver.receive()
+                assert result.value == expected_power, (
+                    f"Test case {idx} failed:"
+                    + f" meter_power: {meter_power}"
+                    + f" bat_inverter_power {bat_inv_power}"
+                    + f" pv_inverter_power {pv_inv_power}"
+                    + f" expected_power: {expected_power}"
+                    + f" actual_power: {result.value}"
+                )
+
+    async def test_consumer_power_fallback_formula_without_grid_meter(
+        self, mocker: MockerFixture
+    ) -> None:
+        """Test the consumer power formula with a grid meter."""
+        mockgrid = MockMicrogrid(grid_meter=False, mocker=mocker)
+        mockgrid.add_consumer_meters(2)
+        mockgrid.add_batteries(1)
+        mockgrid.add_solar_inverters(1, no_meter=True)
+
+        # formula is sum of consumer meters
+
+        async with mockgrid, AsyncExitStack() as stack:
+            consumer = microgrid.consumer()
+            stack.push_async_callback(consumer.stop)
+            consumer_power_receiver = consumer.power.new_receiver()
+
+            # Note: ConsumerPowerFormula has a "nones-are-zero" rule, that says:
+            # * if the meter value is None, it should be treated as None.
+            # * for other components None is treated as 0.
+
+            # fmt: off
+            expected_input_output: list[
+                tuple[list[float | None], list[float | None], list[float | None], Power | None]
+            ] = [
+                # ([consumer_meter1, consumer_meter2, bat_meter], [bat_inv], [pv_inv], expected_power) # noqa: E501
+                ([100, 100, -50], [100], [-200,], Power.from_watts(200)),
+                ([500, 100, -50], [100], [-200,], Power.from_watts(600)),
+                # One of the meters is invalid - should return None according to none-are-zero rule
+                ([None, 100, -50], [100], [-200,], None),
+                ([None, None, -50], [100], [-200,], None),
+                ([500, None, -50], [100], [-200,], None),
+                ([2000, 1000, None], [None], [None], Power.from_watts(3000)),
+            ]
+            # fmt: on
+
+            for idx, (
+                meter_power,
+                bat_inv_power,
+                pv_inv_power,
+                expected_power,
+            ) in enumerate(expected_input_output):
+                await mockgrid.mock_resampler.send_meter_power(meter_power)
+                await mockgrid.mock_resampler.send_bat_inverter_power(bat_inv_power)
+                await mockgrid.mock_resampler.send_pv_inverter_power(pv_inv_power)
+                mockgrid.mock_resampler.next_ts()
+
+                result = await consumer_power_receiver.receive()
+                assert result.value == expected_power, (
+                    f"Test case {idx} failed:"
+                    + f" meter_power: {meter_power}"
+                    + f" bat_inverter_power {bat_inv_power}"
+                    + f" pv_inverter_power {pv_inv_power}"
+                    + f" expected_power: {expected_power}"
+                    + f" actual_power: {result.value}"
+                )

--- a/tests/timeseries/test_formula_formatter.py
+++ b/tests/timeseries/test_formula_formatter.py
@@ -134,5 +134,5 @@ class TestFormulaFormatter:
             composed_formula = (grid.power - pv_pool.power).build("grid_minus_pv")
             assert (
                 str(composed_formula)
-                == "[grid-power](#36 + #7 + #47 + #17 + #57 + #27) - [pv-power](#48 + #58)"
+                == "[grid-power](#36 + #7 + #47 + #17 + #57 + #27) - [pv-power](#47 + #57)"
             )

--- a/tests/timeseries/test_logical_meter.py
+++ b/tests/timeseries/test_logical_meter.py
@@ -77,3 +77,69 @@ class TestLogicalMeter:  # pylint: disable=too-many-public-methods
 
             await mockgrid.mock_resampler.send_non_existing_component_value()
             assert (await pv_power_receiver.receive()).value == Power.zero()
+
+    async def test_pv_power_with_failing_meter(self, mocker: MockerFixture) -> None:
+        """Test the pv power formula."""
+        mockgrid = MockMicrogrid(grid_meter=False, mocker=mocker)
+        mockgrid.add_solar_inverters(2)
+
+        async with mockgrid, AsyncExitStack() as stack:
+            pv_pool = microgrid.new_pv_pool(priority=5)
+            stack.push_async_callback(pv_pool.stop)
+            pv_power_receiver = pv_pool.power.new_receiver()
+
+            # Note: PvPowerFormula has a "nones-are-zero" rule, that says:
+            # * if the meter value is None, it should be treated as None.
+            # * for other components None is treated as 0.
+
+            expected_input_output: list[
+                tuple[list[float | None], list[float | None], Power | None]
+            ] = [
+                # ([meter_power], [pv_inverter_power], expected_power)
+                #
+                # Case 1: Both meters are available, so inverters are not used.
+                ([-1.0, -2.0], [None, -5.0], Power.from_watts(-3.0)),
+                ([-1.0, -2.0], [-10.0, -20.0], Power.from_watts(-3.0)),
+                # Case 2: The first meter is unavailable (None).
+                # Subscribe to the fallback inverter, but return None as the result,
+                # according to the "nones-are-zero" rule
+                ([None, -2.0], [-10.0, -20.0], None),
+                # Case 3: First meter is unavailable (None). Fallback inverter provides
+                # a value.
+                ([None, -2.0], [-10.0, -20.0], Power.from_watts(-12.0)),
+                ([None, -2.0], [-11.0, -20.0], Power.from_watts(-13.0)),
+                # Case 4: Both first meter and its fallback inverter are unavailable
+                # (None). Return 0 according to the "nones-are-zero" rule.
+                ([None, -2.0], [None, -20.0], Power.from_watts(-2.0)),
+                ([None, -2.0], [-11.0, -20.0], Power.from_watts(-13.0)),
+                # Case 5: Both meters are unavailable (None).
+                # Subscribe to the fallback inverter, but return None as the result,
+                # according "nones-are-zero" rule
+                ([None, None], [-5.0, -20.0], None),
+                # Case 6: Both meters are unavailable (None). Fallback inverter provides
+                # a values.
+                ([None, None], [-5.0, -20.0], Power.from_watts(-25.0)),
+                # Case 7: All components are unavailable (None).
+                # Return 0 according to the "nones-are-zero" rule.
+                ([None, None], [None, None], Power.from_watts(0.0)),
+                ([None, None], [-5.0, -20.0], Power.from_watts(-25.0)),
+                # Case 8: Meters becomes available and inverter values are not used.
+                ([-10.0, None], [-5.0, -20.0], Power.from_watts(-30.0)),
+                ([-10.0, -2.0], [-5.0, -20.0], Power.from_watts(-12.0)),
+            ]
+
+            for idx, (meter_power, pv_inverter_power, expected_power) in enumerate(
+                expected_input_output
+            ):
+                await mockgrid.mock_resampler.send_meter_power(meter_power)
+                await mockgrid.mock_resampler.send_pv_inverter_power(pv_inverter_power)
+                mockgrid.mock_resampler.next_ts()
+
+                result = await pv_power_receiver.receive()
+                assert result.value == expected_power, (
+                    f"Test case {idx} failed:"
+                    + f" meter_power: {meter_power}"
+                    + f" pv_inverter_power {pv_inverter_power}"
+                    + f" expected_power: {expected_power}"
+                    + f" actual_power: {result.value}"
+                )

--- a/tests/timeseries/test_logical_meter.py
+++ b/tests/timeseries/test_logical_meter.py
@@ -48,7 +48,8 @@ class TestLogicalMeter:  # pylint: disable=too-many-public-methods
             stack.push_async_callback(pv_pool.stop)
             pv_power_receiver = pv_pool.power.new_receiver()
 
-            await mockgrid.mock_resampler.send_pv_inverter_power([-1.0, -2.0])
+            await mockgrid.mock_resampler.send_meter_power([-1.0, -2.0])
+            await mockgrid.mock_resampler.send_pv_inverter_power([-10.0, -20.0])
             assert (await pv_power_receiver.receive()).value == Power.from_watts(-3.0)
 
     async def test_pv_power_no_meter(self, mocker: MockerFixture) -> None:

--- a/tests/timeseries/test_producer.py
+++ b/tests/timeseries/test_producer.py
@@ -60,6 +60,7 @@ class TestProducer:
             producer_power_receiver = producer.power.new_receiver()
 
             await mockgrid.mock_resampler.send_chp_power([2.0])
+
             assert (await producer_power_receiver.receive()).value == Power.from_watts(
                 2.0
             )
@@ -94,3 +95,83 @@ class TestProducer:
             assert (await producer_power_receiver.receive()).value == Power.from_watts(
                 0.0
             )
+
+    async def test_producer_fallback_formula(self, mocker: MockerFixture) -> None:
+        """Test the producer power formula with fallback formulas."""
+        mockgrid = MockMicrogrid(grid_meter=False, mocker=mocker)
+        mockgrid.add_solar_inverters(2)
+        # CHP has no meter, so no fallback component
+        mockgrid.add_chps(1, no_meters=True)
+
+        async with mockgrid, AsyncExitStack() as stack:
+            producer = microgrid.producer()
+            stack.push_async_callback(producer.stop)
+            producer_power_receiver = producer.power.new_receiver()
+
+            # Note: ProducerPowerFormula has a "nones-are-zero" rule, that says:
+            # * if the meter value is None, it should be treated as None.
+            # * for other components None is treated as 0.
+
+            # fmt: off
+            expected_input_output: list[
+                tuple[list[float | None], list[float | None], list[float | None], Power | None]
+            ] = [
+                # ([pv_meter_power], [pv_inverter_power], [chp_power], expected_power)
+                # Add power from meters and chp
+                ([-1.0, -2.0], [None, -200.0], [300], Power.from_watts(297.0)),
+                ([-1.0, -10], [-100.0, -200.0], [400], Power.from_watts(389.0)),
+                # Case 2: The first meter is unavailable (None).
+                # Subscribe to the fallback inverter, but return None as the result,
+                # according to the "nones-are-zero" rule
+                ([None, -2.0], [-100, -200.0], [400], None),
+                # Case 3: First meter is unavailable (None). Fallback inverter provides
+                # a value.
+                # Add second meter, first inverter and chp power
+                ([None, -2.0], [-100, -200.0], [400], Power.from_watts(298.0)),
+                ([None, -2.0], [-50, -200.0], [300], Power.from_watts(248.0)),
+                # Case 4: Both first meter and its fallback inverter are unavailable
+                # (None). Return 0 from failing component according to the
+                # "nones-are-zero" rule.
+                ([None, -2.0], [None, -200.0], [300], Power.from_watts(298.0)),
+                ([None, -10.0], [-20.0, -200.0], [300], Power.from_watts(270.0)),
+                # Case 5: CHP is unavailable. Return 0 from failing component
+                # according to the "nones-are-zero" rule.
+                ([None, -10.0], [-20.0, -200.0], [None], Power.from_watts(-30.0)),
+                # Case 6: Both meters are unavailable (None). Subscribe for fallback inverter
+                ([None, None], [-20.0, -200.0], [None], None),
+                ([None, None], [-20.0, -200.0], [None], Power.from_watts(-220.0)),
+                ([None, None], [None, -200.0], [None], Power.from_watts(-200.0)),
+                # Case 7: All components are unavailable (None). Return 0 according to the
+                # "nones-are-zero" rule.
+                ([None, None], [None, None], [None], Power.from_watts(0)),
+                ([None, None], [None, None], [None], Power.from_watts(0)),
+                ([None, None], [None, None], [300.0], Power.from_watts(300.0)),
+                ([-200.0, None], [None, -100.0], [50.0], Power.from_watts(-250.0)),
+                ([-200.0, -200.0], [-10.0, -20.0], [50.0], Power.from_watts(-350.0)),
+                # Case 8: Meter is unavailable but we already subscribed for inverter
+                # So don't return None in this case. Just proper formula result.
+                ([None, -200.0], [-10.0, -100.0], [50.0], Power.from_watts(-160.0)),
+
+            ]
+            # fmt: on
+
+            for idx, (
+                meter_power,
+                pv_inverter_power,
+                chp_power,
+                expected_power,
+            ) in enumerate(expected_input_output):
+                await mockgrid.mock_resampler.send_chp_power(chp_power)
+                await mockgrid.mock_resampler.send_meter_power(meter_power)
+                await mockgrid.mock_resampler.send_pv_inverter_power(pv_inverter_power)
+                mockgrid.mock_resampler.next_ts()
+
+                result = await producer_power_receiver.receive()
+                assert result.value == expected_power, (
+                    f"Test case {idx} failed:"
+                    + f" meter_power: {meter_power}"
+                    + f" pv_inverter_power {pv_inverter_power}"
+                    + f" chp_power {chp_power}"
+                    + f" expected_power: {expected_power}"
+                    + f" actual_power: {result.value}"
+                )

--- a/tests/utils/graph_generator.py
+++ b/tests/utils/graph_generator.py
@@ -11,6 +11,7 @@ from frequenz.client.microgrid import (
     ComponentCategory,
     ComponentType,
     Connection,
+    GridMetadata,
     InverterType,
 )
 
@@ -185,7 +186,7 @@ class GraphGenerator:
         Returns:
             a new grid component with default id.
         """
-        return Component(1, ComponentCategory.GRID)
+        return Component(1, ComponentCategory.GRID, None, GridMetadata(None))
 
     def to_graph(self, components: Any) -> _MicrogridComponentGraph:
         """Convert a list of components to a graph.


### PR DESCRIPTION
Fallback components are used in generated formulas. If primary components is unavailable, formula will generate metric from fallback components. Fallback formulas are implemented for:
  - PVPowerFormula
  - ProducerPowerFormula
  - BatteryPowerFormula
  - ConsumerPowerFormula
  - GridPowerFormula
 
All necessary formulas are implemented in this PR
