### PR TITLE
Add fallback value support in PowerDistributingActor for PV inverters

### DIFF
--- a/benchmarks/power_distribution/power_distributor.py
+++ b/benchmarks/power_distribution/power_distributor.py
@@ -121,6 +121,7 @@ async def run_test(  # pylint: disable=too-many-locals
         results_sender=power_result_channel.new_sender(),
         component_pool_status_sender=battery_status_channel.new_sender(),
         api_power_request_timeout=timedelta(seconds=5.0),
+        fallback_power=Power.zero(),
     ):
         tasks: list[Coroutine[Any, Any, list[Result]]] = []
         tasks.append(send_requests(batteries, num_requests))

--- a/src/frequenz/sdk/microgrid/__init__.py
+++ b/src/frequenz/sdk/microgrid/__init__.py
@@ -226,6 +226,7 @@ would play out:
 from datetime import timedelta
 
 from ..actor import ResamplerConfig
+from ..timeseries import Power
 from . import _data_pipeline, connection_manager
 from ._data_pipeline import (
     consumer,
@@ -244,6 +245,7 @@ async def initialize(
     server_url: str,
     resampler_config: ResamplerConfig,
     *,
+    pv_fallback_power: Power = Power.zero(),
     api_power_request_timeout: timedelta = timedelta(seconds=5.0),
 ) -> None:
     """Initialize the microgrid connection manager and the data pipeline.
@@ -255,6 +257,8 @@ async def initialize(
             `9090`) and ssl should be a boolean (defaulting to false). For example:
             `grpc://localhost:1090?ssl=true`.
         resampler_config: Configuration for the resampling actor.
+        pv_fallback_power: The power to assume for a PV inverter when it is not
+            reachable.
         api_power_request_timeout: Timeout to use when making power requests to
             the microgrid API.  When requests to components timeout, they will
             be marked as blocked for a short duration, during which time they
@@ -263,6 +267,7 @@ async def initialize(
     await connection_manager.initialize(server_url)
     await _data_pipeline.initialize(
         resampler_config,
+        pv_fallback_power=pv_fallback_power,
         api_power_request_timeout=api_power_request_timeout,
     )
 

--- a/src/frequenz/sdk/microgrid/_data_pipeline.py
+++ b/src/frequenz/sdk/microgrid/_data_pipeline.py
@@ -104,17 +104,20 @@ class _DataPipeline:  # pylint: disable=too-many-instance-attributes
             self._channel_registry,
             api_power_request_timeout=api_power_request_timeout,
             component_category=ComponentCategory.BATTERY,
+            fallback_power=Power.zero(),
         )
         self._ev_power_wrapper = PowerWrapper(
             self._channel_registry,
             api_power_request_timeout=api_power_request_timeout,
             component_category=ComponentCategory.EV_CHARGER,
+            fallback_power=Power.zero(),
         )
         self._pv_power_wrapper = PowerWrapper(
             self._channel_registry,
             api_power_request_timeout=api_power_request_timeout,
             component_category=ComponentCategory.INVERTER,
             component_type=InverterType.SOLAR,
+            fallback_power=Power.zero(),
         )
 
         self._logical_meter: LogicalMeter | None = None

--- a/src/frequenz/sdk/microgrid/_power_distributing/_component_managers/_battery_manager.py
+++ b/src/frequenz/sdk/microgrid/_power_distributing/_component_managers/_battery_manager.py
@@ -132,6 +132,7 @@ class BatteryManager(ComponentManager):  # pylint: disable=too-many-instance-att
         component_pool_status_sender: Sender[ComponentPoolStatus],
         results_sender: Sender[Result],
         api_power_request_timeout: timedelta,
+        fallback_power: Power,
     ):
         """Initialize this instance.
 
@@ -143,9 +144,13 @@ class BatteryManager(ComponentManager):  # pylint: disable=too-many-instance-att
             results_sender: Channel sender to send the power distribution results to.
             api_power_request_timeout: Timeout to use when making power requests to
                 the microgrid API.
+            fallback_power: The power to assume a battery has if the battery is not
+                reachable.
         """
         self._results_sender = results_sender
         self._api_power_request_timeout = api_power_request_timeout
+        self._fallback_power = fallback_power
+
         self._batteries = connection_manager.get().component_graph.components(
             component_categories={ComponentCategory.BATTERY}
         )

--- a/src/frequenz/sdk/microgrid/_power_distributing/_component_managers/_battery_manager.py
+++ b/src/frequenz/sdk/microgrid/_power_distributing/_component_managers/_battery_manager.py
@@ -145,11 +145,15 @@ class BatteryManager(ComponentManager):  # pylint: disable=too-many-instance-att
             api_power_request_timeout: Timeout to use when making power requests to
                 the microgrid API.
             fallback_power: The power to assume a battery has if the battery is not
-                reachable.
+                reachable.  Non-zero values are not yet supported.
         """
         self._results_sender = results_sender
         self._api_power_request_timeout = api_power_request_timeout
         self._fallback_power = fallback_power
+
+        assert (
+            self._fallback_power == Power.zero()
+        ), "Non-zero fallback power is not supported for batteries."
 
         self._batteries = connection_manager.get().component_graph.components(
             component_categories={ComponentCategory.BATTERY}

--- a/src/frequenz/sdk/microgrid/_power_distributing/_component_managers/_component_manager.py
+++ b/src/frequenz/sdk/microgrid/_power_distributing/_component_managers/_component_manager.py
@@ -8,6 +8,7 @@ import collections.abc
 
 from frequenz.channels import Sender
 
+from ....timeseries._quantities import Power
 from .._component_status import ComponentPoolStatus
 from ..request import Request
 from ..result import Result
@@ -21,6 +22,7 @@ class ComponentManager(abc.ABC):
         self,
         component_pool_status_sender: Sender[ComponentPoolStatus],
         results_sender: Sender[Result],
+        fallback_power: Power,
     ):
         """Initialize the component data manager.
 
@@ -28,6 +30,8 @@ class ComponentManager(abc.ABC):
             component_pool_status_sender: Channel for sending information about which
                 components are expected to be working.
             results_sender: Channel for sending the results of power distribution.
+            fallback_power: The power to assume for a component when it is not
+                reachable.
         """
 
     @abc.abstractmethod

--- a/src/frequenz/sdk/microgrid/_power_distributing/_component_managers/_ev_charger_manager/_ev_charger_manager.py
+++ b/src/frequenz/sdk/microgrid/_power_distributing/_component_managers/_ev_charger_manager/_ev_charger_manager.py
@@ -38,7 +38,9 @@ from ._states import EvcState, EvcStates
 _logger = logging.getLogger(__name__)
 
 
-class EVChargerManager(ComponentManager):
+class EVChargerManager(  # pylint: disable=too-many-instance-attributes
+    ComponentManager
+):
     """Manage ev chargers for the power distributor."""
 
     @override
@@ -47,6 +49,7 @@ class EVChargerManager(ComponentManager):
         component_pool_status_sender: Sender[ComponentPoolStatus],
         results_sender: Sender[Result],
         api_power_request_timeout: timedelta,
+        fallback_power: Power,
     ):
         """Initialize the ev charger data manager.
 
@@ -56,9 +59,13 @@ class EVChargerManager(ComponentManager):
             results_sender: Channel for sending results of power distribution.
             api_power_request_timeout: Timeout to use when making power requests to
                 the microgrid API.
+            fallback_power: The power to assume for an EV charger when it is not
+                reachable.
         """
         self._results_sender = results_sender
         self._api_power_request_timeout = api_power_request_timeout
+        self._fallback_power = fallback_power
+
         self._ev_charger_ids = self._get_ev_charger_ids()
         self._evc_states = EvcStates()
         self._voltage_cache: LatestValueCache[Sample3Phase[Voltage]] = LatestValueCache(

--- a/src/frequenz/sdk/microgrid/_power_distributing/_component_managers/_ev_charger_manager/_ev_charger_manager.py
+++ b/src/frequenz/sdk/microgrid/_power_distributing/_component_managers/_ev_charger_manager/_ev_charger_manager.py
@@ -60,11 +60,15 @@ class EVChargerManager(  # pylint: disable=too-many-instance-attributes
             api_power_request_timeout: Timeout to use when making power requests to
                 the microgrid API.
             fallback_power: The power to assume for an EV charger when it is not
-                reachable.
+                reachable.  Non-zero values are not yet supported.
         """
         self._results_sender = results_sender
         self._api_power_request_timeout = api_power_request_timeout
         self._fallback_power = fallback_power
+
+        assert (
+            self._fallback_power == Power.zero()
+        ), "Non-zero fallback power is not supported for EV chargers."
 
         self._ev_charger_ids = self._get_ev_charger_ids()
         self._evc_states = EvcStates()

--- a/src/frequenz/sdk/microgrid/_power_distributing/_component_managers/_pv_inverter_manager/_pv_inverter_manager.py
+++ b/src/frequenz/sdk/microgrid/_power_distributing/_component_managers/_pv_inverter_manager/_pv_inverter_manager.py
@@ -38,6 +38,7 @@ class PVManager(ComponentManager):
         component_pool_status_sender: Sender[ComponentPoolStatus],
         results_sender: Sender[Result],
         api_power_request_timeout: timedelta,
+        fallback_power: Power,
     ) -> None:
         """Initialize this instance.
 
@@ -47,10 +48,13 @@ class PVManager(ComponentManager):
             results_sender: Channel for sending results of power distribution.
             api_power_request_timeout: Timeout to use when making power requests to
                 the microgrid API.
+            fallback_power: The power to assume for a PV inverter when it is not
+                reachable.
         """
         self._results_sender = results_sender
         self._api_power_request_timeout = api_power_request_timeout
         self._pv_inverter_ids = self._get_pv_inverter_ids()
+        self._fallback_power = fallback_power
 
         self._component_pool_status_tracker = (
             ComponentPoolStatusTracker(

--- a/tests/actor/power_distributing/test_power_distributing.py
+++ b/tests/actor/power_distributing/test_power_distributing.py
@@ -113,6 +113,7 @@ class TestPowerDistributingActor:
                 results_sender=results_channel.new_sender(),
                 component_pool_status_sender=battery_status_channel.new_sender(),
                 api_power_request_timeout=SAFETY_TIMEOUT,
+                fallback_power=Power.zero(),
             ) as distributor:
                 assert isinstance(distributor._component_manager, BatteryManager)
                 assert distributor._component_manager._bat_invs_map == {
@@ -145,6 +146,7 @@ class TestPowerDistributingActor:
                 results_sender=results_channel.new_sender(),
                 component_pool_status_sender=battery_status_channel.new_sender(),
                 api_power_request_timeout=SAFETY_TIMEOUT,
+                fallback_power=Power.zero(),
             ) as distributor:
                 assert isinstance(distributor._component_manager, BatteryManager)
                 assert distributor._component_manager._bat_invs_map == {
@@ -210,6 +212,7 @@ class TestPowerDistributingActor:
             results_sender=results_channel.new_sender(),
             component_pool_status_sender=battery_status_channel.new_sender(),
             api_power_request_timeout=SAFETY_TIMEOUT,
+            fallback_power=Power.zero(),
         ):
             await asyncio.sleep(0.1)  # wait for actor to collect data
 
@@ -273,6 +276,7 @@ class TestPowerDistributingActor:
                 results_sender=results_channel.new_sender(),
                 component_pool_status_sender=battery_status_channel.new_sender(),
                 api_power_request_timeout=SAFETY_TIMEOUT,
+                fallback_power=Power.zero(),
             ):
                 await asyncio.sleep(0.1)  # wait for actor to collect data
 
@@ -375,6 +379,7 @@ class TestPowerDistributingActor:
                 component_pool_status_sender=battery_status_channel.new_sender(),
                 results_sender=results_channel.new_sender(),
                 api_power_request_timeout=SAFETY_TIMEOUT,
+                fallback_power=Power.zero(),
             ):
                 await asyncio.sleep(0.1)  # wait for actor to collect data
 
@@ -456,6 +461,7 @@ class TestPowerDistributingActor:
                 component_pool_status_sender=battery_status_channel.new_sender(),
                 results_sender=results_channel.new_sender(),
                 api_power_request_timeout=SAFETY_TIMEOUT,
+                fallback_power=Power.zero(),
             ):
                 await requests_channel.new_sender().send(request)
                 result_rx = results_channel.new_receiver()
@@ -511,6 +517,7 @@ class TestPowerDistributingActor:
                 component_pool_status_sender=battery_status_channel.new_sender(),
                 results_sender=results_channel.new_sender(),
                 api_power_request_timeout=SAFETY_TIMEOUT,
+                fallback_power=Power.zero(),
             ):
                 await asyncio.sleep(0.1)  # wait for actor to collect data
 
@@ -564,6 +571,7 @@ class TestPowerDistributingActor:
                 component_pool_status_sender=battery_status_channel.new_sender(),
                 results_sender=results_channel.new_sender(),
                 api_power_request_timeout=SAFETY_TIMEOUT,
+                fallback_power=Power.zero(),
             ):
                 await asyncio.sleep(0.1)  # wait for actor to collect data
 
@@ -651,6 +659,7 @@ class TestPowerDistributingActor:
                 component_pool_status_sender=battery_status_channel.new_sender(),
                 results_sender=results_channel.new_sender(),
                 api_power_request_timeout=SAFETY_TIMEOUT,
+                fallback_power=Power.zero(),
             ):
                 await asyncio.sleep(0.1)  # wait for actor to collect data
 
@@ -739,6 +748,7 @@ class TestPowerDistributingActor:
                 component_pool_status_sender=battery_status_channel.new_sender(),
                 results_sender=results_channel.new_sender(),
                 api_power_request_timeout=SAFETY_TIMEOUT,
+                fallback_power=Power.zero(),
             ):
                 await asyncio.sleep(0.1)  # wait for actor to collect data
 
@@ -806,6 +816,7 @@ class TestPowerDistributingActor:
                 component_pool_status_sender=battery_status_channel.new_sender(),
                 results_sender=results_channel.new_sender(),
                 api_power_request_timeout=SAFETY_TIMEOUT,
+                fallback_power=Power.zero(),
             ):
                 await requests_channel.new_sender().send(request)
                 result_rx = results_channel.new_receiver()
@@ -863,6 +874,7 @@ class TestPowerDistributingActor:
                 results_sender=results_channel.new_sender(),
                 component_pool_status_sender=battery_status_channel.new_sender(),
                 api_power_request_timeout=SAFETY_TIMEOUT,
+                fallback_power=Power.zero(),
             ):
                 await asyncio.sleep(0.1)  # wait for actor to collect data
 
@@ -919,6 +931,7 @@ class TestPowerDistributingActor:
                 results_sender=results_channel.new_sender(),
                 component_pool_status_sender=battery_status_channel.new_sender(),
                 api_power_request_timeout=SAFETY_TIMEOUT,
+                fallback_power=Power.zero(),
             ):
                 await asyncio.sleep(0.1)  # wait for actor to collect data
 
@@ -994,6 +1007,7 @@ class TestPowerDistributingActor:
                 results_sender=results_channel.new_sender(),
                 component_pool_status_sender=battery_status_channel.new_sender(),
                 api_power_request_timeout=SAFETY_TIMEOUT,
+                fallback_power=Power.zero(),
             ):
                 await asyncio.sleep(0.1)  # wait for actor to collect data
 
@@ -1041,6 +1055,7 @@ class TestPowerDistributingActor:
                 results_sender=results_channel.new_sender(),
                 component_pool_status_sender=battery_status_channel.new_sender(),
                 api_power_request_timeout=SAFETY_TIMEOUT,
+                fallback_power=Power.zero(),
             ):
                 await requests_channel.new_sender().send(request)
                 result_rx = results_channel.new_receiver()
@@ -1085,6 +1100,7 @@ class TestPowerDistributingActor:
                 results_sender=results_channel.new_sender(),
                 component_pool_status_sender=battery_status_channel.new_sender(),
                 api_power_request_timeout=SAFETY_TIMEOUT,
+                fallback_power=Power.zero(),
             ):
                 await asyncio.sleep(0.1)  # wait for actor to collect data
 
@@ -1133,6 +1149,7 @@ class TestPowerDistributingActor:
                 results_sender=results_channel.new_sender(),
                 component_pool_status_sender=battery_status_channel.new_sender(),
                 api_power_request_timeout=SAFETY_TIMEOUT,
+                fallback_power=Power.zero(),
             ):
                 await asyncio.sleep(0.1)  # wait for actor to collect data
 
@@ -1181,6 +1198,7 @@ class TestPowerDistributingActor:
                 results_sender=results_channel.new_sender(),
                 component_pool_status_sender=battery_status_channel.new_sender(),
                 api_power_request_timeout=SAFETY_TIMEOUT,
+                fallback_power=Power.zero(),
             ):
                 await asyncio.sleep(0.1)  # wait for actor to collect data
 
@@ -1223,6 +1241,7 @@ class TestPowerDistributingActor:
                 results_sender=results_channel.new_sender(),
                 component_pool_status_sender=battery_status_channel.new_sender(),
                 api_power_request_timeout=SAFETY_TIMEOUT,
+                fallback_power=Power.zero(),
             ):
                 await asyncio.sleep(0.1)  # wait for actor to collect data
 
@@ -1278,6 +1297,7 @@ class TestPowerDistributingActor:
                 results_sender=results_channel.new_sender(),
                 component_pool_status_sender=battery_status_channel.new_sender(),
                 api_power_request_timeout=SAFETY_TIMEOUT,
+                fallback_power=Power.zero(),
             ):
                 await asyncio.sleep(0.1)  # wait for actor to collect data
 

--- a/tests/microgrid/test_datapipeline.py
+++ b/tests/microgrid/test_datapipeline.py
@@ -18,6 +18,7 @@ from frequenz.client.microgrid import (
 from pytest_mock import MockerFixture
 
 from frequenz.sdk.microgrid._data_pipeline import _DataPipeline
+from frequenz.sdk.timeseries._quantities import Power
 from frequenz.sdk.timeseries._resampling import ResamplerConfig
 
 from ..utils.mock_microgrid_client import MockMicrogridClient
@@ -35,7 +36,8 @@ async def test_actors_started(
 ) -> None:
     """Test that the datasourcing, resampling and power distributing actors are started."""
     datapipeline = _DataPipeline(
-        resampler_config=ResamplerConfig(resampling_period=timedelta(seconds=1))
+        resampler_config=ResamplerConfig(resampling_period=timedelta(seconds=1)),
+        pv_fallback_power=Power.zero(),
     )
     await asyncio.sleep(1)
 

--- a/tests/timeseries/_pv_pool/test_pv_pool_control_methods.py
+++ b/tests/timeseries/_pv_pool/test_pv_pool_control_methods.py
@@ -10,6 +10,7 @@ from unittest.mock import AsyncMock
 
 import async_solipsism
 import pytest
+import time_machine
 from frequenz.channels import Receiver
 from frequenz.client.microgrid import (
     ComponentCategory,
@@ -27,7 +28,7 @@ from frequenz.sdk.timeseries.pv_pool import PVPoolReport
 
 from ...microgrid.fixtures import _Mocks
 from ...utils.component_data_streamer import MockComponentDataStreamer
-from ...utils.component_data_wrapper import InverterDataWrapper
+from ...utils.component_data_wrapper import InverterDataWrapper, MeterDataWrapper
 from ...utils.graph_generator import GraphGenerator
 from ..mock_microgrid import MockMicrogrid
 
@@ -80,8 +81,12 @@ class TestPVPoolControl:
     """Test control methods for the PVPool."""
 
     async def _init_pv_inverters(self, mocks: _Mocks) -> None:
+        await self._start_pv_inverters(mocks.microgrid.pv_inverter_ids, mocks)
+        await self._start_meters(mocks.microgrid.meter_ids, mocks)
+
+    async def _start_pv_inverters(self, inv_ids: list[int], mocks: _Mocks) -> None:
         now = datetime.now(tz=timezone.utc)
-        for idx, comp_id in enumerate(mocks.microgrid.pv_inverter_ids):
+        for idx, comp_id in enumerate(inv_ids):
             mocks.streamer.start_streaming(
                 InverterDataWrapper(
                     comp_id,
@@ -94,7 +99,24 @@ class TestPVPoolControl:
                 0.05,
             )
 
-    async def _fail_pv_inverters(self, fail_ids: list[int], mocks: _Mocks) -> None:
+    async def _start_meters(
+        self,
+        meter_ids: list[int],
+        mocks: _Mocks,
+        power: float = 0.0,
+    ) -> None:
+        now = datetime.now(tz=timezone.utc)
+        for idx, comp_id in enumerate(meter_ids):
+            mocks.streamer.start_streaming(
+                MeterDataWrapper(
+                    comp_id,
+                    now,
+                    active_power=power,
+                ),
+                0.05,
+            )
+
+    async def _fail_pv_inverters(self, inv_ids: list[int], mocks: _Mocks) -> None:
         now = datetime.now(tz=timezone.utc)
         for idx, comp_id in enumerate(mocks.microgrid.pv_inverter_ids):
             mocks.streamer.update_stream(
@@ -103,7 +125,7 @@ class TestPVPoolControl:
                     now,
                     component_state=(
                         InverterComponentState.ERROR
-                        if comp_id in fail_ids
+                        if comp_id in inv_ids
                         else InverterComponentState.IDLE
                     ),
                     active_power=0.0,
@@ -111,6 +133,10 @@ class TestPVPoolControl:
                     active_power_inclusion_upper_bound=0.0,
                 ),
             )
+
+    async def _stop_components(self, inv_ids: list[int], mocks: _Mocks) -> None:
+        for comp_id in inv_ids:
+            await mocks.streamer.stop_streaming(comp_id)
 
     def _assert_report(  # pylint: disable=too-many-arguments
         self,
@@ -138,9 +164,9 @@ class TestPVPoolControl:
         self,
         bounds_rx: Receiver[PVPoolReport],
         check: typing.Callable[[PVPoolReport], bool],
+        max_reports: int = 100,
     ) -> None:
         """Receive reports until the given condition is met."""
-        max_reports = 10
         ctr = 0
         while ctr < max_reports:
             ctr += 1
@@ -296,4 +322,164 @@ class TestPVPoolControl:
             mocker.call(inv_ids[1], 0.0),
             mocker.call(inv_ids[2], 0.0),
             mocker.call(inv_ids[3], 0.0),
+        ]
+
+    async def test_fallback_power(  # pylint: disable=too-many-statements
+        self,
+        mocks: _Mocks,
+        mocker: MockerFixture,
+    ) -> None:
+        """Test fallback power."""
+        set_power = typing.cast(
+            AsyncMock, microgrid.connection_manager.get().api_client.set_power
+        )
+
+        traveller = time_machine.travel(datetime(2012, 12, 12))
+        mock_time = traveller.start()
+
+        mocker.patch(
+            "frequenz.sdk.microgrid._data_pipeline._DATA_PIPELINE"
+            "._pv_power_wrapper._fallback_power",
+            Power.from_watts(-10000.0),
+        )
+        await self._init_pv_inverters(mocks)
+        pv_pool = microgrid.new_pv_pool(priority=5)
+        bounds_rx = pv_pool.power_status.new_receiver()
+        await self._recv_reports_until(
+            bounds_rx,
+            lambda x: x.bounds is not None and x.bounds.lower.as_watts() == -100000.0,
+        )
+        self._assert_report(
+            await bounds_rx.receive(), power=None, lower=-100000.0, upper=0.0
+        )
+        await pv_pool.propose_power(Power.from_watts(-80000.0))
+        await self._recv_reports_until(
+            bounds_rx,
+            lambda x: x.target_power is not None
+            and x.target_power.as_watts() == -80000.0,
+        )
+        self._assert_report(
+            await bounds_rx.receive(), power=-80000.0, lower=-100000.0, upper=0.0
+        )
+        await asyncio.sleep(0.0)
+
+        # Components are set initial power
+        assert set_power.call_count == 4
+        inv_ids = mocks.microgrid.pv_inverter_ids
+        assert sorted(set_power.call_args_list, key=lambda x: x.args[0]) == [
+            mocker.call(inv_ids[0], -10000.0),
+            mocker.call(inv_ids[1], -20000.0),
+            mocker.call(inv_ids[2], -25000.0),
+            mocker.call(inv_ids[3], -25000.0),
+        ]
+        set_power.reset_mock()
+
+        # Stop inverter 0, which has a sister inverter, so it should use fallback power
+        # even if the meter is still working.
+        await self._stop_components([mocks.microgrid.pv_inverter_ids[0]], mocks)
+        await asyncio.sleep(11.0)
+        await pv_pool.propose_power(Power.from_watts(-40000.0))
+        await self._recv_reports_until(
+            bounds_rx,
+            lambda x: x.target_power is not None
+            and x.target_power.as_watts() == -40000.0,
+        )
+        self._assert_report(
+            await bounds_rx.receive(), power=-40000.0, lower=-90000.0, upper=0.0
+        )
+        await asyncio.sleep(0.0)
+
+        assert sorted(set_power.call_args_list, key=lambda x: x.args[0]) == [
+            mocker.call(inv_ids[1], -10000.0),
+            mocker.call(inv_ids[2], -10000.0),
+            mocker.call(inv_ids[3], -10000.0),
+        ]
+        set_power.reset_mock()
+        await self._start_pv_inverters([mocks.microgrid.pv_inverter_ids[0]], mocks)
+
+        # Stop inverter 2, which has no sister inverter, so it should not use fallback
+        # power when its meter is still streaming.
+        await self._stop_components([mocks.microgrid.pv_inverter_ids[2]], mocks)
+        await asyncio.sleep(11.0)
+        mock_time.shift(timedelta(seconds=11.0))
+        await pv_pool.propose_power(Power.from_watts(-50000.0))
+        await self._recv_reports_until(
+            bounds_rx,
+            lambda x: x.target_power is not None
+            and x.target_power.as_watts() == -50000.0,
+        )
+        self._assert_report(
+            await bounds_rx.receive(), power=-50000.0, lower=-70000.0, upper=0.0
+        )
+        await asyncio.sleep(0.0)
+
+        assert sorted(set_power.call_args_list, key=lambda x: x.args[0]) == [
+            mocker.call(inv_ids[0], -10000.0),
+            mocker.call(inv_ids[1], -20000.0),
+            mocker.call(inv_ids[3], -20000.0),
+        ]
+        set_power.reset_mock()
+
+        # Stop meter 2, which has no sister inverter, so it should not use fallback
+        # power when its meter is still streaming.
+        await self._stop_components([mocks.microgrid.meter_ids[1]], mocks)
+        await asyncio.sleep(11.0)
+        mock_time.shift(timedelta(seconds=11.0))
+        await pv_pool.propose_power(Power.from_watts(-42000.0))
+        await self._recv_reports_until(
+            bounds_rx,
+            lambda x: x.target_power is not None
+            and x.target_power.as_watts() == -42000.0,
+        )
+        self._assert_report(
+            await bounds_rx.receive(), power=-42000.0, lower=-70000.0, upper=0.0
+        )
+        await asyncio.sleep(0.0)
+
+        assert sorted(set_power.call_args_list, key=lambda x: x.args[0]) == [
+            mocker.call(inv_ids[0], -10000.0),
+            mocker.call(inv_ids[1], -11000.0),
+            mocker.call(inv_ids[3], -11000.0),
+        ]
+        set_power.reset_mock()
+
+        # Start meter 2 measuring -5000W.  Now inv 2's fallback power should be -5000W.
+        await self._start_meters([mocks.microgrid.meter_ids[1]], mocks, power=-5000.0)
+        await pv_pool.propose_power(Power.from_watts(-50000.0))
+        await self._recv_reports_until(
+            bounds_rx,
+            lambda x: x.target_power is not None
+            and x.target_power.as_watts() == -50000.0,
+        )
+        self._assert_report(
+            await bounds_rx.receive(), power=-50000.0, lower=-70000.0, upper=0.0
+        )
+        await asyncio.sleep(0.0)
+
+        assert sorted(set_power.call_args_list, key=lambda x: x.args[0]) == [
+            mocker.call(inv_ids[0], -10000.0),
+            mocker.call(inv_ids[1], -17500.0),
+            mocker.call(inv_ids[3], -17500.0),
+        ]
+        set_power.reset_mock()
+
+        # Start inv 2. There should be no fallback power now.
+        await self._start_pv_inverters([mocks.microgrid.pv_inverter_ids[2]], mocks)
+        await asyncio.sleep(1.0)
+        await pv_pool.propose_power(Power.from_watts(-60000.0))
+        await self._recv_reports_until(
+            bounds_rx,
+            lambda x: x.target_power is not None
+            and x.target_power.as_watts() == -60000.0,
+        )
+        self._assert_report(
+            await bounds_rx.receive(), power=-60000.0, lower=-80000.0, upper=0.0
+        )
+        await asyncio.sleep(0.0)
+
+        assert sorted(set_power.call_args_list, key=lambda x: x.args[0]) == [
+            mocker.call(inv_ids[0], -10000.0),
+            mocker.call(inv_ids[1], -20000.0),
+            mocker.call(inv_ids[2], -10000.0),
+            mocker.call(inv_ids[3], -20000.0),
         ]

--- a/tests/timeseries/mock_resampler.py
+++ b/tests/timeseries/mock_resampler.py
@@ -16,7 +16,7 @@ from frequenz.sdk._internal._asyncio import cancel_and_await
 from frequenz.sdk.microgrid._data_pipeline import _DataPipeline
 from frequenz.sdk.microgrid._data_sourcing import ComponentMetricRequest
 from frequenz.sdk.timeseries import ResamplerConfig, Sample
-from frequenz.sdk.timeseries._quantities import Quantity
+from frequenz.sdk.timeseries._quantities import Power, Quantity
 from frequenz.sdk.timeseries.formula_engine._formula_generators._formula_generator import (
     NON_EXISTING_COMPONENT_ID,
 )
@@ -39,7 +39,9 @@ class MockResampler:
         namespaces: int,
     ) -> None:
         """Create a `MockDataPipeline` instance."""
-        self._data_pipeline = _DataPipeline(resampler_config)
+        self._data_pipeline = _DataPipeline(
+            resampler_config, pv_fallback_power=Power.zero()
+        )
 
         self._channel_registry = self._data_pipeline._channel_registry
         self._resampler_request_channel = Broadcast[ComponentMetricRequest](


### PR DESCRIPTION
When an PV inverter is not available, its power is assumed to be the given fallback value, and this fallback power is excluded from the requested power that's set to the rest of the PV inverters.