### PR TITLE
Merge v1.0.0-rc7xx into v1.x.x

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,17 +1,5 @@
 # Frequenz Python SDK Release Notes
 
-## Summary
-
-<!-- Here goes a general summary of what this release is about -->
-
-## Upgrading
-
-<!-- Here goes notes on how to upgrade from previous versions, including deprecations and what they should be replaced with -->
-
-## New Features
-
-<!-- Here goes the main new features and examples or instructions on how to use them -->
-
 ## Bug Fixes
 
-<!-- Here goes notable bug fixes that are worth a special mention or explanation -->
+- Bump the `grpclib` dependency to pull a fix for using IPv6 addresses.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
   "networkx >= 2.8, < 4",
   "numpy >= 1.26.4, < 2",
   "typing_extensions >= 4.6.1, < 5",
+  "grpclib >= 0.4.8rc2",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
`v1.0.0-rc701` updated the grpclib version to `0.4.8rc2`.  This is getting
merged into `v1.x.x`.