### PR TITLE
Distinguish between grid meters and other meters

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -17,3 +17,5 @@
 - Bump the `grpclib` dependency to pull a fix for using IPv6 addresses.
 
 - Allow setting `api_power_request_timeout` in `microgrid.initialize()`.
+
+- Fix an issue where in grid meters could be identified as {pv/ev/battery/chp} meters in some component graph configurations.


### PR DESCRIPTION
The component graph methods for identifying meters as {pv/ev/battery/chp} meters were sometimes incorrectly identifying grid meters as one of {pv/ev/battery/chp} meters.

This PR fixes that issue.