### PR TITLE
Make dependabot do minor updates for the microgrid client separately

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,10 +25,18 @@ updates:
         update-types:
           - "minor"
           - "patch"
+        exclude-patterns:
+          - "frequenz-client-microgrid*"
       optional:
         dependency-type: "development"
         update-types:
           - "minor"
+          - "patch"
+      in-devel-patch:
+        patterns:
+          - "frequenz-client-microgrid*"
+        dependency-type: "production"
+        update-types:
           - "patch"
     ignore:
       # Upgrade to time-machine 2.13.0+ breaks our tests. See:


### PR DESCRIPTION
This library is still under development at the v0 branch, so every minor release is a breaking release.
