### PR TITLE
Revert "Change receiver limit in mock_resampler"

### DIFF
--- a/tests/timeseries/mock_resampler.py
+++ b/tests/timeseries/mock_resampler.py
@@ -61,7 +61,7 @@ class MockResampler:
                 self._input_channels_receivers[name] = [
                     self._channel_registry.get_or_create(
                         Sample[Quantity], name
-                    ).new_receiver(limit=1)
+                    ).new_receiver()
                     for _ in range(namespaces)
                 ]
             return senders


### PR DESCRIPTION
This reverts commit 2a515d1adaae1ce094fa4660f51e989d5e89114b. This was commited by mistake.