### PR TITLE
Remove the redundant `--platform=${TARGETPLATFORM}` in `Dockerfile`

### DIFF
--- a/.github/containers/test-installation/Dockerfile
+++ b/.github/containers/test-installation/Dockerfile
@@ -5,7 +5,7 @@
 
 ARG PYTHON_VERSION="3.11"
 
-FROM --platform=${TARGETPLATFORM} python:${PYTHON_VERSION}-slim
+FROM python:${PYTHON_VERSION}-slim
 
 RUN apt-get update -y && \
     apt-get install --no-install-recommends -y \


### PR DESCRIPTION
We are getting a warning in the CI saying this is the default, so we better remove it.
