### PR TITLE
Bump `frequenz-client-microgrid` to 0.5.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
   # Make sure to update the mkdocs.yml file when
   # changing the version
   # (plugins.mkdocstrings.handlers.python.import)
-  "frequenz-client-microgrid >= 0.5.0, < 0.6.0",
+  "frequenz-client-microgrid >= 0.5.1, < 0.6.0",
   "frequenz-channels >= 1.1.0, < 2.0.0",
   "networkx >= 2.8, < 4",
   "numpy >= 1.26.4, < 2",


### PR DESCRIPTION
This is to keep the default SSL option to false.
