### PR TITLE
Create FileWatcher when ConfigManagingActor runs

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -14,4 +14,4 @@
 
 ## Bug Fixes
 
-<!-- Here goes notable bug fixes that are worth a special mention or explanation -->
+- `ConfigManagingActor`: Fixed an issue where the actor was unable to process events after being restarted.


### PR DESCRIPTION
The ConfigManagingActor was unable to process events after being restarted because the FileWatcher cannot be reused when the ConfigManagingActor is restarted, so we need to create a new instance every time the actor starts running.