### PR TITLE
Add polling parameters to ConfigManagingActor

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,7 +10,9 @@
 
 ## New Features
 
-<!-- Here goes the main new features and examples or instructions on how to use them -->
+- `ConfigManagingActor`: The file polling mechanism is now forced by default. Two new parameters have been added:
+  - `force_polling`: Whether to force file polling to check for changes. Default is `True`.
+  - `polling_interval`: The interval to check for changes. Only relevant if polling is enabled. Default is 1 second.
 
 ## Bug Fixes
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
   # changing the version
   # (plugins.mkdocstrings.handlers.python.import)
   "frequenz-client-microgrid >= 0.5.1, < 0.6.0",
-  "frequenz-channels >= 1.1.0, < 2.0.0",
+  "frequenz-channels >= 1.2.0, < 2.0.0",
   "networkx >= 2.8, < 4",
   "numpy >= 1.26.4, < 2",
   "typing_extensions >= 4.6.1, < 5",

--- a/tests/actor/test_config_manager.py
+++ b/tests/actor/test_config_manager.py
@@ -71,7 +71,9 @@ class TestActorConfigManager:
         )
         config_receiver = config_channel.new_receiver()
 
-        async with ConfigManagingActor(config_file, config_channel.new_sender()):
+        async with ConfigManagingActor(
+            config_file, config_channel.new_sender(), force_polling=False
+        ):
             config = await config_receiver.receive()
             assert config is not None
             assert config.get("logging_lvl") == "DEBUG"
@@ -100,7 +102,9 @@ class TestActorConfigManager:
         current_dir = pathlib.Path.cwd()
         relative_path = os.path.relpath(config_file, current_dir)
 
-        async with ConfigManagingActor(relative_path, config_channel.new_sender()):
+        async with ConfigManagingActor(
+            relative_path, config_channel.new_sender(), force_polling=False
+        ):
             config = await config_receiver.receive()
             assert config is not None
             assert config.get("var2") is None

--- a/tests/timeseries/_battery_pool/test_battery_pool.py
+++ b/tests/timeseries/_battery_pool/test_battery_pool.py
@@ -1306,7 +1306,7 @@ async def run_power_bounds_test(  # pylint: disable=too-many-locals
 
     # One inverter stopped sending data, use one remaining inverter
     await streamer.stop_streaming(next(iter(bat_invs_map[batteries_in_pool[0]])))
-    await asyncio.sleep(MAX_BATTERY_DATA_AGE_SEC + 0.2)
+    await asyncio.sleep(MAX_BATTERY_DATA_AGE_SEC + 0.1)
     msg = await asyncio.wait_for(receiver.receive(), timeout=waiting_time_sec)
     compare_messages(
         msg,


### PR DESCRIPTION
The ConfigManagingActor now allows to force file polling and set the polling interval.