### PR TITLE
Store the original `Component` and `Connection` in the component graph

### DIFF
--- a/src/frequenz/sdk/timeseries/grid.py
+++ b/src/frequenz/sdk/timeseries/grid.py
@@ -203,16 +203,15 @@ def initialize(
             )
         case 1:
             metadata = grid_connections[0].metadata
-            if metadata is not None and metadata.fuse is not None:
-                fuse = Fuse(max_current=Current.from_amperes(metadata.fuse.max_current))
-
             if metadata is None:
                 _logger.warning(
                     "Unable to get grid metadata, the grid connection point is "
                     "considered to have no fuse"
                 )
-            elif fuse is None:
+            elif metadata.fuse is None:
                 _logger.warning("The grid connection point does not have a fuse")
+            else:
+                fuse = Fuse(max_current=Current.from_amperes(metadata.fuse.max_current))
         case _:
             raise RuntimeError(
                 f"Expected at most one grid connection, got {grid_connections_count}"

--- a/src/frequenz/sdk/timeseries/grid.py
+++ b/src/frequenz/sdk/timeseries/grid.py
@@ -207,17 +207,12 @@ def initialize(
         if grid_connections[0].metadata is None:
             raise RuntimeError("Grid metadata is None")
 
-        # The current implementation of the Component Graph fails to
-        # effectively convert components from a dictionary representation to
-        # the expected Component object.
-        # Specifically for the component metadata, it hands back a dictionary
-        # instead of the expected ComponentMetadata type.
-        metadata = grid_connections[0].metadata
-        if isinstance(metadata, dict):
-            if fuse_dict := metadata.get("fuse", None):
-                fuse = Fuse(
-                    max_current=Current.from_amperes(fuse_dict.get("max_current", 0.0))
+        if grid_connections[0].metadata.fuse is not None:
+            fuse = Fuse(
+                max_current=Current.from_amperes(
+                    grid_connections[0].metadata.fuse.max_current
                 )
+            )
 
         if fuse is None:
             _logger.warning("The grid connection point does not have a fuse")

--- a/src/frequenz/sdk/timeseries/grid.py
+++ b/src/frequenz/sdk/timeseries/grid.py
@@ -198,7 +198,8 @@ def initialize(
         case 0:
             fuse = Fuse(max_current=Current.zero())
             _logger.info(
-                "No grid connection found for this microgrid. This is normal for an islanded microgrid."
+                "No grid connection found for this microgrid. "
+                "This is normal for an islanded microgrid."
             )
         case 1:
             metadata = grid_connections[0].metadata

--- a/src/frequenz/sdk/timeseries/grid.py
+++ b/src/frequenz/sdk/timeseries/grid.py
@@ -201,17 +201,16 @@ def initialize(
                 "No grid connection found for this microgrid. This is normal for an islanded microgrid."
             )
         case 1:
-            if grid_connections[0].metadata is None:
-                raise RuntimeError("Grid metadata is None")
+            metadata = grid_connections[0].metadata
+            if metadata is not None and metadata.fuse is not None:
+                fuse = Fuse(max_current=Current.from_amperes(metadata.fuse.max_current))
 
-            if grid_connections[0].metadata.fuse is not None:
-                fuse = Fuse(
-                    max_current=Current.from_amperes(
-                        grid_connections[0].metadata.fuse.max_current
-                    )
+            if metadata is None:
+                _logger.warning(
+                    "Unable to get grid metadata, the grid connection point is "
+                    "considered to have no fuse"
                 )
-
-            if fuse is None:
+            elif fuse is None:
                 _logger.warning("The grid connection point does not have a fuse")
         case _:
             raise RuntimeError(

--- a/tests/microgrid/test_grid.py
+++ b/tests/microgrid/test_grid.py
@@ -55,7 +55,7 @@ async def test_grid_2(mocker: MockerFixture) -> None:
             1,
             client.ComponentCategory.GRID,
             None,
-            client.GridMetadata(client.Fuse(123.0)),
+            client.ComponentMetadata(fuse=client.Fuse(max_current=123.0)),
         ),
         client.Component(2, client.ComponentCategory.METER),
     }


### PR DESCRIPTION
For some reason the Component and Connection objects were converted to `dict` to store them in the component graph. This requires re-building the objects when they need to be extracted, which is wasteful.

It also means that type information is lost, and in the future, when adopting the microgrid API client using v0.17, we have a class hierarchy for components instead of relaying in the category and type, so we would even need to store the type if we wanted to rebuild the objects.

Having nested objects is also an issue, as then the nested properties were kept as `dict`, adding an inconsistency and making it type-unsafe.

With this change we are able to get rid of a hack to retrieve the grid metadata.

Fixes #789.