### PR TITLE
Update bound-streaming channels to resend latest to new receivers

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -30,4 +30,4 @@
 
 ## Bug Fixes
 
-<!-- Here goes notable bug fixes that are worth a special mention or explanation -->
+- Fixes an issue where PV and EV system bounds were not available to the Power Manager sometimes when requested after startup.

--- a/src/frequenz/sdk/timeseries/ev_charger_pool/_ev_charger_pool_reference_store.py
+++ b/src/frequenz/sdk/timeseries/ev_charger_pool/_ev_charger_pool_reference_store.py
@@ -93,7 +93,8 @@ class EVChargerPoolReferenceStore:
         )
 
         self.bounds_channel: Broadcast[SystemBounds] = Broadcast(
-            name=f"System Bounds for EV Chargers: {component_ids}"
+            name=f"System Bounds for EV Chargers: {component_ids}",
+            resend_latest=True,
         )
         self.bounds_tracker: EVCSystemBoundsTracker = EVCSystemBoundsTracker(
             self.component_ids,

--- a/src/frequenz/sdk/timeseries/pv_pool/_pv_pool_reference_store.py
+++ b/src/frequenz/sdk/timeseries/pv_pool/_pv_pool_reference_store.py
@@ -94,7 +94,8 @@ class PVPoolReferenceStore:
             self.resampler_subscription_sender,
         )
         self.bounds_channel: Broadcast[SystemBounds] = Broadcast(
-            name=f"System Bounds for PV inverters: {component_ids}"
+            name=f"System Bounds for PV inverters: {component_ids}",
+            resend_latest=True,
         )
         self.bounds_tracker: PVSystemBoundsTracker = PVSystemBoundsTracker(
             self.component_ids,


### PR DESCRIPTION
The `SystemBoundsTracker`s send out a new value only when there's a
change in the system bounds.  This means when a new receiver is
created, it could wait for a long time before receiving the bounds.

This change allows new receivers to get the latest state when
requested.

This is already the case for battery bounds, and needed only for PV
and EV charger bounds.