### PR TITLE
Allow passing a `base_schema` to `load_config()`

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,7 +6,7 @@
 
 ## Upgrading
 
-<!-- Here goes notes on how to upgrade from previous versions, including deprecations and what they should be replaced with -->
+- `frequenz.sdk.config.load_config()` doesn't accept classes decorated with `marshmallow_dataclass.dataclass` anymore. You should use the built-in `dataclasses.dataclass` directly instead, no other changes should be needed, the metadata in the `dataclass` fields will still be used.
 
 ## New Features
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,7 +10,8 @@
 
 ## New Features
 
-<!-- Here goes the main new features and examples or instructions on how to use them -->
+
+- `frequenz.sdk.config.load_config()` can now use a base schema to customize even further how data is loaded.
 
 ## Bug Fixes
 

--- a/src/frequenz/sdk/config/_util.py
+++ b/src/frequenz/sdk/config/_util.py
@@ -6,6 +6,7 @@
 from collections.abc import Mapping
 from typing import Any, TypeVar, cast
 
+from marshmallow import Schema
 from marshmallow_dataclass import class_schema
 
 T = TypeVar("T")
@@ -16,6 +17,7 @@ def load_config(
     cls: type[T],
     config: Mapping[str, Any],
     /,
+    base_schema: type[Schema] | None = None,
     **marshmallow_load_kwargs: Any,
 ) -> T:
     """Load a configuration from a dictionary into an instance of a configuration class.
@@ -42,13 +44,16 @@ def load_config(
     Args:
         cls: The configuration class.
         config: The configuration dictionary.
+        base_schema: An optional class to be used as a base schema for the configuration
+            class. This allow using custom fields for example. Will be passed to
+            [`marshmallow_dataclass.class_schema`][].
         **marshmallow_load_kwargs: Additional arguments to be passed to
             [`marshmallow.Schema.load`][].
 
     Returns:
         The loaded configuration as an instance of the configuration class.
     """
-    instance = class_schema(cls)().load(config, **marshmallow_load_kwargs)
+    instance = class_schema(cls, base_schema)().load(config, **marshmallow_load_kwargs)
     # We need to cast because `.load()` comes from marshmallow and doesn't know which
     # type is returned.
     return cast(T, instance)

--- a/src/frequenz/sdk/config/_util.py
+++ b/src/frequenz/sdk/config/_util.py
@@ -22,13 +22,22 @@ def load_config(
 
     The configuration class is expected to be a [`dataclasses.dataclass`][], which is
     used to create a [`marshmallow.Schema`][] schema to validate the configuration
-    dictionary.
+    dictionary using [`marshmallow_dataclass.class_schema`][] (which in turn uses the
+    [`marshmallow.Schema.load`][] method to do the validation and deserialization).
 
-    To customize the schema derived from the configuration dataclass, you can use
-    [`marshmallow_dataclass.dataclass`][] to specify extra metadata.
+    To customize the schema derived from the configuration dataclass, you can use the
+    `metadata` key in [`dataclasses.field`][] to pass extra options to
+    [`marshmallow_dataclass`][] to be used during validation and deserialization.
 
     Additional arguments can be passed to [`marshmallow.Schema.load`][] using keyword
-    arguments.
+    arguments `marshmallow_load_kwargs`.
+
+    Note:
+        This method will raise [`marshmallow.ValidationError`][] if the configuration
+        dictionary is invalid and you have to have in mind all of the gotchas of
+        [`marshmallow`][] and [`marshmallow_dataclass`][] applies when using this
+        function.  It is recommended to carefully read the documentation of these
+        libraries.
 
     Args:
         cls: The configuration class.

--- a/tests/config/test_util.py
+++ b/tests/config/test_util.py
@@ -7,7 +7,6 @@ import dataclasses
 from typing import Any
 
 import marshmallow
-import marshmallow_dataclass
 import pytest
 from pytest_mock import MockerFixture
 
@@ -16,14 +15,6 @@ from frequenz.sdk.config._util import load_config
 
 @dataclasses.dataclass
 class SimpleConfig:
-    """A simple configuration class for testing."""
-
-    name: str
-    value: int
-
-
-@marshmallow_dataclass.dataclass
-class MmSimpleConfig:
     """A simple configuration class for testing."""
 
     name: str = dataclasses.field(metadata={"validate": lambda s: s.startswith("test")})
@@ -38,19 +29,8 @@ def test_load_config_dataclass() -> None:
     assert loaded_config == SimpleConfig(name="test", value=42)
 
     config["name"] = "not test"
-    loaded_config = load_config(SimpleConfig, config)
-    assert loaded_config == SimpleConfig(name="not test", value=42)
-
-
-def test_load_config_marshmallow_dataclass() -> None:
-    """Test that load_config loads a configuration into a configuration class."""
-    config: dict[str, Any] = {"name": "test", "value": 42}
-    loaded_config = load_config(MmSimpleConfig, config)
-    assert loaded_config == MmSimpleConfig(name="test", value=42)
-
-    config["name"] = "not test"
     with pytest.raises(marshmallow.ValidationError):
-        _ = load_config(MmSimpleConfig, config)
+        _ = load_config(SimpleConfig, config)
 
 
 def test_load_config_load_None() -> None:
@@ -70,7 +50,7 @@ def test_load_config_type_hints(mocker: MockerFixture) -> None:
     config: dict[str, Any] = {}
 
     # We add the type hint to test that the return type (hint) is correct
-    _: MmSimpleConfig = load_config(MmSimpleConfig, config, marshmallow_arg=1)
+    _: SimpleConfig = load_config(SimpleConfig, config, marshmallow_arg=1)
     mock_class_schema.return_value.load.assert_called_once_with(
         config, marshmallow_arg=1
     )

--- a/tests/config/test_util.py
+++ b/tests/config/test_util.py
@@ -37,7 +37,27 @@ def test_load_config_load_None() -> None:
     """Test that load_config raises ValidationError if the configuration is None."""
     config: dict[str, Any] = {}
     with pytest.raises(marshmallow.ValidationError):
-        _ = load_config(MmSimpleConfig, config.get("loggers", None))
+        _ = load_config(SimpleConfig, config.get("loggers", None))
+
+
+def test_load_config_with_base_schema() -> None:
+    """Test that load_config loads a configuration using a base schema."""
+
+    class _MyBaseSchema(marshmallow.Schema):
+        """A base schema for testing."""
+
+        class Meta:
+            """Meta options for the schema."""
+
+            unknown = marshmallow.EXCLUDE
+
+    config: dict[str, Any] = {"name": "test", "value": 42, "extra": "extra"}
+
+    loaded_config = load_config(SimpleConfig, config, base_schema=_MyBaseSchema)
+    assert loaded_config == SimpleConfig(name="test", value=42)
+
+    with pytest.raises(marshmallow.ValidationError):
+        _ = load_config(SimpleConfig, config)
 
 
 def test_load_config_type_hints(mocker: MockerFixture) -> None:


### PR DESCRIPTION
This PR adds a new argument to `load_config()` to allow passing a `base_schema` to be used when loading the configuration. This is necessary to be able to use custom fields in the schema, like the ones provided by `frequenz.quantities`.

It also drops support for using `marshmallow_dataclas.dataclass` directly. `marshmallow_dataclass.dataclass` is intended to be used only when using `my_dataclass.Schema` to get the schema. But using this is not very convenient when using type hints as they are not well-supported by `marshmallow`, as the `load()` function can't have hints.
    
This is actually why `load_config()` exists in the first place, so we are using `class_schema()` instead, so we don't really need that our types are decorated with `marshmallow_dataclass`, we can use the built-in `dataclass` instead, we just need to add the appropriate metadata if we want more complex validation.

Using `class_shema()` is also necessary to be able to pass a `base_schema`, which we'll need when we want to use schemas with custom fields, like the ones provided by `frequenz.quantities`. 

Finally, it improves `load_config` documentation to make it more explicit that this is just a wrapper to external libraries, so users should read their documentation in full and which functions are used exactly.
