### PR TITLE
Restore support for marshmallow_dataclass

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,8 +6,6 @@
 
 ## Upgrading
 
-- `frequenz.sdk.config.load_config()` doesn't accept classes decorated with `marshmallow_dataclass.dataclass` anymore. You should use the built-in `dataclasses.dataclass` directly instead, no other changes should be needed, the metadata in the `dataclass` fields will still be used.
-
 ## New Features
 
 


### PR DESCRIPTION
It seems to work with `class_shema()` and new Dataclass protocol recognize it as dataclass.