### PR TITLE
Widen the quantities version requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
   # (plugins.mkdocstrings.handlers.python.import)
   "frequenz-client-microgrid >= 0.6.0, < 0.7.0",
   "frequenz-channels >= 1.2.0, < 2.0.0",
-  "frequenz-quantities == 1.0.0rc3",
+  "frequenz-quantities >= 1.0.0rc3, < 2.0.0",
   "networkx >= 2.8, < 4",
   "numpy >= 1.26.4, < 2",
   "typing_extensions >= 4.6.1, < 5",


### PR DESCRIPTION
We should be as permissive as possible with the version requirements in libraries, so we use a range instead of an exact version.
