### PR TITLE
Update to repo-config v0.11.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -57,3 +57,11 @@ updates:
     labels:
       - "part:tooling"
       - "type:tech-debt"
+    groups:
+      compatible:
+        update-types:
+          - "minor"
+          - "patch"
+      artifacts:
+        patterns:
+          - "actions/*-artifact"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,9 +3,9 @@
 
 [build-system]
 requires = [
-  "setuptools == 69.0.3",
-  "setuptools_scm[toml] == 8.0.4",
-  "frequenz-repo-config[lib] == 0.10.0",
+  "setuptools == 75.6.0",
+  "setuptools_scm[toml] == 8.1.0",
+  "frequenz-repo-config[lib] == 0.11.0",
 ]
 build-backend = "setuptools.build_meta"
 
@@ -63,7 +63,7 @@ dev-mkdocs = [
   "mkdocs-material == 9.5.43",
   "mkdocstrings[python] == 0.26.2",
   "mkdocstrings-python == 1.12.2",
-  "frequenz-repo-config[lib] == 0.10.0",
+  "frequenz-repo-config[lib] == 0.11.0",
 ]
 dev-mypy = [
   "mypy == 1.13.0",
@@ -73,7 +73,7 @@ dev-mypy = [
   # For checking the noxfile, docs/ script, and tests
   "frequenz-sdk[dev-mkdocs,dev-noxfile,dev-pytest]",
 ]
-dev-noxfile = ["nox == 2024.10.9", "frequenz-repo-config[lib] == 0.10.0"]
+dev-noxfile = ["nox == 2024.10.9", "frequenz-repo-config[lib] == 0.11.0"]
 dev-pylint = [
   "pylint == 3.3.1",
   # For checking the noxfile, docs/ script, and tests
@@ -81,7 +81,7 @@ dev-pylint = [
 ]
 dev-pytest = [
   "pytest == 8.3.3",
-  "frequenz-repo-config[extra-lint-examples] == 0.10.0",
+  "frequenz-repo-config[extra-lint-examples] == 0.11.0",
   "pytest-mock == 3.14.0",
   "pytest-asyncio == 0.24.0",
   "time-machine == 2.12.0",
@@ -145,6 +145,8 @@ disable = [
   "unsubscriptable-object",
   # Checked by mypy
   "no-member",
+  "possibly-used-before-assignment",
+  "no-name-in-module",
   # Checked by flake8
   "f-string-without-interpolation",
   "redefined-outer-name",
@@ -163,6 +165,7 @@ max-attributes = 12
 [tool.pytest.ini_options]
 testpaths = ["tests", "src"]
 asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"
 required_plugins = ["pytest-asyncio", "pytest-mock"]
 markers = [
   "integration: integration tests (deselect with '-m \"not integration\"')",

--- a/src/frequenz/sdk/actor/__init__.py
+++ b/src/frequenz/sdk/actor/__init__.py
@@ -77,6 +77,7 @@ logged.
 ???+ example
 
     ```python
+    import asyncio
     from frequenz.sdk.actor import Actor, run
 
     class MyActor(Actor):
@@ -85,7 +86,7 @@ logged.
                 print("Hello World!")
                 await asyncio.sleep(1)
 
-    await run(MyActor()) # (1)!
+    await asyncio.run(MyActor()) # (1)!
     ```
 
     1. This line will block until the actor completes its execution or is manually stopped.
@@ -187,26 +188,26 @@ composed easily.
     class EchoActor(Actor):  # (1)!
         def __init__(
                 self,
-                input: Receiver[int],  # (2)!
+                receiver: Receiver[int],  # (2)!
                 output: Sender[int],  # (3)!
                 name: str | None = None,  # (4)!
         ) -> None:
             super().__init__(name=name) # (5)!
-            self._input: Receiver[int] = input  # (6)!
+            self._input: Receiver[int] = receiver  # (6)!
             self._output: Sender[int] = output  # (7)!
     ```
 
     1. We define a new actor class called `EchoActor` that inherits from
         [`Actor`][frequenz.sdk.actor.Actor].
 
-    2. We accept an `input` argument that will be used to receive messages from
+    2. We accept an `receiver` argument that will be used to receive messages from
         a channel.
     3. We accept an `output` argument that will be used to send messages to a channel.
     4. We accept an optional `name` argument that will be used to identify the actor in
         logs.
     5. We call [`Actor.__init__()`][frequenz.sdk.actor.Actor.__init__] to make sure the
         actor is properly initialized.
-    6. We store the `input` argument in a *private* attribute to use it later.
+    6. We store the `receiver` argument in a *private* attribute to use it later.
     7. We store the `output` argument in a *private* attribute to use it later.
 
 ### The `_run()` Method
@@ -231,12 +232,12 @@ or a limited number of runs, terminating upon completion.
     class EchoActor(Actor):
         def __init__(
                 self,
-                input: Receiver[int],
+                receiver: Receiver[int],
                 output: Sender[int],
                 name: str | None = None,
         ) -> None:
             super().__init__(name=name)
-            self._input: Receiver[int] = input
+            self._input: Receiver[int] = receiver
             self._output: Sender[int] = output
 
         async def _run(self) -> None:  # (1)!
@@ -245,7 +246,7 @@ or a limited number of runs, terminating upon completion.
     ```
 
     1. We implement the abstract [`_run()`][_run] method.
-    2. We receive messages from the `input` channel one by one.
+    2. We receive messages from the `receiver` one by one.
     3. We send the received message to the `output` channel.
 
 ### Stopping


### PR DESCRIPTION
Update the files using the migration script with the following changes:

* Group artifact-related actions so they are updated together.
* Add `asyncio_default_fixture_loop_scope` `pytest` option as not specifying this is deprecated.
* Disable some `pylint` checks that are already checked by `mypy`.

We also bump the build dependencies, so the distribution files use names that are compatible with PEP625, which will soon be required by PyPI and fix `pylint` warnings in examples that were previously ignored as they were not checked by `pylint` due to a sybil bug.
