### PR TITLE
Fix ConfigLoggingUpdater not changing root logging level

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -14,4 +14,4 @@
 
 ## Bug Fixes
 
-<!-- Here goes notable bug fixes that are worth a special mention or explanation -->
+* Fix bug with LoggingConfigUpdater not updating root logger level.


### PR DESCRIPTION
Setting log level for root logger with method `logging.basicConfig` during runtime is not working. Instead logging.getLogger() is used.