### PR TITLE
Fix `ConfigManagingActor` raising unhandled exceptions when file doesn't exist

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,7 +6,8 @@
 
 ## Upgrading
 
-<!-- Here goes notes on how to upgrade from previous versions, including deprecations and what they should be replaced with -->
+- The `ConfigManagingActor` now only reacts to `CREATE` and `MODIFY` events. `DELETE` is not supported anymore and are ignored.
+- Remove the `event_types` argument from the `ConfigManagingActor` constructor.
 
 ## New Features
 
@@ -15,3 +16,8 @@
 ## Bug Fixes
 
 - Fix a bug in the resampler that could end up with an *IndexError: list index out of range* exception when a new resampler was added while awaiting the existing resampler to finish resampling.
+
+- Fix bugs with `ConfigManagingActor`:
+  - Raising unhandled exceptions when any file in config directory was deleted.
+  - Raising unhandled exception if not all config files exist.
+  - Eliminate recursive actor crashes when all config files were missing.

--- a/src/frequenz/sdk/config/_config_managing.py
+++ b/src/frequenz/sdk/config/_config_managing.py
@@ -74,7 +74,6 @@ class ConfigManagingActor(Actor):
         self,
         config_paths: abc.Sequence[pathlib.Path | str],
         output: Sender[abc.Mapping[str, Any]],
-        event_types: abc.Set[EventType] = frozenset(EventType),
         *,
         name: str | None = None,
         force_polling: bool = True,
@@ -89,7 +88,6 @@ class ConfigManagingActor(Actor):
                 the previous paths. Dict keys will be merged recursively, but other
                 objects (like lists) will be replaced by the value in the last path.
             output: The sender to send the configuration to.
-            event_types: The set of event types to monitor.
             name: The name of the actor. If `None`, `str(id(self))` will
                 be used. This is used mostly for debugging purposes.
             force_polling: Whether to force file polling to check for changes.
@@ -106,7 +104,6 @@ class ConfigManagingActor(Actor):
             for config_path in config_paths
         ]
         self._output: Sender[abc.Mapping[str, Any]] = output
-        self._event_types: abc.Set[EventType] = event_types
         self._force_polling: bool = force_polling
         self._polling_interval: timedelta = polling_interval
 
@@ -166,17 +163,32 @@ class ConfigManagingActor(Actor):
         # or it is deleted and recreated again.
         file_watcher = FileWatcher(
             paths=list(parent_paths),
-            event_types=self._event_types,
+            event_types={EventType.CREATE, EventType.MODIFY},
             force_polling=self._force_polling,
             polling_interval=self._polling_interval,
         )
 
         try:
             async for event in file_watcher:
+                if not event.path.exists():
+                    _logger.error(
+                        "%s: Received event %s, but the watched path %s doesn't exist.",
+                        self,
+                        event,
+                        event.path,
+                    )
+                    continue
                 # Since we are watching the whole parent directories, we need to make
                 # sure we only react to events related to the configuration files we
                 # are interested in.
-                if not any(event.path.samefile(p) for p in self._config_paths):
+                #
+                # pathlib.Path.samefile raises error if any path doesn't exist so we need to
+                # make sure the paths exists before calling it. This could happen as it is not
+                # required that all config files exist, only one is required but we don't know
+                # which.
+                if not any(
+                    event.path.samefile(p) for p in self._config_paths if p.exists()
+                ):
                     continue
 
                 match event.type:
@@ -195,8 +207,9 @@ class ConfigManagingActor(Actor):
                         )
                         await self.send_config()
                     case EventType.DELETE:
-                        _logger.info(
-                            "%s: The configuration file %s was deleted, ignoring...",
+                        _logger.error(
+                            "%s: Unexpected DELETE event for path %s. Please report this "
+                            "issue to Frequenz.",
                             self,
                             event.path,
                         )

--- a/src/frequenz/sdk/config/_config_managing.py
+++ b/src/frequenz/sdk/config/_config_managing.py
@@ -130,6 +130,15 @@ class ConfigManagingActor(Actor):
             except ValueError as err:
                 _logger.error("%s: Can't read config file, err: %s", self, err)
                 error_count += 1
+            except OSError as err:
+                # It is ok for config file to don't exist.
+                _logger.error(
+                    "%s: Error reading config file %s (%s). Ignoring it.",
+                    self,
+                    err,
+                    config_path,
+                )
+                error_count += 1
 
         if error_count == len(self._config_paths):
             raise ValueError(f"{self}: Can't read any of the config files")


### PR DESCRIPTION
This was detected when I edited config file with `vim` and `config.toml.swp` file was created and deleted.