### PR TITLE
Fix IndexError: list index out of range in resampler

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -14,4 +14,4 @@
 
 ## Bug Fixes
 
-<!-- Here goes notable bug fixes that are worth a special mention or explanation -->
+- Fix a bug in the resampler that could end up with an *IndexError: list index out of range* exception when a new resampler was added while awaiting the existing resampler to finish resampling.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,17 @@
 # Frequenz Python SDK Release Notes
 
+## Summary
+
+<!-- Here goes a general summary of what this release is about -->
+
+## Upgrading
+
+<!-- Here goes notes on how to upgrade from previous versions, including deprecations and what they should be replaced with -->
+
+## New Features
+
+<!-- Here goes the main new features and examples or instructions on how to use them -->
+
 ## Bug Fixes
 
-* Fix bug with `LoggingConfigUpdater` not updating root logger level.
-* The `frequenz-quantities` dependency requirement was widened to allow any v1.x version (it was pinned to `1.0.0rc3` before).
+<!-- Here goes notable bug fixes that are worth a special mention or explanation -->

--- a/src/frequenz/sdk/timeseries/_resampling.py
+++ b/src/frequenz/sdk/timeseries/_resampling.py
@@ -512,11 +512,11 @@ class Resampler:
             exceptions = cast(
                 dict[Source, Exception | asyncio.CancelledError],
                 {
-                    source: results[i]
-                    for i, source in enumerate(resampler_sources)
+                    source: result
+                    for source, result in zip(resampler_sources, results)
                     # CancelledError inherits from BaseException, but we don't want
                     # to catch *all* BaseExceptions here.
-                    if isinstance(results[i], (Exception, asyncio.CancelledError))
+                    if isinstance(result, (Exception, asyncio.CancelledError))
                 },
             )
             if exceptions:


### PR DESCRIPTION
When awaiting the resamplers to finish resampling, we need to make a copy of the resamplers dict, because new resamplers could be added or removed while we are awaiting, which would cause the results to be out of sync.

Here is a traceback of an instance of this bug:

```
2024-11-25 12:45:26,052,52 WARNING  [_broadcast.py:416] Broadcast receiver [Broadcast:GrpcStreamBroadcaster-raw-component-data-2006:_Receiver] is full. Oldest message was dropped.
2024-11-25 12:45:26,052,52 ERROR    [_resampling.py:195] The resample() function got an unexpected error, restarting...
Traceback (most recent call last):
  File "/home/marenz/frequenz/sdk/src/frequenz/sdk/microgrid/_resampling.py", line 179, in _log_resampling_task_error
    resampling_task.result()
  File "/home/marenz/frequenz/sdk/src/frequenz/sdk/timeseries/_resampling.py", line 509, in resample
    {
  File "/home/marenz/frequenz/sdk/src/frequenz/sdk/timeseries/_resampling.py", line 514, in <dictcomp>
    if isinstance(results[i], (Exception, asyncio.CancelledError))
                  ~~~~~~~^^^
IndexError: list index out of range
```
