### PR TITLE
Improve the logging config actor

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -11,6 +11,8 @@
     * Renamed to `LoggingConfigUpdatingActor` to follow the actor naming convention.
     * Make all arguments to the constructor keyword-only.
 
+- The `LoggingConfig.load` method was removed. Please use `frequenz.sdk.config.load_config()` instead.
+
 ## New Features
 
 - `LoggingConfigUpdatingActor`

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,7 +6,10 @@
 
 ## Upgrading
 
-- The `LoggingConfigUpdater` was renamed to `LoggingConfigUpdatingActor` to follow the actor naming convention.
+- `LoggingConfigUpdater`
+
+    * Renamed to `LoggingConfigUpdatingActor` to follow the actor naming convention.
+    * Make all arguments to the constructor keyword-only.
 
 ## New Features
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,17 +6,19 @@
 
 ## Upgrading
 
-- `LoggingConfigUpdater`
+- `frequenz.sdk.config`
 
-    * Renamed to `LoggingConfigUpdatingActor` to follow the actor naming convention.
-    * Make all arguments to the constructor keyword-only.
+    * `LoggingConfigUpdater`
 
-- `LoggingConfig`
+        + Renamed to `LoggingConfigUpdatingActor` to follow the actor naming convention.
+        + Make all arguments to the constructor keyword-only.
 
-    * The `load()` method was removed. Please use `frequenz.sdk.config.load_config()` instead.
-    * The class is now a standard `dataclass` instead of a `marshmallow_dataclass`.
+    * `LoggingConfig`
 
-- `LoggerConfig` is not a standard `dataclass` instead of a `marshmallow_dataclass`.
+        + The `load()` method was removed. Please use `frequenz.sdk.config.load_config()` instead.
+        + The class is now a standard `dataclass` instead of a `marshmallow_dataclass`.
+
+    * `LoggerConfig` is not a standard `dataclass` instead of a `marshmallow_dataclass`.
 
 ## New Features
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -13,7 +13,9 @@
 
 ## New Features
 
-<!-- Here goes the main new features and examples or instructions on how to use them -->
+- `LoggingConfigUpdatingActor`
+
+    * Added a new `name` argument to the constructor to be able to override the actor's name.
 
 ## Bug Fixes
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -11,7 +11,12 @@
     * Renamed to `LoggingConfigUpdatingActor` to follow the actor naming convention.
     * Make all arguments to the constructor keyword-only.
 
-- The `LoggingConfig.load` method was removed. Please use `frequenz.sdk.config.load_config()` instead.
+- `LoggingConfig`
+
+    * The `load()` method was removed. Please use `frequenz.sdk.config.load_config()` instead.
+    * The class is now a standard `dataclass` instead of a `marshmallow_dataclass`.
+
+- `LoggerConfig` is not a standard `dataclass` instead of a `marshmallow_dataclass`.
 
 ## New Features
 

--- a/src/frequenz/sdk/config/__init__.py
+++ b/src/frequenz/sdk/config/__init__.py
@@ -9,8 +9,8 @@ from ._util import load_config
 
 __all__ = [
     "ConfigManagingActor",
-    "LoggingConfig",
     "LoggerConfig",
+    "LoggingConfig",
     "LoggingConfigUpdatingActor",
     "load_config",
 ]

--- a/src/frequenz/sdk/config/_logging_actor.py
+++ b/src/frequenz/sdk/config/_logging_actor.py
@@ -13,8 +13,7 @@ import marshmallow.validate
 from frequenz.channels import Receiver
 from marshmallow_dataclass import dataclass
 
-from frequenz.sdk.actor import Actor
-
+from ..actor import Actor
 from ._util import load_config
 
 _logger = logging.getLogger(__name__)

--- a/src/frequenz/sdk/config/_logging_actor.py
+++ b/src/frequenz/sdk/config/_logging_actor.py
@@ -135,16 +135,16 @@ class LoggingConfigUpdatingActor(Actor):
         self,
         *,
         config_recv: Receiver[Mapping[str, Any]],
-        log_format: str = "%(asctime)s %(levelname)-8s %(name)s:%(lineno)s: %(message)s",
         log_datefmt: str = "%Y-%m-%dT%H:%M:%S%z",
+        log_format: str = "%(asctime)s %(levelname)-8s %(name)s:%(lineno)s: %(message)s",
         name: str | None = None,
     ):
         """Initialize this instance.
 
         Args:
             config_recv: The receiver to listen for configuration changes.
-            log_format: Use the specified format string in logs.
             log_datefmt: Use the specified date/time format in logs.
+            log_format: Use the specified format string in logs.
             name: The name of this actor. If `None`, `str(id(self))` will be used. This
                 is used mostly for debugging purposes.
 

--- a/src/frequenz/sdk/config/_logging_actor.py
+++ b/src/frequenz/sdk/config/_logging_actor.py
@@ -24,6 +24,7 @@ LogLevel = Annotated[
         validate=marshmallow.validate.OneOf(choices=logging.getLevelNamesMapping())
     ),
 ]
+"""A marshmallow field for validating log levels."""
 
 
 @dataclass

--- a/src/frequenz/sdk/config/_logging_actor.py
+++ b/src/frequenz/sdk/config/_logging_actor.py
@@ -154,13 +154,14 @@ class LoggingConfigUpdatingActor(Actor):
             in the application (through a previous `basicConfig()` call), then the format
             settings specified here will be ignored.
         """
-        super().__init__(name=name)
         self._config_recv = config_recv
 
         # Setup default configuration.
         # This ensures logging is configured even if actor fails to start or
         # if the configuration cannot be loaded.
         self._current_config: LoggingConfig = LoggingConfig()
+
+        super().__init__(name=name)
 
         logging.basicConfig(
             format=log_format,

--- a/src/frequenz/sdk/config/_logging_actor.py
+++ b/src/frequenz/sdk/config/_logging_actor.py
@@ -5,13 +5,12 @@
 
 import logging
 from collections.abc import Mapping
-from dataclasses import field
+from dataclasses import dataclass, field
 from typing import Annotated, Any
 
 import marshmallow
 import marshmallow.validate
 from frequenz.channels import Receiver
-from marshmallow_dataclass import dataclass
 
 from ..actor import Actor
 from ._util import load_config

--- a/src/frequenz/sdk/config/_logging_actor.py
+++ b/src/frequenz/sdk/config/_logging_actor.py
@@ -137,6 +137,7 @@ class LoggingConfigUpdatingActor(Actor):
         config_recv: Receiver[Mapping[str, Any]],
         log_format: str = "%(asctime)s %(levelname)-8s %(name)s:%(lineno)s: %(message)s",
         log_datefmt: str = "%Y-%m-%dT%H:%M:%S%z",
+        name: str | None = None,
     ):
         """Initialize this instance.
 
@@ -144,6 +145,8 @@ class LoggingConfigUpdatingActor(Actor):
             config_recv: The receiver to listen for configuration changes.
             log_format: Use the specified format string in logs.
             log_datefmt: Use the specified date/time format in logs.
+            name: The name of this actor. If `None`, `str(id(self))` will be used. This
+                is used mostly for debugging purposes.
 
         Note:
             The `log_format` and `log_datefmt` parameters are used in a call to
@@ -151,7 +154,7 @@ class LoggingConfigUpdatingActor(Actor):
             in the application (through a previous `basicConfig()` call), then the format
             settings specified here will be ignored.
         """
-        super().__init__()
+        super().__init__(name=name)
         self._config_recv = config_recv
 
         # Setup default configuration.

--- a/src/frequenz/sdk/config/_logging_actor.py
+++ b/src/frequenz/sdk/config/_logging_actor.py
@@ -133,6 +133,7 @@ class LoggingConfigUpdatingActor(Actor):
 
     def __init__(
         self,
+        *,
         config_recv: Receiver[Mapping[str, Any]],
         log_format: str = "%(asctime)s %(levelname)-8s %(name)s:%(lineno)s: %(message)s",
         log_datefmt: str = "%Y-%m-%dT%H:%M:%S%z",

--- a/src/frequenz/sdk/config/_logging_actor.py
+++ b/src/frequenz/sdk/config/_logging_actor.py
@@ -36,7 +36,6 @@ class LoggerConfig:
             "metadata": {
                 "description": "Log level for the logger. Uses standard logging levels."
             },
-            "required": False,
         },
     )
     """The log level for the logger."""
@@ -52,7 +51,6 @@ class LoggingConfig:
             "metadata": {
                 "description": "Default default configuration for all loggers.",
             },
-            "required": False,
         },
     )
     """The default log level."""
@@ -63,7 +61,6 @@ class LoggingConfig:
             "metadata": {
                 "description": "Configuration for a logger (the key is the logger name)."
             },
-            "required": False,
         },
     )
     """The list of loggers configurations."""

--- a/tests/config/test_logging_actor.py
+++ b/tests/config/test_logging_actor.py
@@ -13,7 +13,12 @@ from frequenz.channels import Broadcast
 from marshmallow import ValidationError
 from pytest_mock import MockerFixture
 
-from frequenz.sdk.config import LoggerConfig, LoggingConfig, LoggingConfigUpdatingActor
+from frequenz.sdk.config import (
+    LoggerConfig,
+    LoggingConfig,
+    LoggingConfigUpdatingActor,
+    load_config,
+)
 
 
 def test_logging_config() -> None:
@@ -33,19 +38,19 @@ def test_logging_config() -> None:
         },
     )
 
-    assert LoggingConfig.load(config_raw) == config
+    assert load_config(LoggingConfig, config_raw) == config
 
     config_raw = {}
     config = LoggingConfig()
-    assert LoggingConfig.load(config_raw) == config
+    assert load_config(LoggingConfig, config_raw) == config
 
     config_raw = {"root_logger": {"level": "UNKNOWN"}}
     with pytest.raises(ValidationError):
-        LoggingConfig.load(config_raw)
+        load_config(LoggingConfig, config_raw)
 
     config_raw = {"unknown": {"frequenz.sdk.actor": {"level": "DEBUG"}}}
     with pytest.raises(ValidationError):
-        LoggingConfig.load(config_raw)
+        load_config(LoggingConfig, config_raw)
 
 
 @pytest.fixture


### PR DESCRIPTION
- **Make all arguments keyword-only**
- **Add a `name` argument to `LoggingConfigUpdatingActor`**
- **Sort arguments in `LoggingConfigUpdatingActor` constructor**
- **Initialize parent class after all attributes were initialized**
- **Add missing docstring for `LogLevel`**
- **Remove the `LoggingConfig.load` method**
- **Use relative imports**
- **Use the `dataclass` decorator from `dataclasses`**
- **Group config changes in the release notes**
- **Sort `__all__`**
- **Remove unnecessary required from metadata**