### PR TITLE
Make `LoggerConfig` and `LoggingConfig` frozen and keyword-only

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -17,8 +17,14 @@
 
         + The `load()` method was removed. Please use `frequenz.sdk.config.load_config()` instead.
         + The class is now a standard `dataclass` instead of a `marshmallow_dataclass`.
+        + The class is now immutable.
+        + The constructor now accepts only keyword arguments.
 
-    * `LoggerConfig` is now a standard `dataclass` instead of a `marshmallow_dataclass`.
+    * `LoggerConfig`
+
+        + The class is now a standard `dataclass` instead of a `marshmallow_dataclass`.
+        + The class is now immutable.
+        + The constructor now accepts only keyword arguments.
 
 ## New Features
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -18,7 +18,7 @@
         + The `load()` method was removed. Please use `frequenz.sdk.config.load_config()` instead.
         + The class is now a standard `dataclass` instead of a `marshmallow_dataclass`.
 
-    * `LoggerConfig` is not a standard `dataclass` instead of a `marshmallow_dataclass`.
+    * `LoggerConfig` is now a standard `dataclass` instead of a `marshmallow_dataclass`.
 
 ## New Features
 

--- a/src/frequenz/sdk/config/_logging_actor.py
+++ b/src/frequenz/sdk/config/_logging_actor.py
@@ -26,7 +26,7 @@ LogLevel = Annotated[
 """A marshmallow field for validating log levels."""
 
 
-@dataclass
+@dataclass(frozen=True, kw_only=True)
 class LoggerConfig:
     """A configuration for a logger."""
 
@@ -41,7 +41,7 @@ class LoggerConfig:
     """The log level for the logger."""
 
 
-@dataclass
+@dataclass(frozen=True, kw_only=True)
 class LoggingConfig:
     """A configuration for the logging system."""
 


### PR DESCRIPTION
- **Fix typo in release notes**
- **Make `LoggerConfig` and `LoggingConfig` frozen and keyword-only**
