### PR TITLE
Revamp config management

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -11,7 +11,9 @@
     * `LoggingConfigUpdater`
 
         + Renamed to `LoggingConfigUpdatingActor` to follow the actor naming convention.
-        + Make all arguments to the constructor keyword-only.
+        + The actor must now be constructed using a `ConfigManager` instead of a receiver.
+        + Make all arguments to the constructor keyword-only, except for the `config_manager` argument.
+        + If the configuration is removed, the actor will now load back the default configuration.
 
     * `LoggingConfig`
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-<!-- Here goes a general summary of what this release is about -->
+This release includes a new `ConfigManager` class to simplify managing the configuration, and ships other improvements and fixes to the config system in general.
 
 ## Upgrading
 
@@ -33,12 +33,30 @@
          + The `base_schema` argument is now keyword-only.
          + The arguments forwarded to `marshmallow.Schema.load()` now must be passed explicitly via the `marshmallow_load_kwargs` argument, as a `dict`, to improve the type-checking.
 
+    * `ConfigManagingActor`: Raise a `ValueError` if the `config_files` argument an empty sequence.
+
 ## New Features
 
-- `LoggingConfigUpdatingActor`
+- `frequenz.sdk.config`
 
-    * Added a new `name` argument to the constructor to be able to override the actor's name.
+    - Logging was improved in general.
+
+    - Added documentation and user guide.
+
+    - `LoggingConfigUpdatingActor`
+
+        * Added a new `name` argument to the constructor to be able to override the actor's name.
+
+    - `ConfigManager`: Added a class to simplify managing the configuration. It takes care of instantiating the config actors and provides a convenient method for creating receivers with a lot of common functionality.
+
+    - `BaseConfigSchema`: Added a `marshmallow` base `Schema` that includes custom fields for `frequenz-quantities`. In the futute more commonly used fields might be added.
+
+    - `wait_for_first()`: Added a function to make it easy to wait for the first configuration to be received with a timeout.
+
+    - `ConfigManagingActor`: Allow passing a single configuration file.
 
 ## Bug Fixes
 
 - Fix a bug in `BackgroundService` where it won't try to `self.cancel()` and `await self.wait()` if there are no internal tasks. This prevented to properly implement custom stop logic without having to redefine the `stop()` method too.
+
+- Fix a bug where if a string was passed to the `ConfigManagingActor` it would be interpreted as a sequence of 1 character strings.

--- a/docs/user-guide/config.md
+++ b/docs/user-guide/config.md
@@ -1,0 +1,9 @@
+# Configuration
+
+::: frequenz.sdk.config
+    options:
+        members: []
+        show_bases: false
+        show_root_heading: false
+        show_root_toc_entry: false
+        show_source: false

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -119,6 +119,7 @@ plugins:
             - https://docs.python.org/3/objects.inv
             - https://frequenz-floss.github.io/frequenz-channels-python/v1.1/objects.inv
             - https://frequenz-floss.github.io/frequenz-client-microgrid-python/v0.5/objects.inv
+            - https://frequenz-floss.github.io/frequenz-quantities-python/v1/objects.inv
             - https://lovasoa.github.io/marshmallow_dataclass/html/objects.inv
             - https://marshmallow.readthedocs.io/en/stable/objects.inv
             - https://networkx.org/documentation/stable/objects.inv

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
   # (plugins.mkdocstrings.handlers.python.import)
   "frequenz-client-microgrid >= 0.6.0, < 0.7.0",
   "frequenz-channels >= 1.4.0, < 2.0.0",
-  "frequenz-quantities >= 1.0.0rc3, < 2.0.0",
+  "frequenz-quantities[marshmallow] >= 1.0.0, < 2.0.0",
   "networkx >= 2.8, < 4",
   "numpy >= 1.26.4, < 2",
   "typing_extensions >= 4.6.1, < 5",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
   # changing the version
   # (plugins.mkdocstrings.handlers.python.import)
   "frequenz-client-microgrid >= 0.6.0, < 0.7.0",
-  "frequenz-channels >= 1.2.0, < 2.0.0",
+  "frequenz-channels >= 1.4.0, < 2.0.0",
   "frequenz-quantities >= 1.0.0rc3, < 2.0.0",
   "networkx >= 2.8, < 4",
   "numpy >= 1.26.4, < 2",

--- a/src/frequenz/sdk/config/__init__.py
+++ b/src/frequenz/sdk/config/__init__.py
@@ -1,13 +1,15 @@
 # License: MIT
 # Copyright © 2024 Frequenz Energy-as-a-Service GmbH
 
-"""Read and update config variables."""
+"""Configuration management."""
 
 from ._logging_actor import LoggerConfig, LoggingConfig, LoggingConfigUpdatingActor
+from ._manager import ConfigManager
 from ._managing_actor import ConfigManagingActor
 from ._util import load_config
 
 __all__ = [
+    "ConfigManager",
     "ConfigManagingActor",
     "LoggerConfig",
     "LoggingConfig",

--- a/src/frequenz/sdk/config/__init__.py
+++ b/src/frequenz/sdk/config/__init__.py
@@ -4,13 +4,14 @@
 """Configuration management."""
 
 from ._logging_actor import LoggerConfig, LoggingConfig, LoggingConfigUpdatingActor
-from ._manager import ConfigManager
+from ._manager import ConfigManager, InvalidValueForKeyError
 from ._managing_actor import ConfigManagingActor
 from ._util import load_config
 
 __all__ = [
     "ConfigManager",
     "ConfigManagingActor",
+    "InvalidValueForKeyError",
     "LoggerConfig",
     "LoggingConfig",
     "LoggingConfigUpdatingActor",

--- a/src/frequenz/sdk/config/__init__.py
+++ b/src/frequenz/sdk/config/__init__.py
@@ -5,7 +5,7 @@
 
 from ._base_schema import BaseConfigSchema
 from ._logging_actor import LoggerConfig, LoggingConfig, LoggingConfigUpdatingActor
-from ._manager import ConfigManager, InvalidValueForKeyError
+from ._manager import ConfigManager, InvalidValueForKeyError, wait_for_first
 from ._managing_actor import ConfigManagingActor
 from ._util import load_config
 
@@ -18,4 +18,5 @@ __all__ = [
     "LoggingConfig",
     "LoggingConfigUpdatingActor",
     "load_config",
+    "wait_for_first",
 ]

--- a/src/frequenz/sdk/config/__init__.py
+++ b/src/frequenz/sdk/config/__init__.py
@@ -1,7 +1,430 @@
 # License: MIT
 # Copyright © 2024 Frequenz Energy-as-a-Service GmbH
 
-"""Configuration management."""
+"""Configuration management.
+
+# Overview
+
+To provide dynamic configurations to an application, you can use the
+[`ConfigManager`][frequenz.sdk.config.ConfigManager] class. This class provides
+a convenient interface to manage configurations from multiple config files and receive
+updates when the configurations change.  Users can create a receiver to receive
+configurations from the manager.
+
+# Setup
+
+To use the `ConfigManager`, you need to create an instance of it and pass the
+paths to the configuration files. The configuration files must be in the TOML
+format.
+
+When specifying multiple files order matters, as the configuration will be read and
+updated in the order of the paths, so the last path will override the configuration set
+by the previous paths. Dict keys will be merged recursively, but other objects (like
+lists) will be replaced by the value in the last path.
+
+```python
+from frequenz.sdk.config import ConfigManager
+
+async with ConfigManager(["base-config.toml", "overrides.toml"]) as config_manager:
+    ...
+```
+
+# Logging
+
+The `ConfigManager` can also instantiate
+a [`LoggingConfigUpdatingActor`][frequenz.sdk.config.LoggingConfigUpdatingActor] to
+monitor logging configurations. This actor will listen for logging configuration changes
+and update the logging configuration accordingly.
+
+This feature is enabled by default using the key `logging` in the configuration file. To
+disable it you can pass `logging_config_key=None` to the `ConfigManager`.
+
+# Receiving configurations
+
+To receive configurations, you can create a receiver using the [`new_receiver()`][
+frequenz.sdk.config.ConfigManager.new_receiver] method. The receiver will receive
+configurations from the manager for a particular key, and validate and load the
+configurations to a dataclass using [`marshmallow_dataclass`][].
+
+If the key is a sequence of strings, it will be treated as a nested key and the
+receiver will receive the configuration under the nested key. For example
+`["key", "subkey"]` will get only `config["key"]["subkey"]`.
+
+Besides a configuration instance, the receiver can also receive exceptions if there are
+errors loading the configuration (typically
+a [`ValidationError`][marshmallow.ValidationError]), or `None` if there is no
+configuration for the key.
+
+The value under `key` must be another mapping, otherwise
+a [`InvalidValueForKeyError`][frequenz.sdk.config.InvalidValueForKeyError] instance will
+be sent to the receiver.
+
+If there were any errors loading the configuration, the error will be logged too.
+
+```python
+from dataclasses import dataclass
+from frequenz.sdk.config import ConfigManager
+
+@dataclass(frozen=True, kw_only=True)
+class AppConfig:
+    test: int
+
+async with ConfigManager("config.toml") as config_manager:
+    receiver = config_manager.new_receiver("app", AppConfig)
+    app_config = await receiver.receive()
+    match app_config:
+        case AppConfig(test=42):
+            print("App configured with 42")
+        case Exception() as error:
+            print(f"Error loading configuration: {error}")
+        case None:
+            print("There is no configuration for the app key")
+```
+
+## Validation and loading
+
+The configuration class used to create the configuration instance is expected to be
+a [`dataclasses.dataclass`][], which is used to create a [`marshmallow.Schema`][] via
+the [`marshmallow_dataclass.class_schema`][] function.
+
+This means you can customize the schema derived from the configuration
+dataclass using [`marshmallow_dataclass`][] to specify extra validation and
+options via field metadata.
+
+Customization can also be done via a `base_schema`. By default
+[`BaseConfigSchema`][frequenz.sdk.config.BaseConfigSchema] is used to provide support
+for some extra commonly used fields (like [quantities][frequenz.quantities]).
+
+```python
+import marshmallow.validate
+from dataclasses import dataclass, field
+
+@dataclass(frozen=True, kw_only=True)
+class Config:
+    test: int = field(
+        metadata={"validate": marshmallow.validate.Range(min=0)},
+    )
+```
+
+Additional arguments can be passed to [`marshmallow.Schema.load`][] using
+the `marshmallow_load_kwargs` keyword arguments.
+
+If unspecified, the `marshmallow_load_kwargs` will have the `unknown` key set to
+[`marshmallow.EXCLUDE`][] (instead of the normal [`marshmallow.RAISE`][]
+default).
+
+But when [`marshmallow.EXCLUDE`][] is used, a warning will be logged if there are extra
+fields in the configuration that are excluded. This is useful, for example, to catch
+typos in the configuration file.
+
+## Skipping superfluous updates
+
+If there is a burst of configuration updates, the receiver will only receive the
+last configuration, older configurations will be ignored.
+
+If `skip_unchanged` is set to `True`, then a configuration that didn't change
+compared to the last one received will be ignored and not sent to the receiver.
+The comparison is done using the *raw* `dict` to determine if the configuration
+has changed.
+
+## Error handling
+
+The value under `key` must be another mapping, otherwise an error
+will be logged and a [`frequenz.sdk.config.InvalidValueForKeyError`][] instance
+will be sent to the receiver.
+
+Configurations that don't pass the validation will be logged as an error and
+the [`ValidationError`][marshmallow.ValidationError] sent to the receiver.
+
+Any other unexpected error raised during the configuration loading will be
+logged as an error and the error instance sent to the receiver.
+
+## Further customization
+
+If you have special needs for receiving the configurations (for example validating using
+`marshmallow` doesn't fit your needs), you can create a custom receiver using
+[`config_channel.new_receiver()`][frequenz.sdk.config.ConfigManager.config_channel]
+directly. Please bear in mind that this provides a low-level access to the whole config
+in the file as a raw Python mapping.
+
+# Recommended usage
+
+Actors that need to be reconfigured should take a configuration manager and a key to
+receive configurations updates, and instantiate the new receiver themselves. This allows
+actors to have full control over how the configuration is loaded (for example providing
+a custom base schema or marshmallow options).
+
+Passing the key explicitly too allows application to structure the configuration in
+whatever way is most convenient for the application.
+
+Actors can use the [`wait_for_first()`][frequenz.sdk.config.wait_for_first] function to
+wait for the first configuration to be received, and cache the configuration for later
+use and in case the actor is restarted. If the configuration is not received after some
+timeout, a [`asyncio.TimeoutError`][] will be raised (and if uncaught, the actor will
+be automatically restarted after some delay).
+
+Example: Actor that can run without a configuration (using a default configuration)
+    ```python title="actor.py" hl_lines="18 34 42 62 64"
+    import dataclasses
+    import logging
+    from collections.abc import Sequence
+    from datetime import timedelta
+    from typing import assert_never
+
+    from frequenz.channels import select, selected_from
+    from frequenz.channels.event import Event
+
+    from frequenz.sdk.actor import Actor
+    from frequenz.sdk.config import ConfigManager, wait_for_first
+
+    _logger = logging.getLogger(__name__)
+
+    @dataclasses.dataclass(frozen=True, kw_only=True)
+    class MyActorConfig:
+        some_config: timedelta = dataclasses.field(
+            default=timedelta(seconds=42), # (1)!
+            metadata={"metadata": {"description": "Some optional configuration"}},
+        )
+
+    class MyActor(Actor):
+        def __init__(
+            self,
+            config_manager: ConfigManager,
+            /,
+            *,
+            config_key: str | Sequence[str],
+            name: str | None = None,
+        ) -> None:
+            super().__init__(name=name)
+            self._config_manager = config_manager
+            self._config_key = config_key
+            self._config: MyActorConfig = MyActorConfig() # (2)!
+
+        async def _run(self) -> None:
+            config_receiver = self._config_manager.new_receiver(
+                self._config_key, MyActorConfig
+            )
+            self._update_config(
+                await wait_for_first(
+                    config_receiver, receiver_name=str(self), allow_none=True # (3)!
+                )
+            )
+
+            other_receiver = Event()
+
+            async for selected in select(config_receiver, other_receiver):
+                if selected_from(selected, config_receiver):
+                    self._update_config(selected.message)
+                elif selected_from(selected, other_receiver):
+                    # Do something else
+                    ...
+
+        def _update_config(self, config_update: MyActorConfig | Exception | None) -> None:
+            match config_update:
+                case MyActorConfig() as config:
+                    _logger.info("New configuration received, updating.")
+                    self._reconfigure(config)
+                case None:
+                    _logger.info("Configuration was unset, resetting to the default")
+                    self._reconfigure(MyActorConfig()) # (4)!
+                case Exception():
+                    _logger.info( # (5)!
+                        "New configuration has errors, keeping the old configuration."
+                    )
+                case unexpected:
+                    assert_never(unexpected)
+
+        def _reconfigure(self, config: MyActorConfig) -> None:
+            self._config = config
+            # Do something with the new configuration
+    ```
+
+    1. This is different when the actor requires a configuration to run. Here, the
+        config has a default value.
+    2. This is different when the actor requires a configuration to run. Here, the actor
+        can just instantiate a default configuration.
+    3. This is different when the actor requires a configuration to run. Here, the actor
+        can accept a `None` configuration.
+    4. This is different when the actor requires a configuration to run. Here, the actor
+        can reset to a default configuration.
+    5. There is no need to log the error itself, the configuration manager will log it
+        automatically.
+
+Example: Actor that requires a configuration to run
+    ```python title="actor.py" hl_lines="17 33 40 58 60"
+    import dataclasses
+    import logging
+    from collections.abc import Sequence
+    from datetime import timedelta
+    from typing import assert_never
+
+    from frequenz.channels import select, selected_from
+    from frequenz.channels.event import Event
+
+    from frequenz.sdk.actor import Actor
+    from frequenz.sdk.config import ConfigManager, wait_for_first
+
+    _logger = logging.getLogger(__name__)
+
+    @dataclasses.dataclass(frozen=True, kw_only=True)
+    class MyActorConfig:
+        some_config: timedelta = dataclasses.field( # (1)!
+            metadata={"metadata": {"description": "Some required configuration"}},
+        )
+
+    class MyActor(Actor):
+        def __init__(
+            self,
+            config_manager: ConfigManager,
+            /,
+            *,
+            config_key: str | Sequence[str],
+            name: str | None = None,
+        ) -> None:
+            super().__init__(name=name)
+            self._config_manager = config_manager
+            self._config_key = config_key
+            self._config: MyActorConfig # (2)!
+
+        async def _run(self) -> None:
+            config_receiver = self._config_manager.new_receiver(
+                self._config_key, MyActorConfig
+            )
+            self._update_config(
+                await wait_for_first(config_receiver, receiver_name=str(self)) # (3)!
+            )
+
+            other_receiver = Event()
+
+            async for selected in select(config_receiver, other_receiver):
+                if selected_from(selected, config_receiver):
+                    self._update_config(selected.message)
+                elif selected_from(selected, other_receiver):
+                    # Do something else
+                    ...
+
+        def _update_config(self, config_update: MyActorConfig | Exception | None) -> None:
+            match config_update:
+                case MyActorConfig() as config:
+                    _logger.info("New configuration received, updating.")
+                    self._reconfigure(config)
+                case None:
+                    _logger.info("Configuration was unset, keeping the old configuration.") # (4)!
+                case Exception():
+                    _logger.info( # (5)!
+                        "New configuration has errors, keeping the old configuration."
+                    )
+                case unexpected:
+                    assert_never(unexpected)
+
+        def _reconfigure(self, config: MyActorConfig) -> None:
+            self._config = config
+            # Do something with the new configuration
+    ```
+
+    1. This is different when the actor can use a default configuration. Here, the
+        field is required, so there is no default configuration possible.
+    2. This is different when the actor can use a default configuration. Here, the
+       assignment of the configuration is delayed to the `_run()` method.
+    3. This is different when the actor can use a default configuration. Here, the actor
+        doesn't accept `None` as a valid configuration as it can't create a default
+        configuration.
+    4. This is different when the actor can use a default configuration. Here, the actor
+        doesn't accept `None` as a valid configuration as it can't create a default
+        configuration, so it needs to keep the old configuration.
+    5. There is no need to log the error itself, the configuration manager will log it
+        automatically.
+
+
+Example: Application
+    The pattern used by the application is very similar to the one used by actors. In
+    this case the application requires a configuration to run, but if it could also use
+    a default configuration, the changes would be the same as in the actor examples.
+
+    ```python title="app.py" hl_lines="14"
+    import asyncio
+    import dataclasses
+    import logging
+    import pathlib
+    from collections.abc import Sequence
+    from datetime import timedelta
+    from typing import Sequence, assert_never
+
+    from frequenz.sdk.actor import Actor
+    from frequenz.sdk.config import ConfigManager, wait_for_first
+
+    _logger = logging.getLogger(__name__)
+
+    class MyActor(Actor): # (1)!
+        def __init__(
+            self, config_manager: ConfigManager, /, *, config_key: str | Sequence[str]
+        ) -> None:
+            super().__init__()
+            self._config_manager = config_manager
+            self._config_key = config_key
+        async def _run(self) -> None: ...
+
+    @dataclasses.dataclass(frozen=True, kw_only=True)
+    class AppConfig:
+        enable_actor: bool = dataclasses.field(
+            metadata={"metadata": {"description": "Whether to enable the actor"}},
+        )
+
+    class App:
+        def __init__(self, *, config_paths: Sequence[pathlib.Path]):
+            self._config_manager = ConfigManager(config_paths)
+            self._config_receiver = self._config_manager.new_receiver("app", AppConfig)
+            self._actor = MyActor(self._config_manager, config_key="actor")
+
+        async def _update_config(self, config_update: AppConfig | Exception | None) -> None:
+            match config_update:
+                case AppConfig() as config:
+                    _logger.info("New configuration received, updating.")
+                    await self._reconfigure(config)
+                case None:
+                    _logger.info("Configuration was unset, keeping the old configuration.")
+                case Exception():
+                    _logger.info("New configuration has errors, keeping the old configuration.")
+                case unexpected:
+                    assert_never(unexpected)
+
+        async def _reconfigure(self, config: AppConfig) -> None:
+            if config.enable_actor:
+                self._actor.start()
+            else:
+                await self._actor.stop()
+
+        async def run(self) -> None:
+            _logger.info("Starting App...")
+
+            async with self._config_manager:
+                await self._update_config(
+                    await wait_for_first(self._config_receiver, receiver_name="app")
+                )
+
+                _logger.info("Waiting for configuration updates...")
+                async for config_update in self._config_receiver:
+                    await self._reconfigure(config_update)
+
+    if __name__ == "__main__":
+        asyncio.run(App(config_paths="config.toml").run())
+    ```
+
+    1. Look for the actor examples for a proper implementation of the actor.
+
+    Example configuration file:
+
+    ```toml title="config.toml"
+    [app]
+    enable_actor = true
+
+    [actor]
+    some_config = 10
+
+    [logging.root_logger]
+    level = "DEBUG"
+    ```
+"""
 
 from ._base_schema import BaseConfigSchema
 from ._logging_actor import LoggerConfig, LoggingConfig, LoggingConfigUpdatingActor

--- a/src/frequenz/sdk/config/__init__.py
+++ b/src/frequenz/sdk/config/__init__.py
@@ -3,12 +3,14 @@
 
 """Configuration management."""
 
+from ._base_schema import BaseConfigSchema
 from ._logging_actor import LoggerConfig, LoggingConfig, LoggingConfigUpdatingActor
 from ._manager import ConfigManager, InvalidValueForKeyError
 from ._managing_actor import ConfigManagingActor
 from ._util import load_config
 
 __all__ = [
+    "BaseConfigSchema",
     "ConfigManager",
     "ConfigManagingActor",
     "InvalidValueForKeyError",

--- a/src/frequenz/sdk/config/_base_schema.py
+++ b/src/frequenz/sdk/config/_base_schema.py
@@ -1,0 +1,10 @@
+# License: MIT
+# Copyright © 2024 Frequenz Energy-as-a-Service GmbH
+
+"""Base schema for configuration classes."""
+
+from frequenz.quantities.experimental.marshmallow import QuantitySchema
+
+
+class BaseConfigSchema(QuantitySchema):
+    """A base schema for configuration classes."""

--- a/src/frequenz/sdk/config/_manager.py
+++ b/src/frequenz/sdk/config/_manager.py
@@ -11,10 +11,12 @@ from typing import Any, Final
 
 from frequenz.channels import Broadcast, Receiver
 from frequenz.channels.experimental import WithPrevious
+from marshmallow import Schema, ValidationError
 from typing_extensions import override
 
 from ..actor._background_service import BackgroundService
 from ._managing_actor import ConfigManagingActor
+from ._util import DataclassT, load_config
 
 _logger = logging.getLogger(__name__)
 
@@ -124,7 +126,7 @@ class ConfigManager(BackgroundService):
         """Return a string representation of this config manager."""
         return f"config_channel={self.config_channel!r}, " f"actor={self.actor!r}>"
 
-    def new_receiver(
+    def new_receiver(  # pylint: disable=too-many-arguments
         self,
         # This is tricky, because a str is also a Sequence[str], if we would use only
         # Sequence[str], then a regular string would also be accepted and taken as
@@ -132,10 +134,13 @@ class ConfigManager(BackgroundService):
         # the allowed types without changing Sequence[str] to something more specific,
         # like list[str] or tuple[str] (but both have their own problems).
         key: str | Sequence[str],
+        config_class: type[DataclassT],
         /,
         *,
         skip_unchanged: bool = True,
-    ) -> Receiver[Mapping[str, Any] | InvalidValueForKeyError | None]:
+        base_schema: type[Schema] | None = None,
+        marshmallow_load_kwargs: dict[str, Any] | None = None,
+    ) -> Receiver[DataclassT | Exception | None]:
         """Create a new receiver for receiving the configuration for a particular key.
 
         This method has a lot of features and functionalities to make it easier to
@@ -157,6 +162,21 @@ class ConfigManager(BackgroundService):
         will be logged and a [`frequenz.sdk.config.InvalidValueForKeyError`][] instance
         will be sent to the receiver.
 
+        ### Schema validation
+
+        The raw configuration received as a `Mapping` will be validated and loaded to
+        as a `config_class`. The `config_class` class is expected to be
+        a [`dataclasses.dataclass`][], which is used to create
+        a [`marshmallow.Schema`][] via the [`marshmallow_dataclass.class_schema`][]
+        function.
+
+        This means you can customize the schema derived from the configuration
+        dataclass using [`marshmallow_dataclass`][] to specify extra validation and
+        options via field metadata.
+
+        Additional arguments can be passed to [`marshmallow.Schema.load`][] using
+        the `marshmallow_load_kwargs` keyword arguments.
+
         ### Skipping superfluous updates
 
         If there is a burst of configuration updates, the receiver will only receive the
@@ -167,6 +187,18 @@ class ConfigManager(BackgroundService):
         The comparison is done using the *raw* `dict` to determine if the configuration
         has changed.
 
+        ### Error handling
+
+        The value under `key` must be another mapping, otherwise an error
+        will be logged and a [`frequenz.sdk.config.InvalidValueForKeyError`][] instance
+        will be sent to the receiver.
+
+        Configurations that don't pass the validation will be logged as an error and
+        the [`ValidationError`][marshmallow.ValidationError] sent to the receiver.
+
+        Any other unexpected error raised during the configuration loading will be
+        logged as an error and the error instance sent to the receiver.
+
         Example:
             ```python
             # TODO: Add Example
@@ -175,44 +207,49 @@ class ConfigManager(BackgroundService):
         Args:
             key: The configuration key to be read by the receiver. If a sequence of
                 strings is used, it is used as a sub-key.
+            config_class: The class object to use to instantiate a configuration. The
+                configuration will be validated against this type too using
+                [`marshmallow_dataclass`][].
             skip_unchanged: Whether to skip sending the configuration if it hasn't
                 changed compared to the last one received.
+            base_schema: An optional class to be used as a base schema for the
+                configuration class. This allow using custom fields for example. Will be
+                passed to [`marshmallow_dataclass.class_schema`][].
+            marshmallow_load_kwargs: Additional arguments to be passed to
+                [`marshmallow.Schema.load`][].
 
         Returns:
             The receiver for the configuration.
         """
-        recv_name = key if isinstance(key, str) else ":".join(key)
-        receiver = self.config_channel.new_receiver(name=recv_name, limit=1)
-
-        def _get_key_or_error(
-            config: Mapping[str, Any]
-        ) -> Mapping[str, Any] | InvalidValueForKeyError | None:
-            try:
-                return _get_key(config, key)
-            except InvalidValueForKeyError as error:
-                return error
-
-        key_receiver = receiver.map(_get_key_or_error)
+        receiver = self.config_channel.new_receiver(name=f"{self}:{key}", limit=1).map(
+            lambda config: _load_config_with_logging_and_errors(
+                config,
+                config_class,
+                key=key,
+                base_schema=base_schema,
+                marshmallow_load_kwargs=marshmallow_load_kwargs,
+            )
+        )
 
         if skip_unchanged:
             # For some reason the type argument for WithPrevious is not inferred
             # correctly, so we need to specify it explicitly.
-            return key_receiver.filter(
-                WithPrevious[Mapping[str, Any] | InvalidValueForKeyError | None](
+            return receiver.filter(
+                WithPrevious[DataclassT | Exception | None](
                     lambda old, new: _not_equal_with_logging(
                         key=key, old_value=old, new_value=new
                     )
                 )
             )
 
-        return key_receiver
+        return receiver
 
 
 def _not_equal_with_logging(
     *,
     key: str | Sequence[str],
-    old_value: Mapping[str, Any] | InvalidValueForKeyError | None,
-    new_value: Mapping[str, Any] | InvalidValueForKeyError | None,
+    old_value: DataclassT | Exception | None,
+    new_value: DataclassT | Exception | None,
 ) -> bool:
     """Return whether the two mappings are not equal, logging if they are the same."""
     if old_value == new_value:
@@ -232,6 +269,47 @@ def _not_equal_with_logging(
             new_value.value,
         )
     return True
+
+
+def _load_config_with_logging_and_errors(
+    config: Mapping[str, Any],
+    config_class: type[DataclassT],
+    *,
+    key: str | Sequence[str],
+    base_schema: type[Schema] | None = None,
+    marshmallow_load_kwargs: dict[str, Any] | None = None,
+) -> DataclassT | Exception | None:
+    """Load the configuration for the specified key, logging errors and returning them."""
+    try:
+        sub_config = _get_key(config, key)
+        if sub_config is None:
+            _logger.debug("Configuration key %r not found, sending None", key)
+            return None
+
+        loaded_config = load_config(
+            config_class,
+            sub_config,
+            base_schema=base_schema,
+            marshmallow_load_kwargs=marshmallow_load_kwargs,
+        )
+        _logger.debug("Received new configuration: %s", loaded_config)
+        return loaded_config
+    except InvalidValueForKeyError as error:
+        if len(key) > 1 and key != error.key:
+            _logger.error("Error when looking for sub-key %r: %s", key, error)
+        else:
+            _logger.error(str(error))
+        return error
+    except ValidationError as error:
+        _logger.error("The configuration for key %r is invalid: %s", key, error)
+        return error
+    except Exception as error:  # pylint: disable=broad-except
+        _logger.exception(
+            "An unexpected error occurred while loading the configuration for key %r: %s",
+            key,
+            error,
+        )
+        return error
 
 
 def _get_key(

--- a/src/frequenz/sdk/config/_manager.py
+++ b/src/frequenz/sdk/config/_manager.py
@@ -1,0 +1,118 @@
+# License: MIT
+# Copyright © 2024 Frequenz Energy-as-a-Service GmbH
+
+"""Management of configuration."""
+
+import pathlib
+from collections.abc import Mapping, Sequence
+from datetime import timedelta
+from typing import Any, Final
+
+from frequenz.channels import Broadcast, Receiver
+from typing_extensions import override
+
+from ..actor._background_service import BackgroundService
+from ._managing_actor import ConfigManagingActor
+
+
+class ConfigManager(BackgroundService):
+    """A manager for configuration files.
+
+    This class reads configuration files and sends the configuration to the receivers,
+    providing optional configuration key filtering and schema validation.
+    """
+
+    def __init__(  # pylint: disable=too-many-arguments
+        self,
+        config_paths: Sequence[pathlib.Path],
+        /,
+        *,
+        force_polling: bool = True,
+        name: str | None = None,
+        polling_interval: timedelta = timedelta(seconds=1),
+    ) -> None:
+        """Initialize this config manager.
+
+        Args:
+            config_paths: The paths to the TOML files with the configuration. Order
+                matters, as the configuration will be read and updated in the order
+                of the paths, so the last path will override the configuration set by
+                the previous paths. Dict keys will be merged recursively, but other
+                objects (like lists) will be replaced by the value in the last path.
+            force_polling: Whether to force file polling to check for changes.
+            name: A name to use when creating actors. If `None`, `str(id(self))` will
+                be used. This is used mostly for debugging purposes.
+            polling_interval: The interval to poll for changes. Only relevant if
+                polling is enabled.
+        """
+        super().__init__(name=name)
+
+        self.config_channel: Final[Broadcast[Mapping[str, Any]]] = Broadcast(
+            name=f"{self}_config", resend_latest=True
+        )
+        """The broadcast channel for the configuration."""
+
+        self.actor: Final[ConfigManagingActor] = ConfigManagingActor(
+            config_paths,
+            self.config_channel.new_sender(),
+            name=self.name,
+            force_polling=force_polling,
+            polling_interval=polling_interval,
+        )
+        """The actor that manages the configuration."""
+
+    @override
+    def start(self) -> None:
+        """Start this config manager."""
+        self.actor.start()
+
+    @property
+    @override
+    def is_running(self) -> bool:
+        """Whether this config manager is running."""
+        return self.actor.is_running
+
+    @override
+    def cancel(self, msg: str | None = None) -> None:
+        """Cancel all running tasks and actors spawned by this config manager.
+
+        Args:
+            msg: The message to be passed to the tasks being cancelled.
+        """
+        self.actor.cancel(msg)
+
+    # We need the noqa because the `BaseExceptionGroup` is raised indirectly.
+    @override
+    async def wait(self) -> None:  # noqa: DOC502
+        """Wait this config manager to finish.
+
+        Wait until all tasks and actors are finished.
+
+        Raises:
+            BaseExceptionGroup: If any of the tasks spawned by this service raised an
+                exception (`CancelError` is not considered an error and not returned in
+                the exception group).
+        """
+        await self.actor
+
+    @override
+    def __repr__(self) -> str:
+        """Return a string representation of this config manager."""
+        return f"config_channel={self.config_channel!r}, " f"actor={self.actor!r}>"
+
+    async def new_receiver(self) -> Receiver[Mapping[str, Any] | None]:
+        """Create a new receiver for the configuration.
+
+        Note:
+            If there is a burst of configuration updates, the receiver will only
+            receive the last configuration, older configurations will be ignored.
+
+        Example:
+            ```python
+            # TODO: Add Example
+            ```
+
+        Returns:
+            The receiver for the configuration.
+        """
+        return self.config_channel.new_receiver(name=str(self), limit=1)

--- a/src/frequenz/sdk/config/_manager.py
+++ b/src/frequenz/sdk/config/_manager.py
@@ -16,6 +16,7 @@ from marshmallow import Schema, ValidationError
 from typing_extensions import override
 
 from ..actor._background_service import BackgroundService
+from ._base_schema import BaseConfigSchema
 from ._managing_actor import ConfigManagingActor
 from ._util import DataclassT, load_config
 
@@ -139,7 +140,7 @@ class ConfigManager(BackgroundService):
         /,
         *,
         skip_unchanged: bool = True,
-        base_schema: type[Schema] | None = None,
+        base_schema: type[Schema] | None = BaseConfigSchema,
         marshmallow_load_kwargs: dict[str, Any] | None = None,
     ) -> Receiver[DataclassT | Exception | None]:
         """Create a new receiver for receiving the configuration for a particular key.
@@ -387,7 +388,7 @@ def _load_config(
     config_class: type[DataclassT],
     *,
     key: str | Sequence[str],
-    base_schema: type[Schema] | None = None,
+    base_schema: type[Schema] | None = BaseConfigSchema,
     marshmallow_load_kwargs: dict[str, Any] | None = None,
 ) -> DataclassT | InvalidValueForKeyError | ValidationError | None:
     """Try to load a configuration and log any validation errors."""

--- a/src/frequenz/sdk/config/_manager.py
+++ b/src/frequenz/sdk/config/_manager.py
@@ -54,7 +54,7 @@ class ConfigManager(BackgroundService):
 
     def __init__(  # pylint: disable=too-many-arguments
         self,
-        config_paths: Sequence[pathlib.Path],
+        config_paths: str | pathlib.Path | Sequence[pathlib.Path | str],
         /,
         *,
         force_polling: bool = True,

--- a/src/frequenz/sdk/config/_manager.py
+++ b/src/frequenz/sdk/config/_manager.py
@@ -49,7 +49,10 @@ class ConfigManager(BackgroundService):
     """A manager for configuration files.
 
     This class reads configuration files and sends the configuration to the receivers,
-    providing optional configuration key filtering and schema validation.
+    providing configuration key filtering and value validation.
+
+    For a more in-depth introduction and examples, please read the [module
+    documentation][frequenz.sdk.config].
     """
 
     def __init__(  # pylint: disable=too-many-arguments
@@ -85,7 +88,12 @@ class ConfigManager(BackgroundService):
         self.config_channel: Final[Broadcast[Mapping[str, Any]]] = Broadcast(
             name=f"{self}_config", resend_latest=True
         )
-        """The broadcast channel for the configuration."""
+        """The channel used for sending configuration updates (resends the latest value).
+
+        This is the channel used to communicate with the
+        [`ConfigManagingActor`][frequenz.sdk.config.ConfigManager.config_actor] and will
+        receive the complete raw configuration as a mapping.
+        """
 
         self.config_actor: Final[ConfigManagingActor] = ConfigManagingActor(
             config_paths,
@@ -94,7 +102,7 @@ class ConfigManager(BackgroundService):
             force_polling=force_polling,
             polling_interval=polling_interval,
         )
-        """The actor that manages the configuration."""
+        """The actor that manages the configuration for this manager."""
 
         # pylint: disable-next=import-outside-toplevel,cyclic-import
         from ._logging_actor import LoggingConfigUpdatingActor
@@ -106,6 +114,7 @@ class ConfigManager(BackgroundService):
                 self, config_key=logging_config_key, name=self.name
             )
         )
+        """The actor that manages the logging configuration for this manager."""
 
     @override
     def start(self) -> None:
@@ -196,68 +205,8 @@ class ConfigManager(BackgroundService):
         receiver, you can create a receiver directly using
         [`config_channel.new_receiver()`][frequenz.sdk.config.ConfigManager.config_channel].
 
-        ### Filtering
-
-        Only the configuration under the `key` will be received by the receiver. If the
-        `key` is not found in the configuration, the receiver will receive `None`.
-
-        If the key is a sequence of strings, it will be treated as a nested key and the
-        receiver will receive the configuration under the nested key. For example
-        `["key", "subkey"]` will get only `config["key"]["subkey"]`.
-
-        The value under `key` must be another mapping, otherwise an error
-        will be logged and a [`frequenz.sdk.config.InvalidValueForKeyError`][] instance
-        will be sent to the receiver.
-
-        ### Schema validation
-
-        The raw configuration received as a `Mapping` will be validated and loaded to
-        as a `config_class`. The `config_class` class is expected to be
-        a [`dataclasses.dataclass`][], which is used to create
-        a [`marshmallow.Schema`][] via the [`marshmallow_dataclass.class_schema`][]
-        function.
-
-        This means you can customize the schema derived from the configuration
-        dataclass using [`marshmallow_dataclass`][] to specify extra validation and
-        options via field metadata.
-
-        Additional arguments can be passed to [`marshmallow.Schema.load`][] using
-        the `marshmallow_load_kwargs` keyword arguments.
-
-        If unspecified, the `marshmallow_load_kwargs` will have the `unknown` key set to
-        [`marshmallow.EXCLUDE`][] (instead of the normal [`marshmallow.RAISE`][]
-        default).
-
-        But when [`marshmallow.EXCLUDE`][] is used, a warning will still be logged if
-        there are extra fields in the configuration that are excluded. This is useful,
-        for example, to catch typos in the configuration file.
-
-        ### Skipping superfluous updates
-
-        If there is a burst of configuration updates, the receiver will only receive the
-        last configuration, older configurations will be ignored.
-
-        If `skip_unchanged` is set to `True`, then a configuration that didn't change
-        compared to the last one received will be ignored and not sent to the receiver.
-        The comparison is done using the *raw* `dict` to determine if the configuration
-        has changed.
-
-        ### Error handling
-
-        The value under `key` must be another mapping, otherwise an error
-        will be logged and a [`frequenz.sdk.config.InvalidValueForKeyError`][] instance
-        will be sent to the receiver.
-
-        Configurations that don't pass the validation will be logged as an error and
-        the [`ValidationError`][marshmallow.ValidationError] sent to the receiver.
-
-        Any other unexpected error raised during the configuration loading will be
-        logged as an error and the error instance sent to the receiver.
-
-        Example:
-            ```python
-            # TODO: Add Example
-            ```
+        For a more in-depth introduction and examples, please read the [module
+        documentation][frequenz.sdk.config].
 
         Args:
             key: The configuration key to be read by the receiver. If a sequence of
@@ -345,7 +294,10 @@ async def wait_for_first(
     allow_none: bool = False,
     timeout: timedelta = timedelta(minutes=1),
 ) -> DataclassT | None:
-    """Receive the first configuration.
+    """Wait for and receive the the first configuration.
+
+    For a more in-depth introduction and examples, please read the [module
+    documentation][frequenz.sdk.config].
 
     Args:
         receiver: The receiver to receive the first configuration from.

--- a/src/frequenz/sdk/config/_managing_actor.py
+++ b/src/frequenz/sdk/config/_managing_actor.py
@@ -117,24 +117,26 @@ class ConfigManagingActor(Actor):
         config: dict[str, Any] = {}
 
         for config_path in self._config_paths:
-            _logger.info("%s: Reading configuration file %s...", self, config_path)
+            _logger.info(
+                "[%s] Reading configuration file %r...", self.name, str(config_path)
+            )
             try:
                 with config_path.open("rb") as toml_file:
                     data = tomllib.load(toml_file)
                     _logger.info(
-                        "%s: Configuration file %r read successfully.",
-                        self,
+                        "[%s] Configuration file %r read successfully.",
+                        self.name,
                         str(config_path),
                     )
                     config = _recursive_update(config, data)
             except ValueError as err:
-                _logger.error("%s: Can't read config file, err: %s", self, err)
+                _logger.error("[%s] Can't read config file, err: %s", self.name, err)
                 error_count += 1
             except OSError as err:
                 # It is ok for config file to don't exist.
                 _logger.error(
-                    "%s: Error reading config file %r (%s). Ignoring it.",
-                    self,
+                    "[%s] Error reading config file %r (%s). Ignoring it.",
+                    self.name,
                     str(config_path),
                     err,
                 )
@@ -142,13 +144,13 @@ class ConfigManagingActor(Actor):
 
         if error_count == len(self._config_paths):
             _logger.error(
-                "%s: Can't read any of the config files, ignoring config update.", self
+                "[%s] Can't read any of the config files, ignoring config update.", self
             )
             return None
 
         _logger.info(
-            "%s: Read %s/%s configuration files successfully.",
-            self,
+            "[%s] Read %s/%s configuration files successfully.",
+            self.name,
             len(self._config_paths) - error_count,
             len(self._config_paths),
         )
@@ -185,8 +187,8 @@ class ConfigManagingActor(Actor):
             async for event in file_watcher:
                 if not event.path.exists():
                     _logger.error(
-                        "%s: Received event %s, but the watched path %s doesn't exist.",
-                        self,
+                        "[%s] Received event %s, but the watched path %s doesn't exist.",
+                        self.name,
                         event,
                         event.path,
                     )
@@ -207,23 +209,23 @@ class ConfigManagingActor(Actor):
                 match event.type:
                     case EventType.CREATE:
                         _logger.info(
-                            "%s: The configuration file %s was created, sending new config...",
-                            self,
+                            "[%s] The configuration file %s was created, sending new config...",
+                            self.name,
                             event.path,
                         )
                         await self.send_config()
                     case EventType.MODIFY:
                         _logger.info(
-                            "%s: The configuration file %s was modified, sending update...",
-                            self,
+                            "[%s] The configuration file %s was modified, sending update...",
+                            self.name,
                             event.path,
                         )
                         await self.send_config()
                     case EventType.DELETE:
                         _logger.error(
-                            "%s: Unexpected DELETE event for path %s. Please report this "
+                            "[%s] Unexpected DELETE event for path %s. Please report this "
                             "issue to Frequenz.",
-                            self,
+                            self.name,
                             event.path,
                         )
                     case _:

--- a/tests/config/test_logging_actor.py
+++ b/tests/config/test_logging_actor.py
@@ -5,7 +5,6 @@
 
 import asyncio
 import logging
-from collections.abc import Mapping
 from typing import Any
 
 import pytest
@@ -77,78 +76,69 @@ async def test_logging_config_updating_actor(
     # is not working anyway - python ignores it.
     mocker.patch("frequenz.sdk.config._logging_actor.logging.basicConfig")
 
-    config_channel = Broadcast[Mapping[str, Any]](name="config")
-    config_sender = config_channel.new_sender()
-    async with LoggingConfigUpdatingActor(
-        config_recv=config_channel.new_receiver().map(
-            lambda app_config: app_config.get("logging", {})
-        )
-    ) as actor:
+    # Mock ConfigManager
+    mock_config_manager = mocker.Mock()
+    mock_config_manager.config_channel = Broadcast[LoggingConfig | Exception | None](
+        name="config"
+    )
+    mock_config_manager.new_receiver = mocker.Mock(
+        return_value=mock_config_manager.config_channel.new_receiver()
+    )
+
+    async with LoggingConfigUpdatingActor(mock_config_manager) as actor:
         assert logging.getLogger("frequenz.sdk.actor").level == logging.NOTSET
         assert logging.getLogger("frequenz.sdk.timeseries").level == logging.NOTSET
 
         update_logging_spy = mocker.spy(actor, "_update_logging")
 
         # Send first config
-        await config_sender.send(
-            {
-                "logging": {
-                    "root_logger": {"level": "ERROR"},
-                    "loggers": {
-                        "frequenz.sdk.actor": {"level": "DEBUG"},
-                        "frequenz.sdk.timeseries": {"level": "ERROR"},
-                    },
-                }
-            }
+        expected_config = LoggingConfig(
+            root_logger=LoggerConfig(level="ERROR"),
+            loggers={
+                "frequenz.sdk.actor": LoggerConfig(level="DEBUG"),
+                "frequenz.sdk.timeseries": LoggerConfig(level="ERROR"),
+            },
         )
+        await mock_config_manager.config_channel.new_sender().send(expected_config)
         await asyncio.sleep(0.01)
-        update_logging_spy.assert_called_once_with(
-            LoggingConfig(
-                root_logger=LoggerConfig(level="ERROR"),
-                loggers={
-                    "frequenz.sdk.actor": LoggerConfig(level="DEBUG"),
-                    "frequenz.sdk.timeseries": LoggerConfig(level="ERROR"),
-                },
-            )
-        )
+        update_logging_spy.assert_called_once_with(expected_config)
         assert logging.getLogger("frequenz.sdk.actor").level == logging.DEBUG
         assert logging.getLogger("frequenz.sdk.timeseries").level == logging.ERROR
         update_logging_spy.reset_mock()
 
-        # Update config
-        await config_sender.send(
-            {
-                "logging": {
-                    "root_logger": {"level": "WARNING"},
-                    "loggers": {
-                        "frequenz.sdk.actor": {"level": "INFO"},
-                    },
-                }
-            }
+        # Send an exception and verify the previous config is maintained
+        await mock_config_manager.config_channel.new_sender().send(
+            ValueError("Test error")
         )
         await asyncio.sleep(0.01)
+        update_logging_spy.assert_not_called()  # Should not try to update logging
+        # Previous config should be maintained
+        assert logging.getLogger("frequenz.sdk.actor").level == logging.DEBUG
+        assert logging.getLogger("frequenz.sdk.timeseries").level == logging.ERROR
+        assert (
+            actor._current_config == expected_config  # pylint: disable=protected-access
+        )  # pylint: disable=protected-access
+        update_logging_spy.reset_mock()
+
+        # Update config
         expected_config = LoggingConfig(
             root_logger=LoggerConfig(level="WARNING"),
             loggers={
                 "frequenz.sdk.actor": LoggerConfig(level="INFO"),
             },
         )
+        await mock_config_manager.config_channel.new_sender().send(expected_config)
+        await asyncio.sleep(0.01)
         update_logging_spy.assert_called_once_with(expected_config)
         assert logging.getLogger("frequenz.sdk.actor").level == logging.INFO
         assert logging.getLogger("frequenz.sdk.timeseries").level == logging.NOTSET
         update_logging_spy.reset_mock()
 
-        # Send invalid config to make sure actor doesn't crash and doesn't setup invalid config.
-        await config_sender.send({"logging": {"root_logger": {"level": "UNKNOWN"}}})
-        await asyncio.sleep(0.01)
-        update_logging_spy.assert_not_called()
-        assert actor._current_config == expected_config
-        update_logging_spy.reset_mock()
-
-        # Send empty config to reset logging to default
-        await config_sender.send({"other": {"var1": 1}})
+        # Send a None config to make sure actor doesn't crash and configures a default logging
+        await mock_config_manager.config_channel.new_sender().send(None)
         await asyncio.sleep(0.01)
         update_logging_spy.assert_called_once_with(LoggingConfig())
-        assert logging.getLogger("frequenz.sdk.actor").level == logging.NOTSET
-        assert logging.getLogger("frequenz.sdk.timeseries").level == logging.NOTSET
+        assert (
+            actor._current_config == LoggingConfig()  # pylint: disable=protected-access
+        )
         update_logging_spy.reset_mock()

--- a/tests/config/test_manager.py
+++ b/tests/config/test_manager.py
@@ -1,0 +1,462 @@
+# License: MIT
+# Copyright © 2024 Frequenz Energy-as-a-Service GmbH
+
+"""Tests for the config manager module."""
+
+
+import asyncio
+import dataclasses
+import logging
+import pathlib
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from datetime import timedelta
+from typing import Any, assert_never
+
+import marshmallow
+import pytest
+import pytest_mock
+
+from frequenz.sdk.config import ConfigManager, InvalidValueForKeyError, wait_for_first
+from frequenz.sdk.config._manager import _get_key
+
+
+@dataclass
+class SimpleConfig:
+    """A simple configuration class for testing."""
+
+    name: str = dataclasses.field(metadata={"validate": lambda s: s.startswith("test")})
+    value: int
+
+
+@dataclass(frozen=True, kw_only=True)
+class ReceiverTestCase:
+    """A test case for testing new_receiver configurations."""
+
+    title: str
+    key: str | tuple[str, ...]
+    config_class: type[SimpleConfig]
+    input_config: dict[str, Any]
+    expected_output: Any | None
+    base_schema: type[marshmallow.Schema] | None = None
+    marshmallow_load_kwargs: dict[str, Any] | None = None
+
+
+# Test cases for new_receiver
+receiver_test_cases = [
+    ReceiverTestCase(
+        title="Basic Config",
+        key="test",
+        config_class=SimpleConfig,
+        input_config={"test": {"name": "test1", "value": 42}},
+        expected_output=SimpleConfig(name="test1", value=42),
+    ),
+    ReceiverTestCase(
+        title="Nested Key Config",
+        key=("nested", "config"),
+        config_class=SimpleConfig,
+        input_config={"nested": {"config": {"name": "test2", "value": 43}}},
+        expected_output=SimpleConfig(name="test2", value=43),
+    ),
+    ReceiverTestCase(
+        title="Validation Error",
+        key="test",
+        config_class=SimpleConfig,
+        input_config={"test": {"name": "no-test1", "value": 42}},
+        expected_output="{'name': ['Invalid value.']}",
+    ),
+    ReceiverTestCase(
+        title="Invalid Value Type",
+        key="test",
+        config_class=SimpleConfig,
+        input_config={"test": "not a mapping"},
+        expected_output="Value for key ['test'] is not a mapping: 'not a mapping'",
+    ),
+    ReceiverTestCase(
+        title="Raise on unknown",
+        key="test",
+        config_class=SimpleConfig,
+        marshmallow_load_kwargs={"unknown": marshmallow.RAISE},
+        input_config={"test": {"name": "test3", "value": 44, "not_allowed": 42}},
+        expected_output="{'not_allowed': ['Unknown field.']}",
+    ),
+    ReceiverTestCase(
+        title="Missing Key",
+        key="missing",
+        config_class=SimpleConfig,
+        input_config={"test": {"name": "test3", "value": 44}},
+        expected_output=None,
+    ),
+]
+
+
+@pytest.mark.parametrize("test_case", receiver_test_cases, ids=lambda tc: tc.title)
+async def test_new_receiver_configurations(
+    test_case: ReceiverTestCase, mocker: pytest_mock.MockFixture
+) -> None:
+    """Test different configurations for new_receiver."""
+    mocker.patch("frequenz.sdk.config._manager.ConfigManagingActor")
+    config_manager = ConfigManager([pathlib.Path("dummy.toml")])
+    await config_manager.config_channel.new_sender().send(test_case.input_config)
+    receiver = config_manager.new_receiver(
+        test_case.key,
+        test_case.config_class,
+        base_schema=test_case.base_schema,
+        marshmallow_load_kwargs=test_case.marshmallow_load_kwargs,
+    )
+
+    async with asyncio.timeout(1):
+        result = await receiver.receive()
+    match result:
+        case SimpleConfig() | None:
+            assert result == test_case.expected_output
+        case Exception():
+            assert str(result) == str(test_case.expected_output)
+        case unexpected:
+            assert_never(unexpected)
+
+
+async def test_warn_on_unknown_key(
+    mocker: pytest_mock.MockerFixture, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test that a warning is logged when an unknown key is received."""
+    mocker.patch("frequenz.sdk.config._manager.ConfigManagingActor")
+    config_manager = ConfigManager([pathlib.Path("dummy.toml")])
+    await config_manager.config_channel.new_sender().send(
+        {"test": {"name": "test3", "value": 44, "not_allowed": 42}}
+    )
+    receiver = config_manager.new_receiver("test", SimpleConfig)
+
+    async with asyncio.timeout(1):
+        await receiver.receive()
+
+    expected_log_entry = (
+        "frequenz.sdk.config._manager",
+        logging.WARNING,
+        "The configuration for key 'test' has extra fields that will be ignored: "
+        "{'not_allowed': ['Unknown field.']}",
+    )
+    assert expected_log_entry in caplog.record_tuples
+
+
+async def test_skip_config_update_bursts(mocker: pytest_mock.MockerFixture) -> None:
+    """Test that a burst of updates will only send the last update."""
+    mocker.patch("frequenz.sdk.config._manager.ConfigManagingActor")
+    config_manager = ConfigManager([pathlib.Path("dummy.toml")])
+    sender = config_manager.config_channel.new_sender()
+    receiver = config_manager.new_receiver(
+        "test",
+        SimpleConfig,
+        skip_unchanged=True,
+    )
+
+    await sender.send({"test": {"name": "test1", "value": 42}})
+    await sender.send({"test": {"name": "test2", "value": 43}})
+    await sender.send({"test": {"name": "test3", "value": 44}})
+
+    # Should only receive one orig_config and then the changed_config
+    async with asyncio.timeout(1):
+        result = await receiver.receive()
+    assert result == SimpleConfig(name="test3", value=44)
+
+    # There should be no more messages
+    with pytest.raises(asyncio.TimeoutError):
+        async with asyncio.timeout(0.1):
+            await receiver.receive()
+
+
+async def test_skip_unchanged_config(mocker: pytest_mock.MockerFixture) -> None:
+    """Test that unchanged configurations are skipped when skip_unchanged is True."""
+    mocker.patch("frequenz.sdk.config._manager.ConfigManagingActor")
+    config_manager = ConfigManager([pathlib.Path("dummy.toml")])
+    sender = config_manager.config_channel.new_sender()
+    receiver = config_manager.new_receiver(
+        "test",
+        SimpleConfig,
+        skip_unchanged=True,
+    )
+
+    # A first config should be received
+    orig_config = {"test": {"name": "test1", "value": 42}}
+    await sender.send(orig_config)
+    async with asyncio.timeout(1):
+        result = await receiver.receive()
+    assert result == SimpleConfig(name="test1", value=42)
+
+    # An unchanged config should be skipped (no message received)
+    await sender.send(orig_config)
+    with pytest.raises(asyncio.TimeoutError):
+        async with asyncio.timeout(0.1):
+            await receiver.receive()
+
+    # A changed config should be received
+    changed_config = {"test": {"name": "test2", "value": 43}}
+    await sender.send(changed_config)
+    async with asyncio.timeout(1):
+        result = await receiver.receive()
+    assert result == SimpleConfig(name="test2", value=43)
+
+    # There should be no more messages
+    with pytest.raises(asyncio.TimeoutError):
+        async with asyncio.timeout(0.1):
+            await receiver.receive()
+
+
+async def test_wait_for_first(mocker: pytest_mock.MockerFixture) -> None:
+    """Test wait_for_first function."""
+    mocker.patch("frequenz.sdk.config._manager.ConfigManagingActor")
+    config_manager = ConfigManager([pathlib.Path("dummy.toml")])
+
+    receiver = config_manager.new_receiver(
+        "test",
+        SimpleConfig,
+    )
+
+    async with asyncio.timeout(0.2):
+        with pytest.raises(asyncio.TimeoutError):
+            await wait_for_first(receiver, timeout=timedelta(seconds=0.1))
+
+    # Test successful wait
+    await config_manager.config_channel.new_sender().send(
+        {"test": {"name": "test1", "value": 42}}
+    )
+    async with asyncio.timeout(0.2):
+        result = await wait_for_first(receiver, timeout=timedelta(seconds=0.1))
+    assert result == SimpleConfig(name="test1", value=42)
+
+
+def test_unknown_include_not_supported() -> None:
+    """Test that unknown marshmallow load kwargs are not supported."""
+    with pytest.raises(ValueError):
+        ConfigManager([pathlib.Path("dummy.toml")]).new_receiver(
+            "test",
+            SimpleConfig,
+            marshmallow_load_kwargs={"unknown": marshmallow.INCLUDE},
+        )
+
+
+@pytest.mark.integration
+class TestConfigManagerIntegration:
+    """Integration tests for ConfigManager."""
+
+    @pytest.fixture
+    def config_file(self, tmp_path: pathlib.Path) -> pathlib.Path:
+        """Create a temporary config file for testing."""
+        config_file = tmp_path / "config.toml"
+        config_file.write_text(
+            """
+            [test]
+            name = "test1"
+            value = 42
+
+            [logging.loggers.test]
+            level = "DEBUG"
+            """
+        )
+        return config_file
+
+    async def test_full_config_flow(self, config_file: pathlib.Path) -> None:
+        """Test the complete flow of configuration management."""
+        async with (
+            # Disabling force_polling is a hack because of a bug in watchfiles not
+            # detecting sub-second changes when using polling.
+            ConfigManager([config_file], force_polling=False) as config_manager,
+            asyncio.timeout(1),
+        ):
+            receiver = config_manager.new_receiver("test", SimpleConfig)
+            first_config = await wait_for_first(receiver)
+            assert first_config == SimpleConfig(name="test1", value=42)
+            assert logging.getLogger("test").level == logging.DEBUG
+
+            # Update config file
+            config_file.write_text(
+                """
+                [test]
+                name = "test2"
+                value = 43
+
+                [logging.loggers.test]
+                level = "INFO"
+                """
+            )
+
+            # Check updated config
+            config = await receiver.receive()
+            assert config == SimpleConfig(name="test2", value=43)
+
+            # Check updated logging config
+            assert logging.getLogger("test").level == logging.INFO
+
+    async def test_full_config_flow_without_logging(
+        self, config_file: pathlib.Path
+    ) -> None:
+        """Test the complete flow of configuration management without logging."""
+        logging.getLogger("test").setLevel(logging.WARNING)
+        async with (
+            # Disabling force_polling is a hack because of a bug in watchfiles not
+            # detecting sub-second changes when using polling.
+            ConfigManager(
+                [config_file], logging_config_key=None, force_polling=False
+            ) as config_manager,
+            asyncio.timeout(1),
+        ):
+            receiver = config_manager.new_receiver("test", SimpleConfig)
+            first_config = await wait_for_first(receiver)
+            assert first_config == SimpleConfig(name="test1", value=42)
+            assert logging.getLogger("test").level == logging.WARNING
+
+            # Update config file
+            config_file.write_text(
+                """
+                [test]
+                name = "test2"
+                value = 43
+
+                [logging.loggers.test]
+                level = "DEBUG"
+                """
+            )
+
+            # Check updated config
+            config = await receiver.receive()
+            assert config == SimpleConfig(name="test2", value=43)
+
+            # Check updated logging config
+            assert logging.getLogger("test").level == logging.WARNING
+
+
+@dataclass(frozen=True)
+class GetKeyTestCase:
+    """Test case for _get_key function."""
+
+    title: str
+    config: dict[str, Any]
+    key: str | Sequence[str]
+    expected_result: Mapping[str, Any] | None | type[InvalidValueForKeyError]
+    expected_error_key: list[str] | None = None
+    expected_error_value: Any | None = None
+
+
+_get_key_test_cases = [
+    # Simple string key tests
+    GetKeyTestCase(
+        title="Simple string key - exists",
+        config={"a": {"b": 1}},
+        key="a",
+        expected_result={"b": 1},
+    ),
+    GetKeyTestCase(
+        title="Simple string key - doesn't exist",
+        config={"a": {"b": 1}},
+        key="x",
+        expected_result=None,
+    ),
+    GetKeyTestCase(
+        title="Simple string key - invalid value type",
+        config={"a": 42},
+        key="a",
+        expected_result=InvalidValueForKeyError,
+        expected_error_key=["a"],
+        expected_error_value=42,
+    ),
+    # Sequence key tests
+    GetKeyTestCase(
+        title="Sequence key - all exist",
+        config={"a": {"b": {"c": {"d": 1}}}},
+        key=["a", "b", "c"],
+        expected_result={"d": 1},
+    ),
+    GetKeyTestCase(
+        title="Sequence key - middle doesn't exist",
+        config={"a": {"b": {"c": 1}}},
+        key=["a", "x", "c"],
+        expected_result=None,
+    ),
+    GetKeyTestCase(
+        title="Sequence key - invalid value in middle",
+        config={"a": {"b": 42, "c": 1}},
+        key=["a", "b", "c"],
+        expected_result=InvalidValueForKeyError,
+        expected_error_key=["a", "b"],
+        expected_error_value=42,
+    ),
+    GetKeyTestCase(
+        title="Empty sequence key",
+        config={"a": 1},
+        key=[],
+        expected_result={"a": 1},
+    ),
+    # Empty string tests
+    GetKeyTestCase(
+        title="Empty string key",
+        config={"": {"a": 1}},
+        key="",
+        expected_result={"a": 1},
+    ),
+    GetKeyTestCase(
+        title="Empty string in sequence",
+        config={"": {"": {"a": 1}}},
+        key=["", ""],
+        expected_result={"a": 1},
+    ),
+    # None value tests
+    GetKeyTestCase(
+        title="Value is None",
+        config={"a": None},
+        key="a",
+        expected_result=None,
+    ),
+    GetKeyTestCase(
+        title="Nested None value",
+        config={"a": {"b": None}},
+        key=["a", "b", "c"],
+        expected_result=None,
+    ),
+    # Special string key tests to verify string handling
+    GetKeyTestCase(
+        title="String that looks like a sequence",
+        config={"key": {"e": 1}},
+        key="key",
+        expected_result={"e": 1},
+    ),
+    GetKeyTestCase(
+        title="String with special characters",
+        config={"a.b": {"c": 1}},
+        key="a.b",
+        expected_result={"c": 1},
+    ),
+    # Nested mapping tests
+    GetKeyTestCase(
+        title="Deeply nested valid path",
+        config={"a": {"b": {"c": {"d": {"e": {"f": 1}}}}}},
+        key=["a", "b", "c", "d", "e"],
+        expected_result={"f": 1},
+    ),
+    GetKeyTestCase(
+        title="Mixed type nested invalid",
+        config={"a": {"b": [1, 2, 3]}},
+        key=["a", "b"],
+        expected_result=InvalidValueForKeyError,
+        expected_error_key=["a", "b"],
+        expected_error_value=[1, 2, 3],
+    ),
+]
+
+
+@pytest.mark.parametrize("test_case", _get_key_test_cases, ids=lambda tc: tc.title)
+def test_get_key(test_case: GetKeyTestCase) -> None:
+    """Test the _get_key function with various inputs.
+
+    Args:
+        test_case: The test case to run.
+    """
+    if test_case.expected_result is InvalidValueForKeyError:
+        with pytest.raises(InvalidValueForKeyError) as exc_info:
+            _get_key(test_case.config, test_case.key)
+
+        # Verify the error details
+        assert exc_info.value.key == test_case.expected_error_key
+        assert exc_info.value.value == test_case.expected_error_value
+    else:
+        result = _get_key(test_case.config, test_case.key)
+        assert result == test_case.expected_result


### PR DESCRIPTION
This pull request adds a new `ConfigManager` class that takes care of the *client-side* of the `ConfigManagingActor`, providing the common tasks users of the config system need to do.

The class owns the config channel and provides a convenient method to get new receivers that validate the configuration using a `dataclass` as a `marshmallow` schema, and allow filtering to receive only configuration for a specific key. The receiver also reports errors when the configuration can't be properly loaded, and avoid spurious updates when the configuration didn't change compared to the previous one.

The manager also takes care of instantiating both the `ConfigManagingActor` and the `LoggingConfigUpdatingActor` and provides a utility function to wait for the first configuration to be received.
