### PR TITLE
Don't allow checking if `None` is within the bounds

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -198,7 +198,7 @@ jobs:
       # This ensures that the runner has access to the pip cache.
       - name: Reset pip cache ownership
         if: always()
-        run: sudo chown -R $USER:$USER /tmp/pip-cache
+        run: if [[ -e /tmp/pip-cache ]]; then sudo chown -R $USER:$USER /tmp/pip-cache; fi
 
   # This job runs if all the `nox-cross-arch` matrix jobs ran and succeeded.
   # As the `nox-all` job, its main purpose is to provide a single point of

--- a/src/frequenz/sdk/timeseries/_base_types.py
+++ b/src/frequenz/sdk/timeseries/_base_types.py
@@ -165,7 +165,13 @@ _T = TypeVar("_T", bound=Comparable | None)
 
 @dataclass(frozen=True)
 class Bounds(Generic[_T]):
-    """Lower and upper bound values."""
+    """Lower and upper bound values.
+
+    Depending on the genertic type `_T`, the lower and upper bounds can be `None`, in
+    which case it means that there is no lower or upper bound, respectively.
+
+    When checking if an item is within the bounds, the item must always be not `None`.
+    """
 
     lower: _T
     """Lower bound."""
@@ -178,11 +184,12 @@ class Bounds(Generic[_T]):
         Check if the value is within the range of the container.
 
         Args:
-            item: The value to check.
+            item: The value to check. Can't be `None` even if `_T` can be `None`.
 
         Returns:
             bool: True if value is within the range, otherwise False.
         """
+        assert item is not None, "Can't check if `None` is within the bounds."
         if self.lower is None and self.upper is None:
             return True
         if self.lower is None:


### PR DESCRIPTION
This was never supported, a `ValueError` would be raised if `None` was passed to `__contains__`. Now we assert to make it clear that it's not allowed.

In the future we should probably change `Bounds` to always allow `None` as bounds and make `_T` simply bound to `Comparable`, as supporting `None` depending on the generic type makes it very hard to provide correct type hints.
