### PR TITLE
Fix cross-arch CI tests

### DIFF
--- a/.github/containers/nox-cross-arch/arm64-ubuntu-20.04-python.Dockerfile
+++ b/.github/containers/nox-cross-arch/arm64-ubuntu-20.04-python.Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update -y && \
         curl \
         git \
         python${PYTHON_VERSION} \
-        python${PYTHON_VERSION}-distutils && \
+        python${PYTHON_VERSION}-venv && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -198,7 +198,7 @@ jobs:
       # This ensures that the runner has access to the pip cache.
       - name: Reset pip cache ownership
         if: always()
-        run: sudo chown -R $USER:$USER /tmp/pip-cache
+        run: if [[ -e /tmp/pip-cache ]]; then sudo chown -R $USER:$USER /tmp/pip-cache; fi
 
   # This job runs if all the `nox-cross-arch` matrix jobs ran and succeeded.
   # As the `nox-all` job, its main purpose is to provide a single point of


### PR DESCRIPTION
We only need to do this when the cache directory exists, otherwise the step fails with an error.

Also install `python-venv` instead of `python-distutils`, as the `distutils` package was removed in Python 3.12 (and deadsnakes).