### PR TITLE
Remove "Checking battery" log message

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -61,3 +61,5 @@ This release includes a new `ConfigManager` class to simplify managing the confi
 - Fix a bug in `BackgroundService` where it won't try to `self.cancel()` and `await self.wait()` if there are no internal tasks. This prevented to properly implement custom stop logic without having to redefine the `stop()` method too.
 
 - Fix a bug where if a string was passed to the `ConfigManagingActor` it would be interpreted as a sequence of 1 character strings.
+
+- Remove a confusing log message in the power distributing actor.

--- a/src/frequenz/sdk/microgrid/_power_distributing/_component_managers/_battery_manager.py
+++ b/src/frequenz/sdk/microgrid/_power_distributing/_component_managers/_battery_manager.py
@@ -400,7 +400,6 @@ class BatteryManager(ComponentManager):  # pylint: disable=too-many-instance-att
             return Error(request=request, msg="Empty battery IDs in the request")
 
         for battery in request.component_ids:
-            _logger.debug("Checking battery %d", battery)
             if battery not in self._battery_caches:
                 msg = (
                     f"No battery {battery}, available batteries: "


### PR DESCRIPTION
It is not providing any useful information or details about its
context, and it is too noisy.