### PR TITLE
Don't fallback to CHPs

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -15,3 +15,5 @@
 ## Bug Fixes
 
 - Fixed a bug that was preventing power proposals to go through if there once existed some proposals with overlapping component IDs, even if the old proposals have expired.
+
+- Fixed a bug that was causing formulas to fallback to CHPs, when the CHP meters didn't have data.  CHPs are not supported in the data sourcing actor and in the client, so we can't fallback to CHPs.

--- a/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_formula_generator.py
+++ b/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_formula_generator.py
@@ -215,8 +215,7 @@ class FormulaGenerator(ABC, Generic[QuantityT]):
 
         # All fallbacks has to be of the same type and category.
         if (
-            all(graph.is_chp(c) for c in successors)
-            or all(graph.is_pv_inverter(c) for c in successors)
+            all(graph.is_pv_inverter(c) for c in successors)
             or all(graph.is_battery_inverter(c) for c in successors)
             or all(graph.is_ev_charger(c) for c in successors)
         ):


### PR DESCRIPTION
Neither the client nor the data sourcing actor support reading data
from CHPs.  So we can't fallback to CHPs yet.