### PR TITLE
Avoid creating dangling `MetricFetcher`s

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -15,3 +15,5 @@
 - Fixed a bug that raised `CancelledError` when actor was started with `frequenz.sdk.actor.run` and stopped.
 
 - Stop catching `BaseException` in `frequenz.sdk.actor.run`. Only `CancelledError` and `Exception` are caught now.
+
+- Fix `MetricFetcher` leaks when a requested metric fetcher already existed.

--- a/src/frequenz/sdk/timeseries/formula_engine/_formula_engine.py
+++ b/src/frequenz/sdk/timeseries/formula_engine/_formula_engine.py
@@ -719,15 +719,15 @@ class FormulaBuilder(Generic[QuantityT]):
                 invalid data (e.g. due to a component stop). If None, the data from
                 primary metric fetcher will be used.
         """
-        fetcher = self._metric_fetchers.setdefault(
-            name,
-            MetricFetcher(
+        fetcher = self._metric_fetchers.get(name)
+        if fetcher is None:
+            fetcher = MetricFetcher(
                 name,
                 data_stream,
                 nones_are_zeros=nones_are_zeros,
                 fallback=fallback,
-            ),
-        )
+            )
+            self._metric_fetchers[name] = fetcher
         self._steps.append(fetcher)
 
     def push_constant(self, value: float) -> None:


### PR DESCRIPTION
When using `setdefault()`,  if an object already existed for that key, a `MetricFetcher` will be created anyways, only to be discarded right after it was created.
