### PR TITLE
Don't stop pools

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -14,4 +14,5 @@
 
 ## Bug Fixes
 
-<!-- Here goes notable bug fixes that are worth a special mention or explanation -->
+- Fixes a bug where battery pool metrics would stop for one actor when another actor managing the same components stops its pool.
+

--- a/src/frequenz/sdk/timeseries/battery_pool/_battery_pool.py
+++ b/src/frequenz/sdk/timeseries/battery_pool/_battery_pool.py
@@ -399,4 +399,9 @@ class BatteryPool:
 
     async def stop(self) -> None:
         """Stop all tasks and channels owned by the BatteryPool."""
-        await self._pool_ref_store.stop()
+        # This was closing the pool_ref_store, which is not correct, because those are
+        # shared.
+        #
+        # This method will do until we have a mechanism to track the resources created
+        # through it.  It can also eventually cleanup the pool_ref_store, when it is
+        # holding the last reference to it.

--- a/src/frequenz/sdk/timeseries/ev_charger_pool/_ev_charger_pool.py
+++ b/src/frequenz/sdk/timeseries/ev_charger_pool/_ev_charger_pool.py
@@ -217,7 +217,12 @@ class EVChargerPool:
 
     async def stop(self) -> None:
         """Stop all tasks and channels owned by the EVChargerPool."""
-        await self._pool_ref_store.stop()
+        # This was closing the pool_ref_store, which is not correct, because those are
+        # shared.
+        #
+        # This method will do until we have a mechanism to track the resources created
+        # through it.  It can also eventually cleanup the pool_ref_store, when it is
+        # holding the last reference to it.
 
     @property
     def _system_power_bounds(self) -> ReceiverFetcher[SystemBounds]:

--- a/src/frequenz/sdk/timeseries/pv_pool/_pv_pool.py
+++ b/src/frequenz/sdk/timeseries/pv_pool/_pv_pool.py
@@ -179,7 +179,12 @@ class PVPool:
 
     async def stop(self) -> None:
         """Stop all tasks and channels owned by the PVPool."""
-        await self._pool_ref_store.stop()
+        # This was closing the pool_ref_store, which is not correct, because those are
+        # shared.
+        #
+        # This method will do until we have a mechanism to track the resources created
+        # through it.  It can also eventually cleanup the pool_ref_store, when it is
+        # holding the last reference to it.
 
     @property
     def _system_power_bounds(self) -> ReceiverFetcher[SystemBounds]:


### PR DESCRIPTION
When there are multiple pool instances controlling the same components and one of them stops, that would stop all the pools.

This PR adds an emergency fix to prevent this bug, to buy some time to come up with a better solution.