### PR TITLE
Use `Power` instead of `float` in PowerDistributor's battery manager

### DIFF
--- a/src/frequenz/sdk/microgrid/_power_distributing/_component_managers/_battery_manager.py
+++ b/src/frequenz/sdk/microgrid/_power_distributing/_component_managers/_battery_manager.py
@@ -21,7 +21,6 @@ from frequenz.client.microgrid import (
 from frequenz.quantities import Power
 from typing_extensions import override
 
-from ...._internal._math import is_close_to_zero
 from ... import connection_manager
 from .._component_pool_status_tracker import ComponentPoolStatusTracker
 from .._component_status import BatteryStatusTracker, ComponentPoolStatus
@@ -264,14 +263,12 @@ class BatteryManager(ComponentManager):  # pylint: disable=too-many-instance-att
         Returns:
             Result from the microgrid API.
         """
-        distributed_power_value = (
-            request.power.as_watts() - distribution.remaining_power
-        )
-        battery_distribution: dict[int, float] = {}
+        distributed_power_value = request.power - distribution.remaining_power
+        battery_distribution: dict[int, Power] = {}
         for inverter_id, dist in distribution.distribution.items():
             for battery_id in self._inv_bats_map[inverter_id]:
                 battery_distribution[battery_id] = (
-                    battery_distribution.get(battery_id, 0.0) + dist
+                    battery_distribution.get(battery_id, Power.zero()) + dist
                 )
         _logger.debug(
             "Distributing power %d between the batteries %s",
@@ -288,21 +285,19 @@ class BatteryManager(ComponentManager):  # pylint: disable=too-many-instance-att
             succeed_batteries = set(battery_distribution.keys()) - failed_batteries
             response = PartialFailure(
                 request=request,
-                succeeded_power=Power.from_watts(
-                    distributed_power_value - failed_power
-                ),
+                succeeded_power=distributed_power_value - failed_power,
                 succeeded_components=succeed_batteries,
-                failed_power=Power.from_watts(failed_power),
+                failed_power=failed_power,
                 failed_components=failed_batteries,
-                excess_power=Power.from_watts(distribution.remaining_power),
+                excess_power=distribution.remaining_power,
             )
         else:
             succeed_batteries = set(battery_distribution.keys())
             response = Success(
                 request=request,
-                succeeded_power=Power.from_watts(distributed_power_value),
+                succeeded_power=distributed_power_value,
                 succeeded_components=succeed_batteries,
-                excess_power=Power.from_watts(distribution.remaining_power),
+                excess_power=distribution.remaining_power,
             )
 
         await asyncio.gather(
@@ -346,39 +341,59 @@ class BatteryManager(ComponentManager):  # pylint: disable=too-many-instance-att
         """
         return PowerBounds(
             inclusion_lower=sum(
-                max(
-                    battery.power_bounds.inclusion_lower,
-                    sum(
-                        inverter.active_power_inclusion_lower_bound
-                        for inverter in inverters
-                    ),
-                )
-                for battery, inverters in pairs_data
+                (
+                    max(
+                        battery.power_bounds.inclusion_lower,
+                        Power.from_watts(
+                            sum(
+                                inverter.active_power_inclusion_lower_bound
+                                for inverter in inverters
+                            )
+                        ),
+                    )
+                    for battery, inverters in pairs_data
+                ),
+                start=Power.zero(),
             ),
             inclusion_upper=sum(
-                min(
-                    battery.power_bounds.inclusion_upper,
-                    sum(
-                        inverter.active_power_inclusion_upper_bound
-                        for inverter in inverters
-                    ),
-                )
-                for battery, inverters in pairs_data
+                (
+                    min(
+                        battery.power_bounds.inclusion_upper,
+                        Power.from_watts(
+                            sum(
+                                inverter.active_power_inclusion_upper_bound
+                                for inverter in inverters
+                            )
+                        ),
+                    )
+                    for battery, inverters in pairs_data
+                ),
+                start=Power.zero(),
             ),
             exclusion_lower=min(
-                sum(battery.power_bounds.exclusion_lower for battery, _ in pairs_data),
                 sum(
-                    inverter.active_power_exclusion_lower_bound
-                    for _, inverters in pairs_data
-                    for inverter in inverters
+                    (battery.power_bounds.exclusion_lower for battery, _ in pairs_data),
+                    start=Power.zero(),
+                ),
+                Power.from_watts(
+                    sum(
+                        inverter.active_power_exclusion_lower_bound
+                        for _, inverters in pairs_data
+                        for inverter in inverters
+                    )
                 ),
             ),
             exclusion_upper=max(
-                sum(battery.power_bounds.exclusion_upper for battery, _ in pairs_data),
                 sum(
-                    inverter.active_power_exclusion_upper_bound
-                    for _, inverters in pairs_data
-                    for inverter in inverters
+                    (battery.power_bounds.exclusion_upper for battery, _ in pairs_data),
+                    start=Power.zero(),
+                ),
+                Power.from_watts(
+                    sum(
+                        inverter.active_power_exclusion_upper_bound
+                        for _, inverters in pairs_data
+                        for inverter in inverters
+                    )
                 ),
             ),
         )
@@ -410,11 +425,11 @@ class BatteryManager(ComponentManager):  # pylint: disable=too-many-instance-att
 
         bounds = self._get_bounds(pairs_data)
 
-        power = request.power.as_watts()
+        power = request.power
 
         # Zero power requests are always forwarded to the microgrid API, even if they
         # are outside the exclusion bounds.
-        if is_close_to_zero(power):
+        if power.isclose(Power.zero()):
             return None
 
         if request.adjust_power:
@@ -599,7 +614,7 @@ class BatteryManager(ComponentManager):  # pylint: disable=too-many-instance-att
             unavailable_inv_ids = unavailable_inv_ids.union(inverter_ids)
 
         result = self._distribution_algorithm.distribute_power(
-            request.power.as_watts(), inv_bat_pairs
+            request.power, inv_bat_pairs
         )
 
         return result
@@ -608,7 +623,7 @@ class BatteryManager(ComponentManager):  # pylint: disable=too-many-instance-att
         self,
         distribution: DistributionResult,
         timeout: timedelta,
-    ) -> tuple[float, set[int]]:
+    ) -> tuple[Power, set[int]]:
         """Send distributed power to the inverters.
 
         Args:
@@ -622,7 +637,9 @@ class BatteryManager(ComponentManager):  # pylint: disable=too-many-instance-att
         api = connection_manager.get().api_client
 
         tasks = {
-            inverter_id: asyncio.create_task(api.set_power(inverter_id, power))
+            inverter_id: asyncio.create_task(
+                api.set_power(inverter_id, power.as_watts())
+            )
             for inverter_id, power in distribution.distribution.items()
         }
 
@@ -639,9 +656,9 @@ class BatteryManager(ComponentManager):  # pylint: disable=too-many-instance-att
     def _parse_result(
         self,
         tasks: dict[int, asyncio.Task[None]],
-        distribution: dict[int, float],
+        distribution: dict[int, Power],
         request_timeout: timedelta,
-    ) -> tuple[float, set[int]]:
+    ) -> tuple[Power, set[int]]:
         """Parse the results of `set_power` requests.
 
         Check if any task has failed and determine the reason for failure.
@@ -658,7 +675,7 @@ class BatteryManager(ComponentManager):  # pylint: disable=too-many-instance-att
             A tuple where the first element is the total failed power, and the second element is
             the set of batteries that failed.
         """
-        failed_power: float = 0.0
+        failed_power: Power = Power.zero()
         failed_batteries: set[int] = set()
 
         for inverter_id, aws in tasks.items():

--- a/src/frequenz/sdk/microgrid/_power_distributing/_distribution_algorithm/_battery_distribution_algorithm.py
+++ b/src/frequenz/sdk/microgrid/_power_distributing/_distribution_algorithm/_battery_distribution_algorithm.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass
 from typing import NamedTuple, Sequence
 
 from frequenz.client.microgrid import BatteryData, InverterData
+from frequenz.quantities import Power
 
 from ...._internal._math import is_close_to_zero
 from ..result import PowerBounds
@@ -81,10 +82,18 @@ class AggregatedBatteryData:
             list(
                 map(
                     lambda metrics: PowerBounds(
-                        inclusion_upper=metrics.power_inclusion_upper_bound,
-                        inclusion_lower=metrics.power_inclusion_lower_bound,
-                        exclusion_upper=metrics.power_exclusion_upper_bound,
-                        exclusion_lower=metrics.power_exclusion_lower_bound,
+                        inclusion_upper=Power.from_watts(
+                            metrics.power_inclusion_upper_bound
+                        ),
+                        inclusion_lower=Power.from_watts(
+                            metrics.power_inclusion_lower_bound
+                        ),
+                        exclusion_upper=Power.from_watts(
+                            metrics.power_exclusion_upper_bound
+                        ),
+                        exclusion_lower=Power.from_watts(
+                            metrics.power_exclusion_lower_bound
+                        ),
                     ),
                     batteries,
                 )
@@ -107,21 +116,23 @@ def _aggregate_battery_power_bounds(
 
     # Calculate the aggregated bounds for the set of batteries
     power_inclusion_upper_bound = sum(
-        bounds.inclusion_upper for bounds in battery_metrics
+        (bounds.inclusion_upper for bounds in battery_metrics), start=Power.zero()
     )
     power_inclusion_lower_bound = sum(
-        bounds.inclusion_lower for bounds in battery_metrics
+        (bounds.inclusion_lower for bounds in battery_metrics), start=Power.zero()
     )
 
     # To satisfy the largest exclusion bounds in the set we need to
     # provide the power defined by the largest bounds multiplied by the
     # number of batteries in the set.
-    power_exclusion_upper_bound = max(
-        bounds.exclusion_upper for bounds in battery_metrics
-    ) * len(battery_metrics)
-    power_exclusion_lower_bound = min(
-        bounds.exclusion_lower for bounds in battery_metrics
-    ) * len(battery_metrics)
+    power_exclusion_upper_bound = Power.from_watts(
+        max(bounds.exclusion_upper for bounds in battery_metrics).as_watts()
+        * len(battery_metrics)
+    )
+    power_exclusion_lower_bound = Power.from_watts(
+        min(bounds.exclusion_lower for bounds in battery_metrics).as_watts()
+        * len(battery_metrics)
+    )
 
     return PowerBounds(
         inclusion_lower=power_inclusion_lower_bound,
@@ -154,7 +165,7 @@ class AvailabilityRatio:
     ratio: float
     """The availability ratio."""
 
-    min_power: float
+    min_power: Power
     """The minimum power that can be set for the battery-inverters pair."""
 
 
@@ -162,10 +173,10 @@ class AvailabilityRatio:
 class _Power:
     """Helper class for distribution algorithm."""
 
-    upper_bound: float
+    upper_bound: Power
     """The upper bound of the power that can be set for the battery."""
 
-    power: float
+    power: Power
     """The power to be set for the inverter."""
 
 
@@ -180,7 +191,7 @@ class _Allocation:
     inverter_ids: _InverterSet
     """The IDs of the inverters."""
 
-    power: float
+    power: Power
     """The power to be set for the inverters."""
 
 
@@ -188,14 +199,14 @@ class _Allocation:
 class DistributionResult:
     """Distribution result."""
 
-    distribution: dict[int, float]
+    distribution: dict[int, Power]
     """The power to be set for each inverter.
 
     The key is inverter ID, and the value is the power that should be set for
     that inverter.
     """
 
-    remaining_power: float
+    remaining_power: Power
     """The power which could not be distributed because of bounds."""
 
 
@@ -281,6 +292,8 @@ class BatteryDistributionAlgorithm:
             / total_battery_availability_ratio
     ```
     """
+
+    _MINIMUM_DEFICIT_TO_CONSIDER = Power.from_watts(-0.1)
 
     def __init__(self, distributor_exponent: float = 1) -> None:
         """Create distribution algorithm instance.
@@ -386,7 +399,7 @@ class BatteryDistributionAlgorithm:
         self,
         components: list[InvBatPair],
         available_soc: dict[int, float],
-        excl_bounds: dict[int, float],
+        excl_bounds: dict[int, Power],
     ) -> tuple[list[AvailabilityRatio], float]:
         r"""Compute battery ratio and the total sum of all of them.
 
@@ -451,10 +464,10 @@ class BatteryDistributionAlgorithm:
         self,
         *,
         components: list[InvBatPair],
-        power_w: float,
+        power: Power,
         available_soc: dict[int, float],
-        incl_bounds: dict[int, float],
-        excl_bounds: dict[int, float],
+        incl_bounds: dict[int, Power],
+        excl_bounds: dict[int, Power],
     ) -> DistributionResult:
         # pylint: disable=too-many-locals,too-many-branches,too-many-statements
         """Distribute power between given components.
@@ -464,7 +477,7 @@ class BatteryDistributionAlgorithm:
 
         Args:
             components: list of components.
-            power_w: power to distribute
+            power: power to distribute
             available_soc: how much SoC remained to reach:
                 * SoC upper bound - if need to distribute consumption power
                 * SoC lower bound - if need to distribute supply power
@@ -484,21 +497,21 @@ class BatteryDistributionAlgorithm:
         # sum_ratio == 0 means that all batteries are fully charged / discharged
         if is_close_to_zero(sum_ratio):
             final_distribution = {
-                inverter.component_id: 0.0
+                inverter.component_id: Power.zero()
                 for _, inverters in components
                 for inverter in inverters
             }
-            return DistributionResult(final_distribution, power_w)
+            return DistributionResult(final_distribution, power)
 
         # key: inverter_ids, value: _Power(upper_bound, power)
         distribution: dict[_InverterSet, _Power] = {}
-        distributed_power: float = 0.0
-        reserved_power: float = 0.0
-        power_to_distribute: float = power_w
+        distributed_power: Power = Power.zero()
+        reserved_power: Power = Power.zero()
+        power_to_distribute: Power = power
         used_ratio: float = 0.0
         ratio = sum_ratio
-        excess_reserved: dict[_InverterSet, float] = {}
-        deficits: dict[_InverterSet, float] = {}
+        excess_reserved: dict[_InverterSet, Power] = {}
+        deficits: dict[_InverterSet, Power] = {}
 
         for ratio_data in battery_availability_ratio:
             inverter_set = _InverterSet(ratio_data.inverter_ids)
@@ -506,12 +519,12 @@ class BatteryDistributionAlgorithm:
             # capacity
             if is_close_to_zero(ratio):
                 distribution[inverter_set] = _Power(
-                    upper_bound=0.0,
-                    power=0.0,
+                    upper_bound=Power.zero(),
+                    power=Power.zero(),
                 )
                 continue
 
-            power_to_distribute = power_w - reserved_power
+            power_to_distribute = power - reserved_power
             calculated_power = power_to_distribute * ratio_data.ratio / ratio
             reserved_power += max(calculated_power, ratio_data.min_power)
             used_ratio += ratio_data.ratio
@@ -521,7 +534,11 @@ class BatteryDistributionAlgorithm:
             # then we need to distribute more power over all remaining batteries.
             incl_bound = min(
                 sum(
-                    incl_bounds[inverter_id] for inverter_id in ratio_data.inverter_ids
+                    (
+                        incl_bounds[inverter_id]
+                        for inverter_id in ratio_data.inverter_ids
+                    ),
+                    start=Power.zero(),
                 ),
                 incl_bounds[ratio_data.battery_id],
             )
@@ -540,28 +557,28 @@ class BatteryDistributionAlgorithm:
             )
 
         for inverter_ids, deficit in deficits.items():
-            while not is_close_to_zero(deficit) and deficit < 0.0:
+            while not deficit.isclose(Power.zero()) and deficit < Power.zero():
                 if not excess_reserved:
                     break
                 largest = _Allocation(
                     *max(excess_reserved.items(), key=lambda item: item[1])
                 )
 
-                if is_close_to_zero(largest.power) or largest.power < 0.0:
+                if largest.power.isclose(Power.zero()) or largest.power < Power.zero():
                     break
-                if largest.power >= -deficit or math.isclose(largest.power, -deficit):
+                if largest.power >= -deficit or largest.power.isclose(-deficit):
                     excess_reserved[largest.inverter_ids] += deficit
-                    deficits[inverter_ids] = 0.0
-                    deficit = 0.0
+                    deficits[inverter_ids] = Power.zero()
+                    deficit = Power.zero()
                 else:
                     deficit += excess_reserved[largest.inverter_ids]
                     deficits[inverter_ids] = deficit
-                    excess_reserved[largest.inverter_ids] = 0.0
-            if deficit < -0.1:
-                left_over = power_w - distributed_power
+                    excess_reserved[largest.inverter_ids] = Power.zero()
+            if deficit < self._MINIMUM_DEFICIT_TO_CONSIDER:
+                left_over = power - distributed_power
                 if left_over > -deficit:
                     distributed_power += deficit
-                elif left_over > 0.0:
+                elif left_over > Power.zero():
                     distributed_power += left_over
 
         for inverter_ids, excess in excess_reserved.items():
@@ -571,7 +588,7 @@ class BatteryDistributionAlgorithm:
             # Add excess power to the inverter set
             distribution[inverter_ids] = battery_power
 
-        left_over = power_w - distributed_power
+        left_over = power - distributed_power
 
         distribution, left_over = self._greedy_distribute_remaining_power(
             distribution, left_over
@@ -587,9 +604,9 @@ class BatteryDistributionAlgorithm:
     def _distribute_multi_inverter_pairs(
         self,
         distribution: dict[_InverterSet, _Power],
-        excl_bounds: dict[int, float],
-        incl_bounds: dict[int, float],
-    ) -> dict[int, float]:
+        excl_bounds: dict[int, Power],
+        incl_bounds: dict[int, Power],
+    ) -> dict[int, Power]:
         """Distribute power between inverters in a set for a single pair.
 
         Args:
@@ -600,7 +617,7 @@ class BatteryDistributionAlgorithm:
         Returns:
             Return the power for each inverter in given distribution.
         """
-        new_distribution: dict[int, float] = {}
+        new_distribution: dict[int, Power] = {}
 
         for inverter_ids, power in distribution.items():
             if len(inverter_ids) == 1:
@@ -616,7 +633,7 @@ class BatteryDistributionAlgorithm:
 
                 for inverter_id in sorted_inverter_ids:
                     if (
-                        not is_close_to_zero(remaining_power)
+                        not remaining_power.isclose(Power.zero())
                         and excl_bounds[inverter_id] <= remaining_power
                     ):
                         new_power = min(incl_bounds[inverter_id], remaining_power)
@@ -624,13 +641,13 @@ class BatteryDistributionAlgorithm:
                         new_distribution[inverter_id] = new_power
                         remaining_power -= new_power
                     else:
-                        new_distribution[inverter_id] = 0.0
+                        new_distribution[inverter_id] = Power.zero()
 
         return new_distribution
 
     def _greedy_distribute_remaining_power(
-        self, distribution: dict[_InverterSet, _Power], remaining_power: float
-    ) -> tuple[dict[_InverterSet, _Power], float]:
+        self, distribution: dict[_InverterSet, _Power], remaining_power: Power
+    ) -> tuple[dict[_InverterSet, _Power], Power]:
         """Add remaining power greedily to the given distribution.
 
         Distribution for each inverter will not exceed its upper bound.
@@ -642,13 +659,15 @@ class BatteryDistributionAlgorithm:
         Returns:
             Return the new distribution and remaining power.
         """
-        if is_close_to_zero(remaining_power):
+        if remaining_power.isclose(Power.zero()):
             return distribution, remaining_power
 
         for inverter_ids, power in distribution.items():
             # The power.power == 0 means the inverter shall not be used due to
             # SoC bounds or no capacity
-            if is_close_to_zero(remaining_power) or is_close_to_zero(power.power):
+            if remaining_power.isclose(Power.zero()) or power.power.isclose(
+                Power.zero()
+            ):
                 distribution[inverter_ids] = power
             else:
                 additional_power = min(power.upper_bound - power.power, remaining_power)
@@ -658,7 +677,7 @@ class BatteryDistributionAlgorithm:
         return distribution, remaining_power
 
     def distribute_power_equally(
-        self, power: float, inverters: set[int]
+        self, power: Power, inverters: set[int]
     ) -> DistributionResult:
         """Distribute the power equally between the inverters in the set.
 
@@ -675,11 +694,11 @@ class BatteryDistributionAlgorithm:
         power_per_inverter = power / len(inverters)
         return DistributionResult(
             distribution={id: power_per_inverter for id in inverters},
-            remaining_power=0.0,
+            remaining_power=Power.zero(),
         )
 
     def distribute_power(
-        self, power: float, components: list[InvBatPair]
+        self, power: Power, components: list[InvBatPair]
     ) -> DistributionResult:
         """Distribute given power between given components.
 
@@ -691,21 +710,21 @@ class BatteryDistributionAlgorithm:
         Returns:
             Distribution result
         """
-        if is_close_to_zero(power):
+        if power.isclose(Power.zero()):
             return DistributionResult(
                 distribution={
-                    inverter.component_id: 0.0
+                    inverter.component_id: Power.zero()
                     for _, inverters in components
                     for inverter in inverters
                 },
-                remaining_power=0.0,
+                remaining_power=Power.zero(),
             )
-        if power > 0.0:
+        if power > Power.zero():
             return self._distribute_consume_power(power, components)
         return self._distribute_supply_power(power, components)
 
     def _distribute_consume_power(
-        self, power_w: float, components: list[InvBatPair]
+        self, power: Power, components: list[InvBatPair]
     ) -> DistributionResult:
         """Distribute power between the given components.
 
@@ -714,7 +733,7 @@ class BatteryDistributionAlgorithm:
             * will try to align himself to the same level.
 
         Args:
-            power_w: power to distribute
+            power: power to distribute
             components: list of components between which the power should be
                 distributed.
 
@@ -736,14 +755,14 @@ class BatteryDistributionAlgorithm:
 
         return self._distribute_power(
             components=components,
-            power_w=power_w,
+            power=power,
             available_soc=available_soc,
             incl_bounds=incl_bounds,
             excl_bounds=excl_bounds,
         )
 
     def _distribute_supply_power(
-        self, power_w: float, components: list[InvBatPair]
+        self, power: Power, components: list[InvBatPair]
     ) -> DistributionResult:
         """Distribute power between the given components.
 
@@ -752,7 +771,7 @@ class BatteryDistributionAlgorithm:
             * will try to align himself to the same level.
 
         Args:
-            power_w: power to distribute
+            power: power to distribute
             components: list of components between which the power should be
                 distributed.
 
@@ -771,21 +790,21 @@ class BatteryDistributionAlgorithm:
 
         result: DistributionResult = self._distribute_power(
             components=components,
-            power_w=-1 * power_w,
+            power=-power,
             available_soc=available_soc,
             incl_bounds=incl_bounds,
             excl_bounds=excl_bounds,
         )
 
         for inverter_id in result.distribution.keys():
-            result.distribution[inverter_id] *= -1
-        result.remaining_power *= -1
+            result.distribution[inverter_id] = -result.distribution[inverter_id]
+        result.remaining_power = -result.remaining_power
 
         return result
 
     def _inclusion_exclusion_bounds(
         self, components: list[InvBatPair], supply: bool = False
-    ) -> tuple[dict[int, float], dict[int, float]]:
+    ) -> tuple[dict[int, Power], dict[int, Power]]:
         """Calculate inclusion and exclusion bounds for given components.
 
         Inverter exclusion bounds are _not_ adjusted to battery inclusion
@@ -800,8 +819,8 @@ class BatteryDistributionAlgorithm:
         Returns:
             inclusion and exclusion bounds.
         """
-        incl_bounds: dict[int, float] = {}
-        excl_bounds: dict[int, float] = {}
+        incl_bounds: dict[int, Power] = {}
+        excl_bounds: dict[int, Power] = {}
         for battery, inverters in components:
             if supply:
                 excl_bounds[battery.component_id] = (
@@ -817,19 +836,19 @@ class BatteryDistributionAlgorithm:
             for inverter in inverters:
                 if supply:
                     incl_bounds[inverter.component_id] = -max(
-                        inverter.active_power_inclusion_lower_bound,
+                        Power.from_watts(inverter.active_power_inclusion_lower_bound),
                         battery.power_bounds.inclusion_lower,
                     )
-                    excl_bounds[inverter.component_id] = (
+                    excl_bounds[inverter.component_id] = Power.from_watts(
                         -inverter.active_power_exclusion_lower_bound
                     )
 
                 else:
                     incl_bounds[inverter.component_id] = min(
-                        inverter.active_power_inclusion_upper_bound,
+                        Power.from_watts(inverter.active_power_inclusion_upper_bound),
                         battery.power_bounds.inclusion_upper,
                     )
-                    excl_bounds[inverter.component_id] = (
+                    excl_bounds[inverter.component_id] = Power.from_watts(
                         inverter.active_power_exclusion_upper_bound
                     )
         return incl_bounds, excl_bounds

--- a/src/frequenz/sdk/microgrid/_power_distributing/result.py
+++ b/src/frequenz/sdk/microgrid/_power_distributing/result.py
@@ -71,16 +71,16 @@ class Error(_BaseResultMixin):
 class PowerBounds:
     """Inclusion and exclusion power bounds for the requested components."""
 
-    inclusion_lower: float
+    inclusion_lower: Power
     """The lower value of the inclusion power bounds for the requested components."""
 
-    exclusion_lower: float
+    exclusion_lower: Power
     """The lower value of the exclusion power bounds for the requested components."""
 
-    exclusion_upper: float
+    exclusion_upper: Power
     """The upper value of the exclusion power bounds for the requested components."""
 
-    inclusion_upper: float
+    inclusion_upper: Power
     """The upper value of the inclusion power bounds for the requested components."""
 
 

--- a/src/frequenz/sdk/timeseries/battery_pool/_metric_calculator.py
+++ b/src/frequenz/sdk/timeseries/battery_pool/_metric_calculator.py
@@ -534,10 +534,10 @@ class PowerBoundsCalculator(MetricCalculator[SystemBounds]):
         """
         timestamp = _MIN_TIMESTAMP
         loop_timestamp = _MIN_TIMESTAMP
-        inclusion_bounds_lower = 0.0
-        inclusion_bounds_upper = 0.0
-        exclusion_bounds_lower = 0.0
-        exclusion_bounds_upper = 0.0
+        inclusion_bounds_lower = Power.zero()
+        inclusion_bounds_upper = Power.zero()
+        exclusion_bounds_lower = Power.zero()
+        exclusion_bounds_upper = Power.zero()
 
         battery_sets = {
             self._bat_bats_map[battery_id] for battery_id in working_batteries
@@ -563,10 +563,10 @@ class PowerBoundsCalculator(MetricCalculator[SystemBounds]):
 
             loop_timestamp = local_timestamp
             return PowerBounds(
-                inclusion_lower=results[0],
-                exclusion_lower=results[1],
-                exclusion_upper=results[2],
-                inclusion_upper=results[3],
+                inclusion_lower=Power.from_watts(results[0]),
+                exclusion_lower=Power.from_watts(results[1]),
+                exclusion_upper=Power.from_watts(results[2]),
+                inclusion_upper=Power.from_watts(results[3]),
             )
 
         def get_bounds_list(
@@ -602,19 +602,31 @@ class PowerBoundsCalculator(MetricCalculator[SystemBounds]):
 
             inclusion_bounds_lower += max(
                 aggregated_bat_bounds.inclusion_lower,
-                sum(bound.inclusion_lower for bound in inverter_bounds),
+                sum(
+                    (bound.inclusion_lower for bound in inverter_bounds),
+                    start=Power.zero(),
+                ),
             )
             inclusion_bounds_upper += min(
                 aggregated_bat_bounds.inclusion_upper,
-                sum(bound.inclusion_upper for bound in inverter_bounds),
+                sum(
+                    (bound.inclusion_upper for bound in inverter_bounds),
+                    start=Power.zero(),
+                ),
             )
             exclusion_bounds_lower += min(
                 aggregated_bat_bounds.exclusion_lower,
-                sum(bound.exclusion_lower for bound in inverter_bounds),
+                sum(
+                    (bound.exclusion_lower for bound in inverter_bounds),
+                    start=Power.zero(),
+                ),
             )
             exclusion_bounds_upper += max(
                 aggregated_bat_bounds.exclusion_upper,
-                sum(bound.exclusion_upper for bound in inverter_bounds),
+                sum(
+                    (bound.exclusion_upper for bound in inverter_bounds),
+                    start=Power.zero(),
+                ),
             )
 
         if timestamp == _MIN_TIMESTAMP:
@@ -627,11 +639,11 @@ class PowerBoundsCalculator(MetricCalculator[SystemBounds]):
         return SystemBounds(
             timestamp=timestamp,
             inclusion_bounds=timeseries.Bounds(
-                Power.from_watts(inclusion_bounds_lower),
-                Power.from_watts(inclusion_bounds_upper),
+                inclusion_bounds_lower,
+                inclusion_bounds_upper,
             ),
             exclusion_bounds=timeseries.Bounds(
-                Power.from_watts(exclusion_bounds_lower),
-                Power.from_watts(exclusion_bounds_upper),
+                exclusion_bounds_lower,
+                exclusion_bounds_upper,
             ),
         )

--- a/tests/microgrid/power_distributing/test_battery_distribution_algorithm.py
+++ b/tests/microgrid/power_distributing/test_battery_distribution_algorithm.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 
 from frequenz.client.microgrid import BatteryData, InverterData
+from frequenz.quantities import Power
 from pytest import approx, raises
 
 from frequenz.sdk.microgrid._power_distributing._distribution_algorithm import (
@@ -63,10 +64,10 @@ def battery_msg(  # pylint: disable=too-many-arguments
         soc=soc.now if soc.now is not None else math.nan,
         soc_lower_bound=soc.bound.lower if soc.bound is not None else math.nan,
         soc_upper_bound=soc.bound.upper if soc.bound is not None else math.nan,
-        power_inclusion_lower_bound=power.inclusion_lower,
-        power_exclusion_lower_bound=power.exclusion_lower,
-        power_exclusion_upper_bound=power.exclusion_upper,
-        power_inclusion_upper_bound=power.inclusion_upper,
+        power_inclusion_lower_bound=power.inclusion_lower.as_watts(),
+        power_exclusion_lower_bound=power.exclusion_lower.as_watts(),
+        power_exclusion_upper_bound=power.exclusion_upper.as_watts(),
+        power_inclusion_upper_bound=power.inclusion_upper.as_watts(),
         timestamp=timestamp,
     )
 
@@ -89,10 +90,10 @@ def inverter_msg(
     return InverterDataWrapper(
         component_id=component_id,
         timestamp=timestamp,
-        active_power_inclusion_lower_bound=power.inclusion_lower,
-        active_power_exclusion_lower_bound=power.exclusion_lower,
-        active_power_exclusion_upper_bound=power.exclusion_upper,
-        active_power_inclusion_upper_bound=power.inclusion_upper,
+        active_power_inclusion_lower_bound=power.inclusion_lower.as_watts(),
+        active_power_exclusion_lower_bound=power.exclusion_lower.as_watts(),
+        active_power_exclusion_upper_bound=power.exclusion_upper.as_watts(),
+        active_power_inclusion_upper_bound=power.inclusion_upper.as_watts(),
     )
 
 
@@ -185,20 +186,25 @@ class TestDistributionAlgorithm:  # pylint: disable=too-many-public-methods
         components = self.create_components_with_capacity(1, capacity)
 
         available_soc: dict[int, float] = {0: 40}
-        incl_bounds: dict[int, float] = {0: 500, 1: 500}
-        excl_bounds: dict[int, float] = {0: 0, 1: 0}
+        incl_bounds: dict[int, Power] = {
+            0: Power.from_watts(500),
+            1: Power.from_watts(500),
+        }
+        excl_bounds: dict[int, Power] = {0: Power.zero(), 1: Power.zero()}
 
         algorithm = BatteryDistributionAlgorithm(distributor_exponent=1)
         result = algorithm._distribute_power(  # pylint: disable=protected-access
             components=components,
-            power_w=650,
+            power=Power.from_watts(650),
             available_soc=available_soc,
             incl_bounds=incl_bounds,
             excl_bounds=excl_bounds,
         )
 
-        assert result.distribution == approx({1: 500})
-        assert result.remaining_power == approx(150.0)
+        for key, value in {1: 500}.items():
+            assert result.distribution[key].as_watts() == approx(value)
+
+        assert result.remaining_power.as_watts() == approx(150.0)
 
     def test_distribute_power_two_batteries_1(self) -> None:
         """Test when the batteries has different SoC.
@@ -210,20 +216,32 @@ class TestDistributionAlgorithm:  # pylint: disable=too-many-public-methods
         components = self.create_components_with_capacity(2, capacity)
 
         available_soc: dict[int, float] = {0: 40, 2: 20}
-        incl_bounds: dict[int, float] = {0: 500, 2: 500, 1: 500, 3: 500}
-        excl_bounds: dict[int, float] = {0: 0, 2: 0, 1: 0, 3: 0}
+        incl_bounds: dict[int, Power] = {
+            0: Power.from_watts(500),
+            2: Power.from_watts(500),
+            1: Power.from_watts(500),
+            3: Power.from_watts(500),
+        }
+        excl_bounds: dict[int, Power] = {
+            0: Power.zero(),
+            2: Power.zero(),
+            1: Power.zero(),
+            3: Power.zero(),
+        }
 
         algorithm = BatteryDistributionAlgorithm(distributor_exponent=1)
         result = algorithm._distribute_power(  # pylint: disable=protected-access
             components=components,
-            power_w=600,
+            power=Power.from_watts(600),
             available_soc=available_soc,
             incl_bounds=incl_bounds,
             excl_bounds=excl_bounds,
         )
 
-        assert result.distribution == approx({1: 400, 3: 200})
-        assert result.remaining_power == approx(0.0)
+        for key, value in {1: 400, 3: 200}.items():
+            assert result.distribution[key].as_watts() == approx(value)
+
+        assert result.remaining_power.as_watts() == approx(0.0)
 
     def test_distribute_power_two_batteries_2(self) -> None:
         """Test when the batteries has different SoC.
@@ -235,20 +253,32 @@ class TestDistributionAlgorithm:  # pylint: disable=too-many-public-methods
         components = self.create_components_with_capacity(2, capacity)
 
         available_soc: dict[int, float] = {0: 20, 2: 20}
-        incl_bounds: dict[int, float] = {0: 500, 2: 500, 1: 500, 3: 500}
-        excl_bounds: dict[int, float] = {0: 0, 2: 0, 1: 0, 3: 0}
+        incl_bounds: dict[int, Power] = {
+            0: Power.from_watts(500),
+            2: Power.from_watts(500),
+            1: Power.from_watts(500),
+            3: Power.from_watts(500),
+        }
+        excl_bounds: dict[int, Power] = {
+            0: Power.zero(),
+            2: Power.zero(),
+            1: Power.zero(),
+            3: Power.zero(),
+        }
 
         algorithm = BatteryDistributionAlgorithm(distributor_exponent=1)
         result = algorithm._distribute_power(  # pylint: disable=protected-access
             components=components,
-            power_w=600,
+            power=Power.from_watts(600),
             available_soc=available_soc,
             incl_bounds=incl_bounds,
             excl_bounds=excl_bounds,
         )
 
-        assert result.distribution == approx({1: 200, 3: 400})
-        assert result.remaining_power == approx(0.0)
+        for key, value in {1: 200, 3: 400}.items():
+            assert result.distribution[key].as_watts() == approx(value)
+
+        assert result.remaining_power.as_watts() == approx(0.0)
 
     def test_distribute_power_two_batteries_one_inverter(self) -> None:
         """Test when the batteries has different SoC and only one inverter.
@@ -262,20 +292,30 @@ class TestDistributionAlgorithm:  # pylint: disable=too-many-public-methods
         )
 
         available_soc: dict[int, float] = {0: 20, 2: 30}
-        incl_bounds: dict[int, float] = {0: 500, 2: 500, 1: 500}
-        excl_bounds: dict[int, float] = {0: 0, 2: 0, 1: 0}
+        incl_bounds: dict[int, Power] = {
+            0: Power.from_watts(500),
+            2: Power.from_watts(500),
+            1: Power.from_watts(500),
+        }
+        excl_bounds: dict[int, Power] = {
+            0: Power.zero(),
+            2: Power.zero(),
+            1: Power.zero(),
+        }
 
         algorithm = BatteryDistributionAlgorithm(distributor_exponent=1)
         result = algorithm._distribute_power(  # pylint: disable=protected-access
             components=components,
-            power_w=600,
+            power=Power.from_watts(600),
             available_soc=available_soc,
             incl_bounds=incl_bounds,
             excl_bounds=excl_bounds,
         )
 
-        assert result.distribution == approx({1: 500})
-        assert result.remaining_power == approx(100.0)
+        for key, value in {1: 500}.items():
+            assert result.distribution[key].as_watts() == approx(value)
+
+        assert result.remaining_power.as_watts() == approx(100.0)
 
     def test_distribute_power_two_batteries_bounds(self) -> None:
         """Test two batteries.
@@ -288,20 +328,32 @@ class TestDistributionAlgorithm:  # pylint: disable=too-many-public-methods
         components = self.create_components_with_capacity(2, capacity)
 
         available_soc: dict[int, float] = {0: 40, 2: 20}
-        incl_bounds: dict[int, float] = {0: 250, 2: 330, 1: 250, 3: 330}
-        excl_bounds: dict[int, float] = {0: 0, 2: 0, 1: 0, 3: 0}
+        incl_bounds: dict[int, Power] = {
+            0: Power.from_watts(250),
+            2: Power.from_watts(330),
+            1: Power.from_watts(250),
+            3: Power.from_watts(330),
+        }
+        excl_bounds: dict[int, Power] = {
+            0: Power.zero(),
+            2: Power.zero(),
+            1: Power.zero(),
+            3: Power.zero(),
+        }
 
         algorithm = BatteryDistributionAlgorithm(distributor_exponent=1)
         result = algorithm._distribute_power(  # pylint: disable=protected-access
             components=components,
-            power_w=600,
+            power=Power.from_watts(600),
             available_soc=available_soc,
             incl_bounds=incl_bounds,
             excl_bounds=excl_bounds,
         )
 
-        assert result.distribution == approx({1: 250, 3: 330})
-        assert result.remaining_power == approx(20.0)
+        for key, value in {1: 250, 3: 330}.items():
+            assert result.distribution[key].as_watts() == approx(value)
+
+        assert result.remaining_power.as_watts() == approx(20.0)
 
     def test_distribute_power_three_batteries(self) -> None:
         """Test whether the distribution works ok for more batteries."""
@@ -309,27 +361,36 @@ class TestDistributionAlgorithm:  # pylint: disable=too-many-public-methods
         components = self.create_components_with_capacity(3, capacity)
 
         available_soc: dict[int, float] = {0: 40, 2: 20, 4: 20}
-        incl_bounds: dict[int, float] = {
-            0: 1000,
-            2: 1000,
-            4: 1000,
-            1: 1000,
-            3: 3400,
-            5: 3550,
+        incl_bounds: dict[int, Power] = {
+            0: Power.from_watts(1000),
+            2: Power.from_watts(1000),
+            4: Power.from_watts(1000),
+            1: Power.from_watts(1000),
+            3: Power.from_watts(3400),
+            5: Power.from_watts(3550),
         }
-        excl_bounds: dict[int, float] = {0: 0, 2: 0, 4: 0, 1: 0, 3: 0, 5: 0}
+        excl_bounds: dict[int, Power] = {
+            0: Power.zero(),
+            2: Power.zero(),
+            4: Power.zero(),
+            1: Power.zero(),
+            3: Power.zero(),
+            5: Power.zero(),
+        }
 
         algorithm = BatteryDistributionAlgorithm(distributor_exponent=1)
         result = algorithm._distribute_power(  # pylint: disable=protected-access
             components=components,
-            power_w=1000,
+            power=Power.from_watts(1000),
             available_soc=available_soc,
             incl_bounds=incl_bounds,
             excl_bounds=excl_bounds,
         )
 
-        assert result.distribution == approx({1: 400, 3: 400, 5: 200})
-        assert result.remaining_power == approx(0.0)
+        for key, value in {1: 400, 3: 400, 5: 200}.items():
+            assert result.distribution[key].as_watts() == approx(value)
+
+        assert result.remaining_power.as_watts() == approx(0.0)
 
     def test_distribute_power_three_batteries_2(self) -> None:
         """Test whether the power which couldn't be distributed is correct."""
@@ -337,27 +398,36 @@ class TestDistributionAlgorithm:  # pylint: disable=too-many-public-methods
         components = self.create_components_with_capacity(3, capacity)
 
         available_soc: dict[int, float] = {0: 80, 2: 10, 4: 20}
-        incl_bounds: dict[int, float] = {
-            0: 1000,
-            2: 1000,
-            4: 1000,
-            1: 400,
-            3: 3400,
-            5: 300,
+        incl_bounds: dict[int, Power] = {
+            0: Power.from_watts(1000),
+            2: Power.from_watts(1000),
+            4: Power.from_watts(1000),
+            1: Power.from_watts(400),
+            3: Power.from_watts(3400),
+            5: Power.from_watts(300),
         }
-        excl_bounds: dict[int, float] = {0: 0, 2: 0, 4: 0, 1: 0, 3: 0, 5: 0}
+        excl_bounds: dict[int, Power] = {
+            0: Power.zero(),
+            2: Power.zero(),
+            4: Power.zero(),
+            1: Power.zero(),
+            3: Power.zero(),
+            5: Power.zero(),
+        }
 
         algorithm = BatteryDistributionAlgorithm(distributor_exponent=1)
         result = algorithm._distribute_power(  # pylint: disable=protected-access
             components=components,
-            power_w=1000,
+            power=Power.from_watts(1000),
             available_soc=available_soc,
             incl_bounds=incl_bounds,
             excl_bounds=excl_bounds,
         )
 
-        assert result.distribution == approx({1: 400, 3: 300, 5: 300})
-        assert result.remaining_power == approx(0.0)
+        for key, value in {1: 400, 3: 300, 5: 300}.items():
+            assert result.distribution[key].as_watts() == approx(value)
+
+        assert result.remaining_power.as_watts() == approx(0.0)
 
     def test_distribute_power_three_batteries_3(self) -> None:
         """Test with batteries with no capacity."""
@@ -365,27 +435,36 @@ class TestDistributionAlgorithm:  # pylint: disable=too-many-public-methods
         components = self.create_components_with_capacity(3, capacity)
 
         available_soc: dict[int, float] = {0: 80, 2: 10, 4: 20}
-        incl_bounds: dict[int, float] = {
-            0: 1000,
-            2: 1000,
-            4: 1000,
-            1: 500,
-            3: 300,
-            5: 300,
+        incl_bounds: dict[int, Power] = {
+            0: Power.from_watts(1000),
+            2: Power.from_watts(1000),
+            4: Power.from_watts(1000),
+            1: Power.from_watts(500),
+            3: Power.from_watts(300),
+            5: Power.from_watts(300),
         }
-        excl_bounds: dict[int, float] = {0: 0, 2: 0, 4: 0, 1: 0, 3: 0, 5: 0}
+        excl_bounds: dict[int, Power] = {
+            0: Power.zero(),
+            2: Power.zero(),
+            4: Power.zero(),
+            1: Power.zero(),
+            3: Power.zero(),
+            5: Power.zero(),
+        }
 
         algorithm = BatteryDistributionAlgorithm(distributor_exponent=1)
         result = algorithm._distribute_power(  # pylint: disable=protected-access
             components=components,
-            power_w=1000,
+            power=Power.from_watts(1000),
             available_soc=available_soc,
             incl_bounds=incl_bounds,
             excl_bounds=excl_bounds,
         )
 
-        assert result.distribution == approx({1: 0, 3: 300, 5: 0})
-        assert result.remaining_power == approx(700.0)
+        for key, value in {1: 0, 3: 300, 5: 0}.items():
+            assert result.distribution[key].as_watts() == approx(value)
+
+        assert result.remaining_power.as_watts() == approx(700.0)
 
     # Test distribute supply power
     def test_supply_three_batteries_1(self) -> None:
@@ -400,20 +479,34 @@ class TestDistributionAlgorithm:  # pylint: disable=too-many-public-methods
 
         # consume bounds == 0 makes sure they are not used in supply algorithm
         bounds = [
-            PowerBounds(-900, 0, 0, 0),
-            PowerBounds(-1000, 0, 0, 0),
-            PowerBounds(-800, 0, 0, 0),
-            PowerBounds(-700, 0, 0, 0),
-            PowerBounds(-900, 0, 0, 0),
-            PowerBounds(-900, 0, 0, 0),
+            PowerBounds(
+                Power.from_watts(-900), Power.zero(), Power.zero(), Power.zero()
+            ),
+            PowerBounds(
+                Power.from_watts(-1000), Power.zero(), Power.zero(), Power.zero()
+            ),
+            PowerBounds(
+                Power.from_watts(-800), Power.zero(), Power.zero(), Power.zero()
+            ),
+            PowerBounds(
+                Power.from_watts(-700), Power.zero(), Power.zero(), Power.zero()
+            ),
+            PowerBounds(
+                Power.from_watts(-900), Power.zero(), Power.zero(), Power.zero()
+            ),
+            PowerBounds(
+                Power.from_watts(-900), Power.zero(), Power.zero(), Power.zero()
+            ),
         ]
         components = create_components(3, capacity, soc, bounds)
 
         algorithm = BatteryDistributionAlgorithm(distributor_exponent=1)
-        result = algorithm.distribute_power(-1200, components)
+        result = algorithm.distribute_power(Power.from_watts(-1200), components)
 
-        assert result.distribution == approx({1: -200, 3: -400, 5: -600})
-        assert result.remaining_power == approx(0.0)
+        for key, value in {1: -200, 3: -400, 5: -600}.items():
+            assert result.distribution[key].as_watts() == approx(value)
+
+        assert result.remaining_power.as_watts() == approx(0.0)
 
     def test_supply_three_batteries_2(self) -> None:
         """Test distribute supply power."""
@@ -425,20 +518,34 @@ class TestDistributionAlgorithm:  # pylint: disable=too-many-public-methods
         ]
         # consume bounds == 0 makes sure they are not used in supply algorithm
         bounds = [
-            PowerBounds(-900, 0, 0, 0),
-            PowerBounds(-1000, 0, 0, 0),
-            PowerBounds(-800, 0, 0, 0),
-            PowerBounds(-700, 0, 0, 0),
-            PowerBounds(-900, 0, 0, 0),
-            PowerBounds(-900, 0, 0, 0),
+            PowerBounds(
+                Power.from_watts(-900), Power.zero(), Power.zero(), Power.zero()
+            ),
+            PowerBounds(
+                Power.from_watts(-1000), Power.zero(), Power.zero(), Power.zero()
+            ),
+            PowerBounds(
+                Power.from_watts(-800), Power.zero(), Power.zero(), Power.zero()
+            ),
+            PowerBounds(
+                Power.from_watts(-700), Power.zero(), Power.zero(), Power.zero()
+            ),
+            PowerBounds(
+                Power.from_watts(-900), Power.zero(), Power.zero(), Power.zero()
+            ),
+            PowerBounds(
+                Power.from_watts(-900), Power.zero(), Power.zero(), Power.zero()
+            ),
         ]
         components = create_components(3, capacity, soc, bounds)
 
         algorithm = BatteryDistributionAlgorithm(distributor_exponent=1)
-        result = algorithm.distribute_power(-1400, components)
+        result = algorithm.distribute_power(Power.from_watts(-1400), components)
 
-        assert result.distribution == approx({1: -400, 3: -400, 5: -600})
-        assert result.remaining_power == approx(0.0)
+        for key, value in {1: -400, 3: -400, 5: -600}.items():
+            assert result.distribution[key].as_watts() == approx(value)
+
+        assert result.remaining_power.as_watts() == approx(0.0)
 
     def test_supply_three_batteries_3(self) -> None:
         """Distribute supply power with small upper bounds."""
@@ -450,20 +557,34 @@ class TestDistributionAlgorithm:  # pylint: disable=too-many-public-methods
         ]
         # consume bounds == 0 makes sure they are not used in supply algorithm
         supply_bounds = [
-            PowerBounds(-600, 0, 0, 0),
-            PowerBounds(-1000, 0, 0, 0),
-            PowerBounds(-600, 0, 0, 0),
-            PowerBounds(-100, 0, 0, 0),
-            PowerBounds(-800, 0, 0, 0),
-            PowerBounds(-900, 0, 0, 0),
+            PowerBounds(
+                Power.from_watts(-600), Power.zero(), Power.zero(), Power.zero()
+            ),
+            PowerBounds(
+                Power.from_watts(-1000), Power.zero(), Power.zero(), Power.zero()
+            ),
+            PowerBounds(
+                Power.from_watts(-600), Power.zero(), Power.zero(), Power.zero()
+            ),
+            PowerBounds(
+                Power.from_watts(-100), Power.zero(), Power.zero(), Power.zero()
+            ),
+            PowerBounds(
+                Power.from_watts(-800), Power.zero(), Power.zero(), Power.zero()
+            ),
+            PowerBounds(
+                Power.from_watts(-900), Power.zero(), Power.zero(), Power.zero()
+            ),
         ]
         components = create_components(3, capacity, soc, supply_bounds)
 
         algorithm = BatteryDistributionAlgorithm(distributor_exponent=1)
-        result = algorithm.distribute_power(-1400, components)
+        result = algorithm.distribute_power(Power.from_watts(-1400), components)
 
-        assert result.distribution == approx({1: -500, 3: -100, 5: -800})
-        assert result.remaining_power == approx(0.0)
+        for key, value in {1: -500, 3: -100, 5: -800}.items():
+            assert result.distribution[key].as_watts() == approx(value)
+
+        assert result.remaining_power.as_watts() == approx(0.0)
 
     def test_supply_three_batteries_4(self) -> None:
         """Distribute supply power with small upper bounds."""
@@ -475,20 +596,34 @@ class TestDistributionAlgorithm:  # pylint: disable=too-many-public-methods
         ]
         # consume bounds == 0 makes sure they are not used in supply algorithm
         bounds = [
-            PowerBounds(-600, 0, 0, 0),
-            PowerBounds(-1000, 0, 0, 0),
-            PowerBounds(-600, 0, 0, 0),
-            PowerBounds(-100, 0, 0, 0),
-            PowerBounds(-800, 0, 0, 0),
-            PowerBounds(-900, 0, 0, 0),
+            PowerBounds(
+                Power.from_watts(-600), Power.zero(), Power.zero(), Power.zero()
+            ),
+            PowerBounds(
+                Power.from_watts(-1000), Power.zero(), Power.zero(), Power.zero()
+            ),
+            PowerBounds(
+                Power.from_watts(-600), Power.zero(), Power.zero(), Power.zero()
+            ),
+            PowerBounds(
+                Power.from_watts(-100), Power.zero(), Power.zero(), Power.zero()
+            ),
+            PowerBounds(
+                Power.from_watts(-800), Power.zero(), Power.zero(), Power.zero()
+            ),
+            PowerBounds(
+                Power.from_watts(-900), Power.zero(), Power.zero(), Power.zero()
+            ),
         ]
         components = create_components(3, capacity, soc, bounds)
 
         algorithm = BatteryDistributionAlgorithm(distributor_exponent=1)
-        result = algorithm.distribute_power(-1700, components)
+        result = algorithm.distribute_power(Power.from_watts(-1700), components)
 
-        assert result.distribution == approx({1: -600, 3: -100, 5: -800})
-        assert result.remaining_power == approx(-200.0)
+        for key, value in {1: -600, 3: -100, 5: -800}.items():
+            assert result.distribution[key].as_watts() == approx(value)
+
+        assert result.remaining_power.as_watts() == approx(-200.0)
 
     def test_supply_three_batteries_5(self) -> None:
         """Test no capacity."""
@@ -500,20 +635,34 @@ class TestDistributionAlgorithm:  # pylint: disable=too-many-public-methods
         ]
         # consume bounds == 0 makes sure they are not used in supply algorithm
         supply_bounds = [
-            PowerBounds(-600, 0, 0, 0),
-            PowerBounds(-1000, 0, 0, 0),
-            PowerBounds(-600, 0, 0, 0),
-            PowerBounds(-100, 0, 0, 0),
-            PowerBounds(-800, 0, 0, 0),
-            PowerBounds(-900, 0, 0, 0),
+            PowerBounds(
+                Power.from_watts(-600), Power.zero(), Power.zero(), Power.zero()
+            ),
+            PowerBounds(
+                Power.from_watts(-1000), Power.zero(), Power.zero(), Power.zero()
+            ),
+            PowerBounds(
+                Power.from_watts(-600), Power.zero(), Power.zero(), Power.zero()
+            ),
+            PowerBounds(
+                Power.from_watts(-100), Power.zero(), Power.zero(), Power.zero()
+            ),
+            PowerBounds(
+                Power.from_watts(-800), Power.zero(), Power.zero(), Power.zero()
+            ),
+            PowerBounds(
+                Power.from_watts(-900), Power.zero(), Power.zero(), Power.zero()
+            ),
         ]
         components = create_components(3, capacity, soc, supply_bounds)
 
         algorithm = BatteryDistributionAlgorithm(distributor_exponent=1)
-        result = algorithm.distribute_power(-1700, components)
+        result = algorithm.distribute_power(Power.from_watts(-1700), components)
 
-        assert result.distribution == approx({1: 0, 3: -100, 5: 0})
-        assert result.remaining_power == approx(-1600.0)
+        for key, value in {1: 0, 3: -100, 5: 0}.items():
+            assert result.distribution[key].as_watts() == approx(value)
+
+        assert result.remaining_power.as_watts() == approx(-1600.0)
 
     def test_supply_two_batteries_1(self) -> None:
         """Distribute supply power between two batteries."""
@@ -525,18 +674,28 @@ class TestDistributionAlgorithm:  # pylint: disable=too-many-public-methods
 
         # consume bounds == 0 makes sure they are not used in supply algorithm
         supply_bounds = [
-            PowerBounds(-600, 0, 0, 0),
-            PowerBounds(-1000, 0, 0, 0),
-            PowerBounds(-600, 0, 0, 0),
-            PowerBounds(-1000, 0, 0, 0),
+            PowerBounds(
+                Power.from_watts(-600), Power.zero(), Power.zero(), Power.zero()
+            ),
+            PowerBounds(
+                Power.from_watts(-1000), Power.zero(), Power.zero(), Power.zero()
+            ),
+            PowerBounds(
+                Power.from_watts(-600), Power.zero(), Power.zero(), Power.zero()
+            ),
+            PowerBounds(
+                Power.from_watts(-1000), Power.zero(), Power.zero(), Power.zero()
+            ),
         ]
         components = create_components(2, capacity, soc, supply_bounds)
 
         algorithm = BatteryDistributionAlgorithm(distributor_exponent=1)
-        result = algorithm.distribute_power(-600, components)
+        result = algorithm.distribute_power(Power.from_watts(-600), components)
 
-        assert result.distribution == approx({1: -500, 3: -100})
-        assert result.remaining_power == approx(0.0)
+        for key, value in {1: -500, 3: -100}.items():
+            assert result.distribution[key].as_watts() == approx(value)
+
+        assert result.remaining_power.as_watts() == approx(0.0)
 
     def test_supply_two_batteries_2(self) -> None:
         """Distribute supply power between two batteries."""
@@ -547,18 +706,28 @@ class TestDistributionAlgorithm:  # pylint: disable=too-many-public-methods
         ]
         # consume bounds == 0 makes sure they are not used in supply algorithm
         supply_bounds = [
-            PowerBounds(-600, 0, 0, 0),
-            PowerBounds(-1000, 0, 0, 0),
-            PowerBounds(-600, 0, 0, 0),
-            PowerBounds(-1000, 0, 0, 0),
+            PowerBounds(
+                Power.from_watts(-600), Power.zero(), Power.zero(), Power.zero()
+            ),
+            PowerBounds(
+                Power.from_watts(-1000), Power.zero(), Power.zero(), Power.zero()
+            ),
+            PowerBounds(
+                Power.from_watts(-600), Power.zero(), Power.zero(), Power.zero()
+            ),
+            PowerBounds(
+                Power.from_watts(-1000), Power.zero(), Power.zero(), Power.zero()
+            ),
         ]
         components = create_components(2, capacity, soc, supply_bounds)
 
         algorithm = BatteryDistributionAlgorithm(distributor_exponent=1)
-        result = algorithm.distribute_power(-600, components)
+        result = algorithm.distribute_power(Power.from_watts(-600), components)
 
-        assert result.distribution == approx({1: -346.1538, 3: -253.8461})
-        assert result.remaining_power == approx(0.0)
+        for key, value in {1: -346.1538, 3: -253.8461}.items():
+            assert result.distribution[key].as_watts() == approx(value)
+
+        assert result.remaining_power.as_watts() == approx(0.0)
 
     # Test consumption power distribution
     def test_consumption_three_batteries_1(self) -> None:
@@ -571,20 +740,34 @@ class TestDistributionAlgorithm:  # pylint: disable=too-many-public-methods
         ]
         # consume bounds == 0 makes sure they are not used in supply algorithm
         bounds = [
-            PowerBounds(0, 0, 0, 900),
-            PowerBounds(0, 0, 0, 1000),
-            PowerBounds(0, 0, 0, 800),
-            PowerBounds(0, 0, 0, 700),
-            PowerBounds(0, 0, 0, 900),
-            PowerBounds(0, 0, 0, 900),
+            PowerBounds(
+                Power.zero(), Power.zero(), Power.zero(), Power.from_watts(900)
+            ),
+            PowerBounds(
+                Power.zero(), Power.zero(), Power.zero(), Power.from_watts(1000)
+            ),
+            PowerBounds(
+                Power.zero(), Power.zero(), Power.zero(), Power.from_watts(800)
+            ),
+            PowerBounds(
+                Power.zero(), Power.zero(), Power.zero(), Power.from_watts(700)
+            ),
+            PowerBounds(
+                Power.zero(), Power.zero(), Power.zero(), Power.from_watts(900)
+            ),
+            PowerBounds(
+                Power.zero(), Power.zero(), Power.zero(), Power.from_watts(900)
+            ),
         ]
         components = create_components(3, capacity, soc, bounds)
 
         algorithm = BatteryDistributionAlgorithm(distributor_exponent=1)
-        result = algorithm.distribute_power(1200, components)
+        result = algorithm.distribute_power(Power.from_watts(1200), components)
 
-        assert result.distribution == approx({1: 200, 3: 400, 5: 600})
-        assert result.remaining_power == approx(0.0)
+        for key, value in {1: 200, 3: 400, 5: 600}.items():
+            assert result.distribution[key].as_watts() == approx(value)
+
+        assert result.remaining_power.as_watts() == approx(0.0)
 
     def test_consumption_three_batteries_2(self) -> None:
         """Distribute consume power with three batteries but one with double the capacity."""
@@ -596,20 +779,34 @@ class TestDistributionAlgorithm:  # pylint: disable=too-many-public-methods
         ]
         # consume bounds == 0 makes sure they are not used in supply algorithm
         bounds = [
-            PowerBounds(0, 0, 0, 900),
-            PowerBounds(0, 0, 0, 1000),
-            PowerBounds(0, 0, 0, 800),
-            PowerBounds(0, 0, 0, 700),
-            PowerBounds(0, 0, 0, 900),
-            PowerBounds(0, 0, 0, 900),
+            PowerBounds(
+                Power.zero(), Power.zero(), Power.zero(), Power.from_watts(900)
+            ),
+            PowerBounds(
+                Power.zero(), Power.zero(), Power.zero(), Power.from_watts(1000)
+            ),
+            PowerBounds(
+                Power.zero(), Power.zero(), Power.zero(), Power.from_watts(800)
+            ),
+            PowerBounds(
+                Power.zero(), Power.zero(), Power.zero(), Power.from_watts(700)
+            ),
+            PowerBounds(
+                Power.zero(), Power.zero(), Power.zero(), Power.from_watts(900)
+            ),
+            PowerBounds(
+                Power.zero(), Power.zero(), Power.zero(), Power.from_watts(900)
+            ),
         ]
         components = create_components(3, capacity, soc, bounds)
 
         algorithm = BatteryDistributionAlgorithm(distributor_exponent=1)
-        result = algorithm.distribute_power(1400, components)
+        result = algorithm.distribute_power(Power.from_watts(1400), components)
 
-        assert result.distribution == approx({1: 400, 3: 400, 5: 600})
-        assert result.remaining_power == approx(0.0)
+        for key, value in {1: 400, 3: 400, 5: 600}.items():
+            assert result.distribution[key].as_watts() == approx(value)
+
+        assert result.remaining_power.as_watts() == approx(0.0)
 
     def test_consumption_three_batteries_3(self) -> None:
         """Distribute consume power with small bounds."""
@@ -621,20 +818,34 @@ class TestDistributionAlgorithm:  # pylint: disable=too-many-public-methods
         ]
         # consume bounds == 0 makes sure they are not used in supply algorithm
         bounds = [
-            PowerBounds(0, 0, 0, 600),
-            PowerBounds(0, 0, 0, 1000),
-            PowerBounds(0, 0, 0, 600),
-            PowerBounds(0, 0, 0, 100),
-            PowerBounds(0, 0, 0, 800),
-            PowerBounds(0, 0, 0, 900),
+            PowerBounds(
+                Power.zero(), Power.zero(), Power.zero(), Power.from_watts(600)
+            ),
+            PowerBounds(
+                Power.zero(), Power.zero(), Power.zero(), Power.from_watts(1000)
+            ),
+            PowerBounds(
+                Power.zero(), Power.zero(), Power.zero(), Power.from_watts(600)
+            ),
+            PowerBounds(
+                Power.zero(), Power.zero(), Power.zero(), Power.from_watts(100)
+            ),
+            PowerBounds(
+                Power.zero(), Power.zero(), Power.zero(), Power.from_watts(800)
+            ),
+            PowerBounds(
+                Power.zero(), Power.zero(), Power.zero(), Power.from_watts(900)
+            ),
         ]
         components = create_components(3, capacity, soc, bounds)
 
         algorithm = BatteryDistributionAlgorithm(distributor_exponent=1)
-        result = algorithm.distribute_power(1400, components)
+        result = algorithm.distribute_power(Power.from_watts(1400), components)
 
-        assert result.distribution == approx({1: 500, 3: 100, 5: 800})
-        assert result.remaining_power == approx(0.0)
+        for key, value in {1: 500, 3: 100, 5: 800}.items():
+            assert result.distribution[key].as_watts() == approx(value)
+
+        assert result.remaining_power.as_watts() == approx(0.0)
 
     def test_consumption_three_batteries_4(self) -> None:
         """Distribute consume power with small upper bounds."""
@@ -646,20 +857,34 @@ class TestDistributionAlgorithm:  # pylint: disable=too-many-public-methods
         ]
         # consume bounds == 0 makes sure they are not used in supply algorithm
         bounds = [
-            PowerBounds(0, 0, 0, 600),
-            PowerBounds(0, 0, 0, 1000),
-            PowerBounds(0, 0, 0, 600),
-            PowerBounds(0, 0, 0, 100),
-            PowerBounds(0, 0, 0, 800),
-            PowerBounds(0, 0, 0, 900),
+            PowerBounds(
+                Power.zero(), Power.zero(), Power.zero(), Power.from_watts(600)
+            ),
+            PowerBounds(
+                Power.zero(), Power.zero(), Power.zero(), Power.from_watts(1000)
+            ),
+            PowerBounds(
+                Power.zero(), Power.zero(), Power.zero(), Power.from_watts(600)
+            ),
+            PowerBounds(
+                Power.zero(), Power.zero(), Power.zero(), Power.from_watts(100)
+            ),
+            PowerBounds(
+                Power.zero(), Power.zero(), Power.zero(), Power.from_watts(800)
+            ),
+            PowerBounds(
+                Power.zero(), Power.zero(), Power.zero(), Power.from_watts(900)
+            ),
         ]
         components = create_components(3, capacity, soc, bounds)
 
         algorithm = BatteryDistributionAlgorithm(distributor_exponent=1)
-        result = algorithm.distribute_power(1700, components)
+        result = algorithm.distribute_power(Power.from_watts(1700), components)
 
-        assert result.distribution == approx({1: 600, 3: 100, 5: 800})
-        assert result.remaining_power == approx(200.0)
+        for key, value in {1: 600, 3: 100, 5: 800}.items():
+            assert result.distribution[key].as_watts() == approx(value)
+
+        assert result.remaining_power.as_watts() == approx(200.0)
 
     def test_consumption_three_batteries_5(self) -> None:
         """Test what if some batteries has invalid SoC and capacity."""
@@ -671,20 +896,34 @@ class TestDistributionAlgorithm:  # pylint: disable=too-many-public-methods
         ]
         # consume bounds == 0 makes sure they are not used in supply algorithm
         bounds = [
-            PowerBounds(0, 0, 0, 600),
-            PowerBounds(0, 0, 0, 1000),
-            PowerBounds(0, 0, 0, 600),
-            PowerBounds(0, 0, 0, 100),
-            PowerBounds(0, 0, 0, 800),
-            PowerBounds(0, 0, 0, 900),
+            PowerBounds(
+                Power.zero(), Power.zero(), Power.zero(), Power.from_watts(600)
+            ),
+            PowerBounds(
+                Power.zero(), Power.zero(), Power.zero(), Power.from_watts(1000)
+            ),
+            PowerBounds(
+                Power.zero(), Power.zero(), Power.zero(), Power.from_watts(600)
+            ),
+            PowerBounds(
+                Power.zero(), Power.zero(), Power.zero(), Power.from_watts(100)
+            ),
+            PowerBounds(
+                Power.zero(), Power.zero(), Power.zero(), Power.from_watts(800)
+            ),
+            PowerBounds(
+                Power.zero(), Power.zero(), Power.zero(), Power.from_watts(900)
+            ),
         ]
         components = create_components(3, capacity, soc, bounds)
 
         algorithm = BatteryDistributionAlgorithm(distributor_exponent=1)
-        result = algorithm.distribute_power(1700, components)
+        result = algorithm.distribute_power(Power.from_watts(1700), components)
 
-        assert result.distribution == approx({1: 0, 3: 100, 5: 0})
-        assert result.remaining_power == approx(1600.0)
+        for key, value in {1: 0, 3: 100, 5: 0}.items():
+            assert result.distribution[key].as_watts() == approx(value)
+
+        assert result.remaining_power.as_watts() == approx(1600.0)
 
     def test_consumption_three_batteries_6(self) -> None:
         """Distribute consume power."""
@@ -696,20 +935,34 @@ class TestDistributionAlgorithm:  # pylint: disable=too-many-public-methods
         ]
         # consume bounds == 0 makes sure they are not used in supply algorithm
         bounds = [
-            PowerBounds(0, 0, 0, 600),
-            PowerBounds(0, 0, 0, 1000),
-            PowerBounds(0, 0, 0, 600),
-            PowerBounds(0, 0, 0, 100),
-            PowerBounds(0, 0, 0, 800),
-            PowerBounds(0, 0, 0, 900),
+            PowerBounds(
+                Power.zero(), Power.zero(), Power.zero(), Power.from_watts(600)
+            ),
+            PowerBounds(
+                Power.zero(), Power.zero(), Power.zero(), Power.from_watts(1000)
+            ),
+            PowerBounds(
+                Power.zero(), Power.zero(), Power.zero(), Power.from_watts(600)
+            ),
+            PowerBounds(
+                Power.zero(), Power.zero(), Power.zero(), Power.from_watts(100)
+            ),
+            PowerBounds(
+                Power.zero(), Power.zero(), Power.zero(), Power.from_watts(800)
+            ),
+            PowerBounds(
+                Power.zero(), Power.zero(), Power.zero(), Power.from_watts(900)
+            ),
         ]
         components = create_components(3, capacity, soc, bounds)
 
         algorithm = BatteryDistributionAlgorithm(distributor_exponent=1)
-        result = algorithm.distribute_power(1700, components)
+        result = algorithm.distribute_power(Power.from_watts(1700), components)
 
-        assert result.distribution == approx({1: 0, 3: 100, 5: 800})
-        assert result.remaining_power == approx(800.0)
+        for key, value in {1: 0, 3: 100, 5: 800}.items():
+            assert result.distribution[key].as_watts() == approx(value)
+
+        assert result.remaining_power.as_watts() == approx(800.0)
 
     def test_consumption_three_batteries_7(self) -> None:
         """Distribute consume power."""
@@ -721,20 +974,34 @@ class TestDistributionAlgorithm:  # pylint: disable=too-many-public-methods
         ]
         # consume bounds == 0 makes sure they are not used in supply algorithm
         bounds = [
-            PowerBounds(0, 0, 0, 500),
-            PowerBounds(0, 0, 0, 1000),
-            PowerBounds(0, 0, 0, 600),
-            PowerBounds(0, 0, 0, 700),
-            PowerBounds(0, 0, 0, 800),
-            PowerBounds(0, 0, 0, 900),
+            PowerBounds(
+                Power.zero(), Power.zero(), Power.zero(), Power.from_watts(500)
+            ),
+            PowerBounds(
+                Power.zero(), Power.zero(), Power.zero(), Power.from_watts(1000)
+            ),
+            PowerBounds(
+                Power.zero(), Power.zero(), Power.zero(), Power.from_watts(600)
+            ),
+            PowerBounds(
+                Power.zero(), Power.zero(), Power.zero(), Power.from_watts(700)
+            ),
+            PowerBounds(
+                Power.zero(), Power.zero(), Power.zero(), Power.from_watts(800)
+            ),
+            PowerBounds(
+                Power.zero(), Power.zero(), Power.zero(), Power.from_watts(900)
+            ),
         ]
         components = create_components(3, capacity, soc, bounds)
 
         algorithm = BatteryDistributionAlgorithm(distributor_exponent=1)
-        result = algorithm.distribute_power(500, components)
+        result = algorithm.distribute_power(Power.from_watts(500), components)
 
-        assert result.distribution == approx({1: 498.3388, 3: 1.661129, 5: 0})
-        assert result.remaining_power == approx(0.0)
+        for key, value in {1: 498.3388, 3: 1.661129, 5: 0}.items():
+            assert result.distribution[key].as_watts() == approx(value)
+
+        assert result.remaining_power.as_watts() == approx(0.0)
 
     def test_consumption_two_batteries_1(self) -> None:
         """Distribute consume power."""
@@ -745,18 +1012,28 @@ class TestDistributionAlgorithm:  # pylint: disable=too-many-public-methods
         ]
         # consume bounds == 0 makes sure they are not used in supply algorithm
         bounds = [
-            PowerBounds(0, 0, 0, 600),
-            PowerBounds(0, 0, 0, 1000),
-            PowerBounds(0, 0, 0, 600),
-            PowerBounds(0, 0, 0, 1000),
+            PowerBounds(
+                Power.zero(), Power.zero(), Power.zero(), Power.from_watts(600)
+            ),
+            PowerBounds(
+                Power.zero(), Power.zero(), Power.zero(), Power.from_watts(1000)
+            ),
+            PowerBounds(
+                Power.zero(), Power.zero(), Power.zero(), Power.from_watts(600)
+            ),
+            PowerBounds(
+                Power.zero(), Power.zero(), Power.zero(), Power.from_watts(1000)
+            ),
         ]
         components = create_components(2, capacity, soc, bounds)
 
         algorithm = BatteryDistributionAlgorithm(distributor_exponent=1)
-        result = algorithm.distribute_power(600, components)
+        result = algorithm.distribute_power(Power.from_watts(600), components)
 
-        assert result.distribution == approx({1: 100, 3: 500})
-        assert result.remaining_power == approx(0.0)
+        for key, value in {1: 100, 3: 500}.items():
+            assert result.distribution[key].as_watts() == approx(value)
+
+        assert result.remaining_power.as_watts() == approx(0.0)
 
     def test_consumption_two_batteries_distribution_exponent(self) -> None:
         """Distribute consume power."""
@@ -767,30 +1044,44 @@ class TestDistributionAlgorithm:  # pylint: disable=too-many-public-methods
         ]
         # consume bounds == 0 makes sure they are not used in supply algorithm
         bounds = [
-            PowerBounds(0, 0, 0, 9000),
-            PowerBounds(0, 0, 0, 9000),
-            PowerBounds(0, 0, 0, 9000),
-            PowerBounds(0, 0, 0, 9000),
+            PowerBounds(
+                Power.zero(), Power.zero(), Power.zero(), Power.from_watts(9000)
+            ),
+            PowerBounds(
+                Power.zero(), Power.zero(), Power.zero(), Power.from_watts(9000)
+            ),
+            PowerBounds(
+                Power.zero(), Power.zero(), Power.zero(), Power.from_watts(9000)
+            ),
+            PowerBounds(
+                Power.zero(), Power.zero(), Power.zero(), Power.from_watts(9000)
+            ),
         ]
         components = create_components(2, capacity, soc, bounds)
 
         algorithm = BatteryDistributionAlgorithm(distributor_exponent=1)
-        result = algorithm.distribute_power(8000, components)
+        result = algorithm.distribute_power(Power.from_watts(8000), components)
 
-        assert result.distribution == approx({1: 2000, 3: 6000})
-        assert result.remaining_power == approx(0.0)
+        for key, value in {1: 2000.0, 3: 6000.0}.items():
+            assert result.distribution[key].as_watts() == approx(value)
+
+        assert result.remaining_power.as_watts() == approx(0.0)
 
         algorithm2 = BatteryDistributionAlgorithm(distributor_exponent=2)
-        result2 = algorithm2.distribute_power(8000, components)
+        result2 = algorithm2.distribute_power(Power.from_watts(8000), components)
 
-        assert result2.distribution == approx({1: 800, 3: 7200})
-        assert result2.remaining_power == approx(0.0)
+        for key, value in {1: 800.0, 3: 7200.0}.items():
+            assert result2.distribution[key].as_watts() == approx(value)
+
+        assert result2.remaining_power.as_watts() == approx(0.0)
 
         algorithm3 = BatteryDistributionAlgorithm(distributor_exponent=3)
-        result3 = algorithm3.distribute_power(8000, components)
+        result3 = algorithm3.distribute_power(Power.from_watts(8000), components)
 
-        assert result3.distribution == approx({1: 285.7142, 3: 7714.2857})
-        assert result3.remaining_power == approx(0.0)
+        for key, value in {1: 285.7142, 3: 7714.2857}.items():
+            assert result3.distribution[key].as_watts() == approx(value)
+
+        assert result3.remaining_power.as_watts() == approx(0.0)
 
     def test_consumption_two_batteries_distribution_exponent_1(self) -> None:
         """Distribute consume power."""
@@ -801,48 +1092,68 @@ class TestDistributionAlgorithm:  # pylint: disable=too-many-public-methods
         ]
         # consume bounds == 0 makes sure they are not used in supply algorithm
         bounds = [
-            PowerBounds(0, 0, 0, 9000),
-            PowerBounds(0, 0, 0, 9000),
-            PowerBounds(0, 0, 0, 9000),
-            PowerBounds(0, 0, 0, 9000),
+            PowerBounds(
+                Power.zero(), Power.zero(), Power.zero(), Power.from_watts(9000)
+            ),
+            PowerBounds(
+                Power.zero(), Power.zero(), Power.zero(), Power.from_watts(9000)
+            ),
+            PowerBounds(
+                Power.zero(), Power.zero(), Power.zero(), Power.from_watts(9000)
+            ),
+            PowerBounds(
+                Power.zero(), Power.zero(), Power.zero(), Power.from_watts(9000)
+            ),
         ]
         components = create_components(2, capacity, soc, bounds)
 
         algorithm = BatteryDistributionAlgorithm(distributor_exponent=1)
-        result = algorithm.distribute_power(900, components)
+        result = algorithm.distribute_power(Power.from_watts(900), components)
 
-        assert result.distribution == approx({1: 300, 3: 600})
-        assert result.remaining_power == approx(0.0)
+        for key, value in {1: 300.0, 3: 600.0}.items():
+            assert result.distribution[key].as_watts() == approx(value)
+
+        assert result.remaining_power.as_watts() == approx(0.0)
 
         algorithm = BatteryDistributionAlgorithm(distributor_exponent=1)
-        result = algorithm.distribute_power(8000, components)
+        result = algorithm.distribute_power(Power.from_watts(8000), components)
 
-        assert result.distribution == approx({1: 2666.6666, 3: 5333.3333})
-        assert result.remaining_power == approx(0.0)
+        for key, value in {1: 2666.6666, 3: 5333.3333}.items():
+            assert result.distribution[key].as_watts() == approx(value)
 
-        algorithm2 = BatteryDistributionAlgorithm(distributor_exponent=2)
-        result2 = algorithm2.distribute_power(900, components)
-
-        assert result2.distribution == approx({1: 180, 3: 720})
-        assert result2.remaining_power == approx(0.0)
+        assert result.remaining_power.as_watts() == approx(0.0)
 
         algorithm2 = BatteryDistributionAlgorithm(distributor_exponent=2)
-        result2 = algorithm2.distribute_power(8000, components)
+        result2 = algorithm2.distribute_power(Power.from_watts(900), components)
 
-        assert result2.distribution == approx({1: 1600, 3: 6400})
-        assert result2.remaining_power == approx(0.0)
+        for key, value in {1: 180, 3: 720}.items():
+            assert result2.distribution[key].as_watts() == approx(value)
+
+        assert result2.remaining_power.as_watts() == approx(0.0)
+
+        algorithm2 = BatteryDistributionAlgorithm(distributor_exponent=2)
+        result2 = algorithm2.distribute_power(Power.from_watts(8000), components)
+
+        for key, value in {1: 1600, 3: 6400}.items():
+            assert result2.distribution[key].as_watts() == approx(value)
+
+        assert result2.remaining_power.as_watts() == approx(0.0)
 
         algorithm2 = BatteryDistributionAlgorithm(distributor_exponent=3)
-        result2 = algorithm2.distribute_power(900, components)
+        result2 = algorithm2.distribute_power(Power.from_watts(900), components)
 
-        assert result2.distribution == approx({1: 100, 3: 800})
-        assert result2.remaining_power == approx(0.0)
+        for key, value in {1: 100, 3: 800}.items():
+            assert result2.distribution[key].as_watts() == approx(value)
+
+        assert result2.remaining_power.as_watts() == approx(0.0)
 
         algorithm3 = BatteryDistributionAlgorithm(distributor_exponent=3)
-        result3 = algorithm3.distribute_power(8000, components)
+        result3 = algorithm3.distribute_power(Power.from_watts(8000), components)
 
-        assert result3.distribution == approx({1: 888.8888, 3: 7111.1111})
-        assert result3.remaining_power == approx(0.0)
+        for key, value in {1: 888.8888, 3: 7111.1111}.items():
+            assert result3.distribution[key].as_watts() == approx(value)
+
+        assert result3.remaining_power.as_watts() == approx(0.0)
 
     def test_supply_two_batteries_distribution_exponent(self) -> None:
         """Distribute power."""
@@ -853,30 +1164,44 @@ class TestDistributionAlgorithm:  # pylint: disable=too-many-public-methods
         ]
         # consume bounds == 0 makes sure they are not used in supply algorithm
         bounds = [
-            PowerBounds(-9000, 0, 0, 0),
-            PowerBounds(-9000, 0, 0, 0),
-            PowerBounds(-9000, 0, 0, 0),
-            PowerBounds(-9000, 0, 0, 0),
+            PowerBounds(
+                Power.from_watts(-9000), Power.zero(), Power.zero(), Power.zero()
+            ),
+            PowerBounds(
+                Power.from_watts(-9000), Power.zero(), Power.zero(), Power.zero()
+            ),
+            PowerBounds(
+                Power.from_watts(-9000), Power.zero(), Power.zero(), Power.zero()
+            ),
+            PowerBounds(
+                Power.from_watts(-9000), Power.zero(), Power.zero(), Power.zero()
+            ),
         ]
         components = create_components(2, capacity, soc, bounds)
 
         algorithm = BatteryDistributionAlgorithm(distributor_exponent=1)
-        result = algorithm.distribute_power(-8000, components)
+        result = algorithm.distribute_power(Power.from_watts(-8000), components)
 
-        assert result.distribution == approx({1: -2000, 3: -6000})
-        assert result.remaining_power == approx(0.0)
+        for key, value in {1: -2000.0, 3: -6000.0}.items():
+            assert result.distribution[key].as_watts() == approx(value)
+
+        assert result.remaining_power.as_watts() == approx(0.0)
 
         algorithm2 = BatteryDistributionAlgorithm(distributor_exponent=2)
-        result2 = algorithm2.distribute_power(-8000, components)
+        result2 = algorithm2.distribute_power(Power.from_watts(-8000), components)
 
-        assert result2.distribution == approx({1: -800, 3: -7200})
-        assert result2.remaining_power == approx(0.0)
+        for key, value in {1: -800, 3: -7200}.items():
+            assert result2.distribution[key].as_watts() == approx(value)
+
+        assert result2.remaining_power.as_watts() == approx(0.0)
 
         algorithm3 = BatteryDistributionAlgorithm(distributor_exponent=3)
-        result3 = algorithm3.distribute_power(-8000, components)
+        result3 = algorithm3.distribute_power(Power.from_watts(-8000), components)
 
-        assert result3.distribution == approx({1: -285.7142, 3: -7714.2857})
-        assert result3.remaining_power == approx(0.0)
+        for key, value in {1: -285.7142, 3: -7714.2857}.items():
+            assert result3.distribution[key].as_watts() == approx(value)
+
+        assert result3.remaining_power.as_watts() == approx(0.0)
 
     def test_supply_two_batteries_distribution_exponent_1(self) -> None:
         """Distribute power."""
@@ -887,30 +1212,44 @@ class TestDistributionAlgorithm:  # pylint: disable=too-many-public-methods
         ]
         # consume bounds == 0 makes sure they are not used in supply algorithm
         supply_bounds = [
-            PowerBounds(-9000, 0, 0, 0),
-            PowerBounds(-9000, 0, 0, 0),
-            PowerBounds(-9000, 0, 0, 0),
-            PowerBounds(-9000, 0, 0, 0),
+            PowerBounds(
+                Power.from_watts(-9000), Power.zero(), Power.zero(), Power.zero()
+            ),
+            PowerBounds(
+                Power.from_watts(-9000), Power.zero(), Power.zero(), Power.zero()
+            ),
+            PowerBounds(
+                Power.from_watts(-9000), Power.zero(), Power.zero(), Power.zero()
+            ),
+            PowerBounds(
+                Power.from_watts(-9000), Power.zero(), Power.zero(), Power.zero()
+            ),
         ]
         components = create_components(2, capacity, soc, supply_bounds)
 
         algorithm = BatteryDistributionAlgorithm(distributor_exponent=1)
-        result = algorithm.distribute_power(-8000, components)
+        result = algorithm.distribute_power(Power.from_watts(-8000), components)
 
-        assert result.distribution == approx({1: -2666.6666, 3: -5333.3333})
-        assert result.remaining_power == approx(0.0)
+        for key, value in {1: -2666.6666, 3: -5333.3333}.items():
+            assert result.distribution[key].as_watts() == approx(value)
+
+        assert result.remaining_power.as_watts() == approx(0.0)
 
         algorithm2 = BatteryDistributionAlgorithm(distributor_exponent=2)
-        result2 = algorithm2.distribute_power(-8000, components)
+        result2 = algorithm2.distribute_power(Power.from_watts(-8000), components)
 
-        assert result2.distribution == approx({1: -1600, 3: -6400})
-        assert result2.remaining_power == approx(0.0)
+        for key, value in {1: -1600, 3: -6400}.items():
+            assert result2.distribution[key].as_watts() == approx(value)
+
+        assert result2.remaining_power.as_watts() == approx(0.0)
 
         algorithm3 = BatteryDistributionAlgorithm(distributor_exponent=3)
-        result3 = algorithm3.distribute_power(-8000, components)
+        result3 = algorithm3.distribute_power(Power.from_watts(-8000), components)
 
-        assert result3.distribution == approx({1: -888.8888, 3: -7111.1111})
-        assert result3.remaining_power == approx(0.0)
+        for key, value in {1: -888.8888, 3: -7111.1111}.items():
+            assert result3.distribution[key].as_watts() == approx(value)
+
+        assert result3.remaining_power.as_watts() == approx(0.0)
 
     def test_supply_three_batteries_distribution_exponent_2(self) -> None:
         """Distribute power."""
@@ -922,38 +1261,50 @@ class TestDistributionAlgorithm:  # pylint: disable=too-many-public-methods
         ]
         # consume bounds == 0 makes sure they are not used in supply algorithm
         bounds = [
-            PowerBounds(-9000, 0, 0, 0),
-            PowerBounds(-9000, 0, 0, 0),
-            PowerBounds(-9000, 0, 0, 0),
-            PowerBounds(-9000, 0, 0, 0),
-            PowerBounds(-9000, 0, 0, 0),
-            PowerBounds(-9000, 0, 0, 0),
+            PowerBounds(
+                Power.from_watts(-9000), Power.zero(), Power.zero(), Power.zero()
+            ),
+            PowerBounds(
+                Power.from_watts(-9000), Power.zero(), Power.zero(), Power.zero()
+            ),
+            PowerBounds(
+                Power.from_watts(-9000), Power.zero(), Power.zero(), Power.zero()
+            ),
+            PowerBounds(
+                Power.from_watts(-9000), Power.zero(), Power.zero(), Power.zero()
+            ),
+            PowerBounds(
+                Power.from_watts(-9000), Power.zero(), Power.zero(), Power.zero()
+            ),
+            PowerBounds(
+                Power.from_watts(-9000), Power.zero(), Power.zero(), Power.zero()
+            ),
         ]
         components = create_components(3, capacity, soc, bounds)
 
         algorithm = BatteryDistributionAlgorithm(distributor_exponent=1)
-        result = algorithm.distribute_power(-8000, components)
+        result = algorithm.distribute_power(Power.from_watts(-8000), components)
 
-        assert result.distribution == approx(
-            {1: -1777.7777, 3: -2666.6666, 5: -3555.5555}
-        )
-        assert result.remaining_power == approx(0.0)
+        for key, value in {1: -1777.7777, 3: -2666.6666, 5: -3555.5555}.items():
+            assert result.distribution[key].as_watts() == approx(value)
+
+        assert result.remaining_power.as_watts() == approx(0.0)
 
         algorithm2 = BatteryDistributionAlgorithm(distributor_exponent=2)
-        result2 = algorithm2.distribute_power(-8000, components)
+        result2 = algorithm2.distribute_power(Power.from_watts(-8000), components)
 
-        assert result2.distribution == approx(
-            {1: -1103.4482, 3: -2482.7586, 5: -4413.7931}
-        )
-        assert result2.remaining_power == approx(0.0)
+        for key, value in {1: -1103.4482, 3: -2482.7586, 5: -4413.7931}.items():
+            assert result2.distribution[key].as_watts() == approx(value)
+
+        assert result2.remaining_power.as_watts() == approx(0.0)
 
         algorithm3 = BatteryDistributionAlgorithm(distributor_exponent=3)
-        result3 = algorithm3.distribute_power(-8000, components)
+        result3 = algorithm3.distribute_power(Power.from_watts(-8000), components)
 
-        assert result3.distribution == approx(
-            {1: -646.4646, 3: -2181.8181, 5: -5171.7171}
-        )
-        assert result3.remaining_power == approx(0.0)
+        for key, value in {1: -646.4646, 3: -2181.8181, 5: -5171.7171}.items():
+            assert result3.distribution[key].as_watts() == approx(value)
+
+        assert result3.remaining_power.as_watts() == approx(0.0)
 
     def test_supply_three_batteries_distribution_exponent_3(self) -> None:
         """Distribute power."""
@@ -965,26 +1316,42 @@ class TestDistributionAlgorithm:  # pylint: disable=too-many-public-methods
         ]
         # consume bounds == 0 makes sure they are not used in supply algorithm
         supply_bounds = [
-            PowerBounds(-9000, 0, 0, 0),
-            PowerBounds(-9000, 0, 0, 0),
-            PowerBounds(-9000, 0, 0, 0),
-            PowerBounds(-9000, 0, 0, 0),
-            PowerBounds(-9000, 0, 0, 0),
-            PowerBounds(-9000, 0, 0, 0),
+            PowerBounds(
+                Power.from_watts(-9000), Power.zero(), Power.zero(), Power.zero()
+            ),
+            PowerBounds(
+                Power.from_watts(-9000), Power.zero(), Power.zero(), Power.zero()
+            ),
+            PowerBounds(
+                Power.from_watts(-9000), Power.zero(), Power.zero(), Power.zero()
+            ),
+            PowerBounds(
+                Power.from_watts(-9000), Power.zero(), Power.zero(), Power.zero()
+            ),
+            PowerBounds(
+                Power.from_watts(-9000), Power.zero(), Power.zero(), Power.zero()
+            ),
+            PowerBounds(
+                Power.from_watts(-9000), Power.zero(), Power.zero(), Power.zero()
+            ),
         ]
         components = create_components(3, capacity, soc, supply_bounds)
 
         algorithm = BatteryDistributionAlgorithm(distributor_exponent=0.5)
-        result = algorithm.distribute_power(-1300, components)
+        result = algorithm.distribute_power(Power.from_watts(-1300), components)
 
-        assert result.distribution == approx({1: -600, 3: -400, 5: -300})
-        assert result.remaining_power == approx(0.0)
+        for key, value in {1: -600, 3: -400, 5: -300}.items():
+            assert result.distribution[key].as_watts() == approx(value)
+
+        assert result.remaining_power.as_watts() == approx(0.0)
 
         algorithm = BatteryDistributionAlgorithm(distributor_exponent=0)
-        result = algorithm.distribute_power(-1200, components)
+        result = algorithm.distribute_power(Power.from_watts(-1200), components)
 
-        assert result.distribution == approx({1: -400, 3: -400, 5: -400})
-        assert result.remaining_power == approx(0.0)
+        for key, value in {1: -400, 3: -400, 5: -400}.items():
+            assert result.distribution[key].as_watts() == approx(value)
+
+        assert result.remaining_power.as_watts() == approx(0.0)
 
     def test_supply_two_batteries_distribution_exponent_less_then_1(self) -> None:
         """Distribute power."""
@@ -995,24 +1362,36 @@ class TestDistributionAlgorithm:  # pylint: disable=too-many-public-methods
         ]
         # consume bounds == 0 makes sure they are not used in supply algorithm
         bounds = [
-            PowerBounds(0, 0, 0, 9000),
-            PowerBounds(0, 0, 0, 9000),
-            PowerBounds(0, 0, 0, 9000),
-            PowerBounds(0, 0, 0, 9000),
+            PowerBounds(
+                Power.zero(), Power.zero(), Power.zero(), Power.from_watts(9000)
+            ),
+            PowerBounds(
+                Power.zero(), Power.zero(), Power.zero(), Power.from_watts(9000)
+            ),
+            PowerBounds(
+                Power.zero(), Power.zero(), Power.zero(), Power.from_watts(9000)
+            ),
+            PowerBounds(
+                Power.zero(), Power.zero(), Power.zero(), Power.from_watts(9000)
+            ),
         ]
         components = create_components(2, capacity, soc, bounds)
 
         algorithm = BatteryDistributionAlgorithm(distributor_exponent=0.5)
-        result = algorithm.distribute_power(1000, components)
+        result = algorithm.distribute_power(Power.from_watts(1000), components)
 
-        assert result.distribution == approx({1: 600, 3: 400})
-        assert result.remaining_power == approx(0.0)
+        for key, value in {1: 600, 3: 400}.items():
+            assert result.distribution[key].as_watts() == approx(value)
+
+        assert result.remaining_power.as_watts() == approx(0.0)
 
         algorithm = BatteryDistributionAlgorithm(distributor_exponent=0)
-        result = algorithm.distribute_power(1000, components)
+        result = algorithm.distribute_power(Power.from_watts(1000), components)
 
-        assert result.distribution == approx({1: 500, 3: 500})
-        assert result.remaining_power == approx(0.0)
+        for key, value in {1: 500, 3: 500}.items():
+            assert result.distribution[key].as_watts() == approx(value)
+
+        assert result.remaining_power.as_watts() == approx(0.0)
 
 
 class TestDistWithExclBounds:
@@ -1021,15 +1400,20 @@ class TestDistWithExclBounds:
     @staticmethod
     def assert_result(result: DistributionResult, expected: DistributionResult) -> None:
         """Assert the result is as expected."""
-        assert result.distribution == approx(expected.distribution, abs=0.01)
-        assert result.remaining_power == approx(expected.remaining_power, abs=0.01)
+        for key, value in expected.distribution.items():
+            assert result.distribution[key].as_watts() == approx(
+                value.as_watts(), abs=0.01
+            )
+        assert result.remaining_power.as_watts() == approx(
+            expected.remaining_power.as_watts(), abs=0.01
+        )
 
     @staticmethod
     def assert_any_result(
         result: DistributionResult,
         expected_distribution_ids: Set[int],
-        expected_distribution_powers: Sequence[float],
-        expected_remaining_power: float,
+        expected_distribution_powers: Sequence[Power],
+        expected_remaining_power: Power,
     ) -> None:
         """Assert the result is as expected, disregarding which power goes to which component."""
         assert result.remaining_power == expected_remaining_power
@@ -1075,65 +1459,175 @@ class TestDistWithExclBounds:
             Metric(70.0, Bound(10, 90)),
         ]
         bounds = [
-            PowerBounds(-1000, -100, 20, 1000),
-            PowerBounds(-1000, -90, 100, 1000),
-            PowerBounds(-1000, -50, 100, 1000),
-            PowerBounds(-1000, -100, 90, 1000),
-            PowerBounds(-1000, -20, 100, 1000),
-            PowerBounds(-1000, -100, 80, 1000),
+            PowerBounds(
+                Power.from_watts(-1000),
+                Power.from_watts(-100),
+                Power.from_watts(20),
+                Power.from_watts(1000),
+            ),
+            PowerBounds(
+                Power.from_watts(-1000),
+                Power.from_watts(-90),
+                Power.from_watts(100),
+                Power.from_watts(1000),
+            ),
+            PowerBounds(
+                Power.from_watts(-1000),
+                Power.from_watts(-50),
+                Power.from_watts(100),
+                Power.from_watts(1000),
+            ),
+            PowerBounds(
+                Power.from_watts(-1000),
+                Power.from_watts(-100),
+                Power.from_watts(90),
+                Power.from_watts(1000),
+            ),
+            PowerBounds(
+                Power.from_watts(-1000),
+                Power.from_watts(-20),
+                Power.from_watts(100),
+                Power.from_watts(1000),
+            ),
+            PowerBounds(
+                Power.from_watts(-1000),
+                Power.from_watts(-100),
+                Power.from_watts(80),
+                Power.from_watts(1000),
+            ),
         ]
         components = create_components(3, capacities, soc, bounds)
 
         algorithm = BatteryDistributionAlgorithm()
 
         self.assert_result(
-            algorithm.distribute_power(0, components),
-            DistributionResult({1: 0, 3: 0, 5: 0}, remaining_power=0.0),
+            algorithm.distribute_power(Power.zero(), components),
+            DistributionResult(
+                {1: Power.zero(), 3: Power.zero(), 5: Power.zero()},
+                remaining_power=Power.zero(),
+            ),
         )
 
         self.assert_result(
-            algorithm.distribute_power(-300, components),
-            DistributionResult({1: -100, 3: -100, 5: -100}, remaining_power=0.0),
+            algorithm.distribute_power(Power.from_watts(-300), components),
+            DistributionResult(
+                {
+                    1: Power.from_watts(-100),
+                    3: Power.from_watts(-100),
+                    5: Power.from_watts(-100),
+                },
+                remaining_power=Power.zero(),
+            ),
         )
         self.assert_result(
-            algorithm.distribute_power(300, components),
-            DistributionResult({1: 100, 3: 100, 5: 100}, remaining_power=0.0),
+            algorithm.distribute_power(Power.from_watts(300), components),
+            DistributionResult(
+                {
+                    1: Power.from_watts(100),
+                    3: Power.from_watts(100),
+                    5: Power.from_watts(100),
+                },
+                remaining_power=Power.zero(),
+            ),
         )
         self.assert_result(
-            algorithm.distribute_power(-600, components),
-            DistributionResult({1: -100, 3: -200, 5: -300}, remaining_power=0.0),
+            algorithm.distribute_power(Power.from_watts(-600), components),
+            DistributionResult(
+                {
+                    1: Power.from_watts(-100),
+                    3: Power.from_watts(-200),
+                    5: Power.from_watts(-300),
+                },
+                remaining_power=Power.zero(),
+            ),
         )
         self.assert_result(
-            algorithm.distribute_power(900, components),
-            DistributionResult({1: 450, 3: 300, 5: 150}, remaining_power=0.0),
+            algorithm.distribute_power(Power.from_watts(900), components),
+            DistributionResult(
+                {
+                    1: Power.from_watts(450),
+                    3: Power.from_watts(300),
+                    5: Power.from_watts(150),
+                },
+                remaining_power=Power.zero(),
+            ),
         )
         self.assert_result(
-            algorithm.distribute_power(-900, components),
-            DistributionResult({1: -150, 3: -300, 5: -450}, remaining_power=0.0),
+            algorithm.distribute_power(Power.from_watts(-900), components),
+            DistributionResult(
+                {
+                    1: Power.from_watts(-150),
+                    3: Power.from_watts(-300),
+                    5: Power.from_watts(-450),
+                },
+                remaining_power=Power.zero(),
+            ),
         )
         self.assert_result(
-            algorithm.distribute_power(2200, components),
-            DistributionResult({1: 1000, 3: 833.33, 5: 366.66}, remaining_power=0.0),
+            algorithm.distribute_power(Power.from_watts(2200), components),
+            DistributionResult(
+                {
+                    1: Power.from_watts(1000),
+                    3: Power.from_watts(833.33),
+                    5: Power.from_watts(366.66),
+                },
+                remaining_power=Power.zero(),
+            ),
         )
         self.assert_result(
-            algorithm.distribute_power(-2200, components),
-            DistributionResult({1: -366.66, 3: -833.33, 5: -1000}, remaining_power=0.0),
+            algorithm.distribute_power(Power.from_watts(-2200), components),
+            DistributionResult(
+                {
+                    1: Power.from_watts(-366.66),
+                    3: Power.from_watts(-833.33),
+                    5: Power.from_watts(-1000),
+                },
+                remaining_power=Power.zero(),
+            ),
         )
         self.assert_result(
-            algorithm.distribute_power(2800, components),
-            DistributionResult({1: 1000, 3: 1000, 5: 800}, remaining_power=0.0),
+            algorithm.distribute_power(Power.from_watts(2800), components),
+            DistributionResult(
+                {
+                    1: Power.from_watts(1000),
+                    3: Power.from_watts(1000),
+                    5: Power.from_watts(800),
+                },
+                remaining_power=Power.zero(),
+            ),
         )
         self.assert_result(
-            algorithm.distribute_power(-2800, components),
-            DistributionResult({1: -800, 3: -1000, 5: -1000}, remaining_power=0.0),
+            algorithm.distribute_power(Power.from_watts(-2800), components),
+            DistributionResult(
+                {
+                    1: Power.from_watts(-800),
+                    3: Power.from_watts(-1000),
+                    5: Power.from_watts(-1000),
+                },
+                remaining_power=Power.zero(),
+            ),
         )
         self.assert_result(
-            algorithm.distribute_power(3800, components),
-            DistributionResult({1: 1000, 3: 1000, 5: 1000}, remaining_power=800.0),
+            algorithm.distribute_power(Power.from_watts(3800), components),
+            DistributionResult(
+                {
+                    1: Power.from_watts(1000),
+                    3: Power.from_watts(1000),
+                    5: Power.from_watts(1000),
+                },
+                remaining_power=Power.from_watts(800.0),
+            ),
         )
         self.assert_result(
-            algorithm.distribute_power(-3200, components),
-            DistributionResult({1: -1000, 3: -1000, 5: -1000}, remaining_power=-200.0),
+            algorithm.distribute_power(Power.from_watts(-3200), components),
+            DistributionResult(
+                {
+                    1: Power.from_watts(-1000),
+                    3: Power.from_watts(-1000),
+                    5: Power.from_watts(-1000),
+                },
+                remaining_power=Power.from_watts(-200.0),
+            ),
         )
 
     def test_scenario_2(self) -> None:
@@ -1173,70 +1667,178 @@ class TestDistWithExclBounds:
             Metric(70.0, Bound(10, 90)),
         ]
         bounds = [
-            PowerBounds(-1000, -100, 20, 1000),
-            PowerBounds(-1000, -90, 100, 1000),
-            PowerBounds(-1000, -50, 100, 1000),
-            PowerBounds(-1000, -100, 90, 1000),
-            PowerBounds(-1000, -20, 100, 1000),
-            PowerBounds(-1000, -100, 80, 1000),
+            PowerBounds(
+                Power.from_watts(-1000),
+                Power.from_watts(-100),
+                Power.from_watts(20),
+                Power.from_watts(1000),
+            ),
+            PowerBounds(
+                Power.from_watts(-1000),
+                Power.from_watts(-90),
+                Power.from_watts(100),
+                Power.from_watts(1000),
+            ),
+            PowerBounds(
+                Power.from_watts(-1000),
+                Power.from_watts(-50),
+                Power.from_watts(100),
+                Power.from_watts(1000),
+            ),
+            PowerBounds(
+                Power.from_watts(-1000),
+                Power.from_watts(-100),
+                Power.from_watts(90),
+                Power.from_watts(1000),
+            ),
+            PowerBounds(
+                Power.from_watts(-1000),
+                Power.from_watts(-20),
+                Power.from_watts(100),
+                Power.from_watts(1000),
+            ),
+            PowerBounds(
+                Power.from_watts(-1000),
+                Power.from_watts(-100),
+                Power.from_watts(80),
+                Power.from_watts(1000),
+            ),
         ]
         components = create_components(3, capacities, soc, bounds)
 
         algorithm = BatteryDistributionAlgorithm()
 
         self.assert_result(
-            algorithm.distribute_power(-300, components),
-            DistributionResult({1: -100, 3: -100, 5: -100}, remaining_power=0.0),
-        )
-        self.assert_result(
-            algorithm.distribute_power(300, components),
-            DistributionResult({1: 100, 3: 100, 5: 100}, remaining_power=0.0),
-        )
-        self.assert_result(
-            algorithm.distribute_power(-530, components),
+            algorithm.distribute_power(Power.from_watts(-300), components),
             DistributionResult(
-                {1: -151.42, 3: -151.42, 5: -227.14}, remaining_power=0.0
+                {
+                    1: Power.from_watts(-100),
+                    3: Power.from_watts(-100),
+                    5: Power.from_watts(-100),
+                },
+                remaining_power=Power.zero(),
             ),
         )
         self.assert_result(
-            algorithm.distribute_power(530, components),
-            DistributionResult({1: 212, 3: 212, 5: 106}, remaining_power=0.0),
-        )
-        self.assert_result(
-            algorithm.distribute_power(2000, components),
-            DistributionResult({1: 800, 3: 800, 5: 400}, remaining_power=0.0),
-        )
-        self.assert_result(
-            algorithm.distribute_power(-2000, components),
+            algorithm.distribute_power(Power.from_watts(300), components),
             DistributionResult(
-                {1: -571.42, 3: -571.42, 5: -857.14}, remaining_power=0.0
+                {
+                    1: Power.from_watts(100),
+                    3: Power.from_watts(100),
+                    5: Power.from_watts(100),
+                },
+                remaining_power=Power.zero(),
             ),
         )
         self.assert_result(
-            algorithm.distribute_power(2500, components),
-            DistributionResult({1: 1000, 3: 1000, 5: 500}, remaining_power=0.0),
-        )
-        self.assert_result(
-            algorithm.distribute_power(-2500, components),
+            algorithm.distribute_power(Power.from_watts(-530), components),
             DistributionResult(
-                {1: -785.71, 3: -714.28, 5: -1000.0}, remaining_power=0.0
+                {
+                    1: Power.from_watts(-151.42),
+                    3: Power.from_watts(-151.42),
+                    5: Power.from_watts(-227.14),
+                },
+                remaining_power=Power.zero(),
             ),
         )
         self.assert_result(
-            algorithm.distribute_power(3000, components),
-            DistributionResult({1: 1000, 3: 1000, 5: 1000}, remaining_power=0.0),
+            algorithm.distribute_power(Power.from_watts(530), components),
+            DistributionResult(
+                {
+                    1: Power.from_watts(212),
+                    3: Power.from_watts(212),
+                    5: Power.from_watts(106),
+                },
+                remaining_power=Power.zero(),
+            ),
         )
         self.assert_result(
-            algorithm.distribute_power(-3000, components),
-            DistributionResult({1: -1000, 3: -1000, 5: -1000}, remaining_power=0.0),
+            algorithm.distribute_power(Power.from_watts(2000), components),
+            DistributionResult(
+                {
+                    1: Power.from_watts(800),
+                    3: Power.from_watts(800),
+                    5: Power.from_watts(400),
+                },
+                remaining_power=Power.zero(),
+            ),
         )
         self.assert_result(
-            algorithm.distribute_power(3500, components),
-            DistributionResult({1: 1000, 3: 1000, 5: 1000}, remaining_power=500.0),
+            algorithm.distribute_power(Power.from_watts(-2000), components),
+            DistributionResult(
+                {
+                    1: Power.from_watts(-571.42),
+                    3: Power.from_watts(-571.42),
+                    5: Power.from_watts(-857.14),
+                },
+                remaining_power=Power.zero(),
+            ),
         )
         self.assert_result(
-            algorithm.distribute_power(-3500, components),
-            DistributionResult({1: -1000, 3: -1000, 5: -1000}, remaining_power=-500.0),
+            algorithm.distribute_power(Power.from_watts(2500), components),
+            DistributionResult(
+                {
+                    1: Power.from_watts(1000),
+                    3: Power.from_watts(1000),
+                    5: Power.from_watts(500),
+                },
+                remaining_power=Power.zero(),
+            ),
+        )
+        self.assert_result(
+            algorithm.distribute_power(Power.from_watts(-2500), components),
+            DistributionResult(
+                {
+                    1: Power.from_watts(-785.71),
+                    3: Power.from_watts(-714.28),
+                    5: Power.from_watts(-1000.0),
+                },
+                remaining_power=Power.zero(),
+            ),
+        )
+        self.assert_result(
+            algorithm.distribute_power(Power.from_watts(3000), components),
+            DistributionResult(
+                {
+                    1: Power.from_watts(1000),
+                    3: Power.from_watts(1000),
+                    5: Power.from_watts(1000),
+                },
+                remaining_power=Power.zero(),
+            ),
+        )
+        self.assert_result(
+            algorithm.distribute_power(Power.from_watts(-3000), components),
+            DistributionResult(
+                {
+                    1: Power.from_watts(-1000),
+                    3: Power.from_watts(-1000),
+                    5: Power.from_watts(-1000),
+                },
+                remaining_power=Power.zero(),
+            ),
+        )
+        self.assert_result(
+            algorithm.distribute_power(Power.from_watts(3500), components),
+            DistributionResult(
+                {
+                    1: Power.from_watts(1000),
+                    3: Power.from_watts(1000),
+                    5: Power.from_watts(1000),
+                },
+                remaining_power=Power.from_watts(500.0),
+            ),
+        )
+        self.assert_result(
+            algorithm.distribute_power(Power.from_watts(-3500), components),
+            DistributionResult(
+                {
+                    1: Power.from_watts(-1000),
+                    3: Power.from_watts(-1000),
+                    5: Power.from_watts(-1000),
+                },
+                remaining_power=Power.from_watts(-500.0),
+            ),
         )
 
     def test_scenario_3(self) -> None:
@@ -1274,50 +1876,134 @@ class TestDistWithExclBounds:
             Metric(70.0, Bound(10, 90)),
         ]
         bounds = [
-            PowerBounds(-1000, 0, 0, 1000),
-            PowerBounds(-1000, 0, 0, 1000),
-            PowerBounds(-1000, -100, 100, 1000),
-            PowerBounds(-1000, -100, 100, 1000),
-            PowerBounds(-1000, 0, 0, 1000),
-            PowerBounds(-1000, 0, 0, 1000),
+            PowerBounds(
+                Power.from_watts(-1000),
+                Power.zero(),
+                Power.zero(),
+                Power.from_watts(1000),
+            ),
+            PowerBounds(
+                Power.from_watts(-1000),
+                Power.zero(),
+                Power.zero(),
+                Power.from_watts(1000),
+            ),
+            PowerBounds(
+                Power.from_watts(-1000),
+                Power.from_watts(-100),
+                Power.from_watts(100),
+                Power.from_watts(1000),
+            ),
+            PowerBounds(
+                Power.from_watts(-1000),
+                Power.from_watts(-100),
+                Power.from_watts(100),
+                Power.from_watts(1000),
+            ),
+            PowerBounds(
+                Power.from_watts(-1000),
+                Power.zero(),
+                Power.zero(),
+                Power.from_watts(1000),
+            ),
+            PowerBounds(
+                Power.from_watts(-1000),
+                Power.zero(),
+                Power.zero(),
+                Power.from_watts(1000),
+            ),
         ]
         components = create_components(3, capacities, soc, bounds)
 
         algorithm = BatteryDistributionAlgorithm()
 
         self.assert_result(
-            algorithm.distribute_power(-320, components),
-            DistributionResult({1: -88, 3: -108.57, 5: -123.43}, remaining_power=0.0),
-        )
-        self.assert_result(
-            algorithm.distribute_power(320, components),
-            DistributionResult({1: 128, 3: 128, 5: 64}, remaining_power=0.0),
-        )
-        self.assert_result(
-            algorithm.distribute_power(-1800, components),
+            algorithm.distribute_power(Power.from_watts(-320), components),
             DistributionResult(
-                {1: -514.28, 3: -514.28, 5: -771.42}, remaining_power=0.0
+                {
+                    1: Power.from_watts(-88),
+                    3: Power.from_watts(-108.57),
+                    5: Power.from_watts(-123.43),
+                },
+                remaining_power=Power.zero(),
             ),
         )
         self.assert_result(
-            algorithm.distribute_power(1800, components),
-            DistributionResult({1: 720, 3: 720, 5: 360}, remaining_power=0.0),
+            algorithm.distribute_power(Power.from_watts(320), components),
+            DistributionResult(
+                {
+                    1: Power.from_watts(128),
+                    3: Power.from_watts(128),
+                    5: Power.from_watts(64),
+                },
+                remaining_power=Power.zero(),
+            ),
         )
         self.assert_result(
-            algorithm.distribute_power(-2800, components),
-            DistributionResult({1: -800, 3: -1000, 5: -1000}, remaining_power=0.0),
+            algorithm.distribute_power(Power.from_watts(-1800), components),
+            DistributionResult(
+                {
+                    1: Power.from_watts(-514.28),
+                    3: Power.from_watts(-514.28),
+                    5: Power.from_watts(-771.42),
+                },
+                remaining_power=Power.zero(),
+            ),
         )
         self.assert_result(
-            algorithm.distribute_power(2800, components),
-            DistributionResult({1: 1000, 3: 1000, 5: 800}, remaining_power=0.0),
+            algorithm.distribute_power(Power.from_watts(1800), components),
+            DistributionResult(
+                {
+                    1: Power.from_watts(720),
+                    3: Power.from_watts(720),
+                    5: Power.from_watts(360),
+                },
+                remaining_power=Power.zero(),
+            ),
         )
         self.assert_result(
-            algorithm.distribute_power(-3500, components),
-            DistributionResult({1: -1000, 3: -1000, 5: -1000}, remaining_power=-500.0),
+            algorithm.distribute_power(Power.from_watts(-2800), components),
+            DistributionResult(
+                {
+                    1: Power.from_watts(-800),
+                    3: Power.from_watts(-1000),
+                    5: Power.from_watts(-1000),
+                },
+                remaining_power=Power.zero(),
+            ),
         )
         self.assert_result(
-            algorithm.distribute_power(3500, components),
-            DistributionResult({1: 1000, 3: 1000, 5: 1000}, remaining_power=500.0),
+            algorithm.distribute_power(Power.from_watts(2800), components),
+            DistributionResult(
+                {
+                    1: Power.from_watts(1000),
+                    3: Power.from_watts(1000),
+                    5: Power.from_watts(800),
+                },
+                remaining_power=Power.zero(),
+            ),
+        )
+        self.assert_result(
+            algorithm.distribute_power(Power.from_watts(-3500), components),
+            DistributionResult(
+                {
+                    1: Power.from_watts(-1000),
+                    3: Power.from_watts(-1000),
+                    5: Power.from_watts(-1000),
+                },
+                remaining_power=Power.from_watts(-500.0),
+            ),
+        )
+        self.assert_result(
+            algorithm.distribute_power(Power.from_watts(3500), components),
+            DistributionResult(
+                {
+                    1: Power.from_watts(1000),
+                    3: Power.from_watts(1000),
+                    5: Power.from_watts(1000),
+                },
+                remaining_power=Power.from_watts(500.0),
+            ),
         )
 
     def test_scenario_4(self) -> None:
@@ -1351,13 +2037,34 @@ class TestDistWithExclBounds:
                             component_id=1,
                             capacity=Metric(10000),
                             soc=Metric(50, Bound(10, 90)),
-                            power=PowerBounds(-1500, -200, 200, 1500),
+                            power=PowerBounds(
+                                Power.from_watts(-1500),
+                                Power.from_watts(-200),
+                                Power.from_watts(200),
+                                Power.from_watts(1500),
+                            ),
                         )
                     ]
                 ),
                 [
-                    inverter_msg(2, PowerBounds(-1000, -100, 100, 1000)),
-                    inverter_msg(3, PowerBounds(-1000, -100, 100, 1000)),
+                    inverter_msg(
+                        2,
+                        PowerBounds(
+                            Power.from_watts(-1000),
+                            Power.from_watts(-100),
+                            Power.from_watts(100),
+                            Power.from_watts(1000),
+                        ),
+                    ),
+                    inverter_msg(
+                        3,
+                        PowerBounds(
+                            Power.from_watts(-1000),
+                            Power.from_watts(-100),
+                            Power.from_watts(100),
+                            Power.from_watts(1000),
+                        ),
+                    ),
                 ],
             )
         ]
@@ -1367,24 +2074,27 @@ class TestDistWithExclBounds:
         # The assignment of power to each inverter can be swapped, as they both have the
         # same bounds, none will be preferred
         self.assert_any_result(
-            algorithm.distribute_power(-300, components),
+            algorithm.distribute_power(Power.from_watts(-300), components),
             expected_distribution_ids={2, 3},
-            expected_distribution_powers=[-300, 0],
-            expected_remaining_power=0,
+            expected_distribution_powers=[Power.from_watts(-300), Power.zero()],
+            expected_remaining_power=Power.zero(),
         )
 
         self.assert_any_result(
-            algorithm.distribute_power(300, components),
+            algorithm.distribute_power(Power.from_watts(300), components),
             expected_distribution_ids={2, 3},
-            expected_distribution_powers=[300, 0],
-            expected_remaining_power=0,
+            expected_distribution_powers=[Power.from_watts(300), Power.zero()],
+            expected_remaining_power=Power.zero(),
         )
 
         self.assert_any_result(
-            algorithm.distribute_power(-1800, components),
+            algorithm.distribute_power(Power.from_watts(-1800), components),
             expected_distribution_ids={2, 3},
-            expected_distribution_powers=[-1000, -500],
-            expected_remaining_power=-300,
+            expected_distribution_powers=[
+                Power.from_watts(-1000),
+                Power.from_watts(-500),
+            ],
+            expected_remaining_power=Power.from_watts(-300),
         )
 
     def test_scenario_5(self) -> None:
@@ -1425,13 +2135,34 @@ class TestDistWithExclBounds:
                             component_id=1,
                             capacity=Metric(10000),
                             soc=Metric(20, Bound(10, 90)),
-                            power=PowerBounds(-1500, -200, 200, 1500),
+                            power=PowerBounds(
+                                Power.from_watts(-1500),
+                                Power.from_watts(-200),
+                                Power.from_watts(200),
+                                Power.from_watts(1500),
+                            ),
                         )
                     ]
                 ),
                 [
-                    inverter_msg(10, PowerBounds(-1000, -100, 100, 1000)),
-                    inverter_msg(11, PowerBounds(-1000, -100, 100, 1000)),
+                    inverter_msg(
+                        10,
+                        PowerBounds(
+                            Power.from_watts(-1000),
+                            Power.from_watts(-100),
+                            Power.from_watts(100),
+                            Power.from_watts(1000),
+                        ),
+                    ),
+                    inverter_msg(
+                        11,
+                        PowerBounds(
+                            Power.from_watts(-1000),
+                            Power.from_watts(-100),
+                            Power.from_watts(100),
+                            Power.from_watts(1000),
+                        ),
+                    ),
                 ],
             ),
             InvBatPair(
@@ -1441,13 +2172,34 @@ class TestDistWithExclBounds:
                             component_id=2,
                             capacity=Metric(10000),
                             soc=Metric(60, Bound(10, 90)),
-                            power=PowerBounds(-1500, 0, 0, 1500),
+                            power=PowerBounds(
+                                Power.from_watts(-1500),
+                                Power.zero(),
+                                Power.zero(),
+                                Power.from_watts(1500),
+                            ),
                         )
                     ]
                 ),
                 [
-                    inverter_msg(20, PowerBounds(-1000, -100, 100, 1000)),
-                    inverter_msg(21, PowerBounds(-1000, -100, 100, 1000)),
+                    inverter_msg(
+                        20,
+                        PowerBounds(
+                            Power.from_watts(-1000),
+                            Power.from_watts(-100),
+                            Power.from_watts(100),
+                            Power.from_watts(1000),
+                        ),
+                    ),
+                    inverter_msg(
+                        21,
+                        PowerBounds(
+                            Power.from_watts(-1000),
+                            Power.from_watts(-100),
+                            Power.from_watts(100),
+                            Power.from_watts(1000),
+                        ),
+                    ),
                 ],
             ),
         ]
@@ -1455,36 +2207,61 @@ class TestDistWithExclBounds:
         algorithm = BatteryDistributionAlgorithm()
 
         self.assert_any_result(
-            algorithm.distribute_power(-300, components),
+            algorithm.distribute_power(Power.from_watts(-300), components),
             expected_distribution_ids={10, 11, 20, 21},
-            expected_distribution_powers=[-200, 0, -100, 0],
-            expected_remaining_power=0.0,
+            expected_distribution_powers=[
+                Power.from_watts(-200),
+                Power.zero(),
+                Power.from_watts(-100),
+                Power.zero(),
+            ],
+            expected_remaining_power=Power.zero(),
         )
 
         self.assert_any_result(
-            algorithm.distribute_power(300, components),
+            algorithm.distribute_power(Power.from_watts(300), components),
             expected_distribution_ids={10, 11, 20, 21},
-            expected_distribution_powers=[200, 0, 100, 0],
-            expected_remaining_power=0.0,
+            expected_distribution_powers=[
+                Power.from_watts(200),
+                Power.zero(),
+                Power.from_watts(100),
+                Power.zero(),
+            ],
+            expected_remaining_power=Power.zero(),
         )
 
         self.assert_any_result(
-            algorithm.distribute_power(-1800, components),
+            algorithm.distribute_power(Power.from_watts(-1800), components),
             expected_distribution_ids={10, 11, 20, 21},
-            expected_distribution_powers=[-300, 0, -1000, -500],
-            expected_remaining_power=0.0,
+            expected_distribution_powers=[
+                Power.from_watts(-300),
+                Power.zero(),
+                Power.from_watts(-1000),
+                Power.from_watts(-500),
+            ],
+            expected_remaining_power=Power.zero(),
         )
 
         self.assert_any_result(
-            algorithm.distribute_power(3000, components),
+            algorithm.distribute_power(Power.from_watts(3000), components),
             expected_distribution_ids={10, 11, 20, 21},
-            expected_distribution_powers=[1000, 500, 1000, 500],
-            expected_remaining_power=0.0,
+            expected_distribution_powers=[
+                Power.from_watts(1000),
+                Power.from_watts(500),
+                Power.from_watts(1000),
+                Power.from_watts(500),
+            ],
+            expected_remaining_power=Power.zero(),
         )
 
         self.assert_any_result(
-            algorithm.distribute_power(3500, components),
+            algorithm.distribute_power(Power.from_watts(3500), components),
             expected_distribution_ids={10, 11, 20, 21},
-            expected_distribution_powers=[1000, 500, 1000, 500],
-            expected_remaining_power=500.0,
+            expected_distribution_powers=[
+                Power.from_watts(1000),
+                Power.from_watts(500),
+                Power.from_watts(1000),
+                Power.from_watts(500),
+            ],
+            expected_remaining_power=Power.from_watts(500.0),
         )

--- a/tests/microgrid/power_distributing/test_power_distributing.py
+++ b/tests/microgrid/power_distributing/test_power_distributing.py
@@ -171,7 +171,12 @@ class TestPowerDistributingActor:
                     battery_id,
                     capacity=Metric(98000),
                     soc=Metric(40, Bound(20, 80)),
-                    power=PowerBounds(-1000, 0, 0, 1000),
+                    power=PowerBounds(
+                        Power.from_watts(-1000),
+                        Power.zero(),
+                        Power.zero(),
+                        Power.from_watts(1000),
+                    ),
                 ),
                 0.05,
             )
@@ -182,7 +187,12 @@ class TestPowerDistributingActor:
             mocks.streamer.start_streaming(
                 inverter_msg(
                     inverter_id,
-                    power=PowerBounds(-500, 0, 0, 500),
+                    power=PowerBounds(
+                        Power.from_watts(-500),
+                        Power.zero(),
+                        Power.zero(),
+                        Power.from_watts(500),
+                    ),
                 ),
                 0.05,
             )
@@ -238,7 +248,12 @@ class TestPowerDistributingActor:
                     9,
                     soc=Metric(60, Bound(20, 80)),
                     capacity=Metric(98000),
-                    power=PowerBounds(-1000, -300, 300, 1000),
+                    power=PowerBounds(
+                        Power.from_watts(-1000),
+                        Power.from_watts(-300),
+                        Power.from_watts(300),
+                        Power.from_watts(1000),
+                    ),
                 ),
                 0.05,
             )
@@ -248,7 +263,12 @@ class TestPowerDistributingActor:
                     19,
                     soc=Metric(60, Bound(20, 80)),
                     capacity=Metric(98000),
-                    power=PowerBounds(-1000, -300, 300, 1000),
+                    power=PowerBounds(
+                        Power.from_watts(-1000),
+                        Power.from_watts(-300),
+                        Power.from_watts(300),
+                        Power.from_watts(1000),
+                    ),
                 ),
                 0.05,
             )
@@ -302,7 +322,12 @@ class TestPowerDistributingActor:
                 assert isinstance(
                     result, OutOfBounds
                 ), f"Expected OutOfBounds, got {result}"
-                assert result.bounds == PowerBounds(-1000, -600, 600, 1000)
+                assert result.bounds == PowerBounds(
+                    Power.from_watts(-1000),
+                    Power.from_watts(-600),
+                    Power.from_watts(600),
+                    Power.from_watts(1000),
+                )
                 assert result.request == request
 
     # pylint: disable=too-many-locals
@@ -406,7 +431,12 @@ class TestPowerDistributingActor:
                     bat_components[0].component_id,
                     soc=Metric(math.nan, Bound(20, 80)),
                     capacity=Metric(98000),
-                    power=PowerBounds(-1000, 0, 0, 1000),
+                    power=PowerBounds(
+                        Power.from_watts(-1000),
+                        Power.zero(),
+                        Power.zero(),
+                        Power.from_watts(1000),
+                    ),
                 ),
                 0.05,
             )
@@ -564,7 +594,12 @@ class TestPowerDistributingActor:
             mocks.streamer.start_streaming(
                 inverter_msg(
                     inverter.component_id,
-                    power=PowerBounds(-1000, -500, 500, 1000),
+                    power=PowerBounds(
+                        Power.from_watts(-1000),
+                        Power.from_watts(-500),
+                        Power.from_watts(500),
+                        Power.from_watts(1000),
+                    ),
                 ),
                 0.05,
             )
@@ -573,7 +608,12 @@ class TestPowerDistributingActor:
                     batteries[0].component_id,
                     soc=Metric(40, Bound(20, 80)),
                     capacity=Metric(10_000),
-                    power=PowerBounds(-1000, -200, 200, 1000),
+                    power=PowerBounds(
+                        Power.from_watts(-1000),
+                        Power.from_watts(-200),
+                        Power.from_watts(200),
+                        Power.from_watts(1000),
+                    ),
                 ),
                 0.05,
             )
@@ -582,7 +622,12 @@ class TestPowerDistributingActor:
                     batteries[1].component_id,
                     soc=Metric(40, Bound(20, 80)),
                     capacity=Metric(10_000),
-                    power=PowerBounds(-1000, -100, 100, 1000),
+                    power=PowerBounds(
+                        Power.from_watts(-1000),
+                        Power.from_watts(-100),
+                        Power.from_watts(100),
+                        Power.from_watts(1000),
+                    ),
                 ),
                 0.05,
             )
@@ -618,7 +663,12 @@ class TestPowerDistributingActor:
 
                 assert isinstance(result, OutOfBounds)
                 assert result.request == request
-                assert result.bounds == PowerBounds(-1000, -500, 500, 1000)
+                assert result.bounds == PowerBounds(
+                    Power.from_watts(-1000),
+                    Power.from_watts(-500),
+                    Power.from_watts(500),
+                    Power.from_watts(1000),
+                )
 
     async def test_two_batteries_one_inverter_different_exclusion_bounds(
         self, mocker: MockerFixture
@@ -655,7 +705,12 @@ class TestPowerDistributingActor:
                     batteries[0].component_id,
                     soc=Metric(40, Bound(20, 80)),
                     capacity=Metric(10_000),
-                    power=PowerBounds(-1000, -200, 200, 1000),
+                    power=PowerBounds(
+                        Power.from_watts(-1000),
+                        Power.from_watts(-200),
+                        Power.from_watts(200),
+                        Power.from_watts(1000),
+                    ),
                 ),
                 0.05,
             )
@@ -664,7 +719,12 @@ class TestPowerDistributingActor:
                     batteries[1].component_id,
                     soc=Metric(40, Bound(20, 80)),
                     capacity=Metric(10_000),
-                    power=PowerBounds(-1000, -100, 100, 1000),
+                    power=PowerBounds(
+                        Power.from_watts(-1000),
+                        Power.from_watts(-100),
+                        Power.from_watts(100),
+                        Power.from_watts(1000),
+                    ),
                 ),
                 0.05,
             )
@@ -701,7 +761,12 @@ class TestPowerDistributingActor:
                 assert isinstance(result, OutOfBounds)
                 assert result.request == request
                 # each inverter is bounded at 500
-                assert result.bounds == PowerBounds(-500, -400, 400, 500)
+                assert result.bounds == PowerBounds(
+                    Power.from_watts(-500),
+                    Power.from_watts(-400),
+                    Power.from_watts(400),
+                    Power.from_watts(500),
+                )
 
     async def test_connected_but_not_requested_batteries(
         self, mocker: MockerFixture
@@ -774,7 +839,12 @@ class TestPowerDistributingActor:
                     9,
                     soc=Metric(math.nan, Bound(20, 80)),
                     capacity=Metric(98000),
-                    power=PowerBounds(-1000, 0, 0, 1000),
+                    power=PowerBounds(
+                        Power.from_watts(-1000),
+                        Power.zero(),
+                        Power.zero(),
+                        Power.from_watts(1000),
+                    ),
                 ),
                 0.05,
             )
@@ -823,7 +893,12 @@ class TestPowerDistributingActor:
                     9,
                     soc=Metric(40, Bound(20, 80)),
                     capacity=Metric(math.nan),
-                    power=PowerBounds(-1000, 0, 0, 1000),
+                    power=PowerBounds(
+                        Power.from_watts(-1000),
+                        Power.zero(),
+                        Power.zero(),
+                        Power.from_watts(1000),
+                    ),
                 ),
                 0.05,
             )
@@ -873,7 +948,12 @@ class TestPowerDistributingActor:
             mocks.streamer.start_streaming(
                 inverter_msg(
                     18,
-                    power=PowerBounds(-1000, 0, 0, 1000),
+                    power=PowerBounds(
+                        Power.from_watts(-1000),
+                        Power.zero(),
+                        Power.zero(),
+                        Power.from_watts(1000),
+                    ),
                 ),
                 0.05,
             )
@@ -882,7 +962,12 @@ class TestPowerDistributingActor:
             mocks.streamer.start_streaming(
                 inverter_msg(
                     8,
-                    power=PowerBounds(-1000, 0, 0, math.nan),
+                    power=PowerBounds(
+                        Power.from_watts(-1000),
+                        Power.zero(),
+                        Power.zero(),
+                        Power.from_watts(math.nan),
+                    ),
                 ),
                 0.05,
             )
@@ -892,7 +977,12 @@ class TestPowerDistributingActor:
                     9,
                     soc=Metric(40, Bound(20, 80)),
                     capacity=Metric(float(98000)),
-                    power=PowerBounds(math.nan, 0, 0, math.nan),
+                    power=PowerBounds(
+                        Power.from_watts(math.nan),
+                        Power.zero(),
+                        Power.zero(),
+                        Power.from_watts(math.nan),
+                    ),
                 ),
                 0.05,
             )
@@ -1009,7 +1099,7 @@ class TestPowerDistributingActor:
             assert isinstance(result, OutOfBounds)
             assert result is not None
             assert result.request == request
-            assert result.bounds.inclusion_upper == 1000
+            assert result.bounds.inclusion_upper == Power.from_watts(1000)
 
     async def test_power_distributor_one_user_adjust_power_supply(
         self, mocker: MockerFixture
@@ -1051,7 +1141,7 @@ class TestPowerDistributingActor:
             assert isinstance(result, OutOfBounds)
             assert result is not None
             assert result.request == request
-            assert result.bounds.inclusion_lower == -1000
+            assert result.bounds.inclusion_lower == Power.from_watts(-1000)
 
     async def test_power_distributor_one_user_adjust_power_success(
         self, mocker: MockerFixture
@@ -1144,7 +1234,7 @@ class TestPowerDistributingActor:
 
             batteries = {9, 19, 29}
             failed_batteries = {9}
-            failed_power = 500.0
+            failed_power = Power.from_watts(500.0)
 
             await self._patch_battery_pool_status(mocks, mocker, batteries)
 
@@ -1185,6 +1275,6 @@ class TestPowerDistributingActor:
                 assert result.succeeded_components == batteries - failed_batteries
                 assert result.failed_components == failed_batteries
                 assert result.succeeded_power.isclose(Power.from_watts(1000.0))
-                assert result.failed_power.isclose(Power.from_watts(failed_power))
+                assert result.failed_power.isclose(failed_power)
                 assert result.excess_power.isclose(Power.from_watts(200.0))
                 assert result.request == request


### PR DESCRIPTION
The PV manager and the EV Charger manager of the PowerDistributor are
already using `Power` and not `float`.