### PR TITLE
Bug fix: Print Power as str instead of decimal

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -14,4 +14,4 @@
 
 ## Bug Fixes
 
-<!-- Here goes notable bug fixes that are worth a special mention or explanation -->
+* Fix TypeError raised by BatteryManager when distributing power

--- a/src/frequenz/sdk/microgrid/_power_distributing/_component_managers/_battery_manager.py
+++ b/src/frequenz/sdk/microgrid/_power_distributing/_component_managers/_battery_manager.py
@@ -273,7 +273,7 @@ class BatteryManager(ComponentManager):  # pylint: disable=too-many-instance-att
                     battery_distribution.get(battery_id, Power.zero()) + dist
                 )
         _logger.debug(
-            "Distributing power %d between the batteries %s",
+            "Distributing power %s between the batteries %s",
             distributed_power_value,
             str(battery_distribution),
         )


### PR DESCRIPTION
Commit 41d4543ca changed `float` to `Power` in PowerDistributor's battery manager, but left %d in formatting.