### PR TITLE
Use ComponentCategory from common repo

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,6 +7,7 @@
 ## Upgrading
 
 * The microgrid client dependency has been updated to version 0.9.0
+* The `ComponentCategory` is now based on the frequenz.client.common package
 
 ## New Features
 

--- a/benchmarks/power_distribution/power_distributor.py
+++ b/benchmarks/power_distribution/power_distributor.py
@@ -12,8 +12,8 @@ from datetime import timedelta
 from typing import Any
 
 from frequenz.channels import Broadcast
-from frequenz.client.common.microgrid.components import ComponentId
-from frequenz.client.microgrid import Component, ComponentCategory
+from frequenz.client.common.microgrid.components import ComponentCategory, ComponentId
+from frequenz.client.microgrid import Component
 from frequenz.quantities import Power
 
 from frequenz.sdk import microgrid

--- a/src/frequenz/sdk/microgrid/_data_pipeline.py
+++ b/src/frequenz/sdk/microgrid/_data_pipeline.py
@@ -17,8 +17,8 @@ from dataclasses import dataclass
 from datetime import timedelta
 
 from frequenz.channels import Broadcast, Sender
-from frequenz.client.common.microgrid.components import ComponentId
-from frequenz.client.microgrid import ComponentCategory, InverterType
+from frequenz.client.common.microgrid.components import ComponentCategory, ComponentId
+from frequenz.client.microgrid import InverterType
 
 from frequenz.sdk.microgrid._power_managing._base_classes import Algorithm, DefaultPower
 

--- a/src/frequenz/sdk/microgrid/_data_sourcing/microgrid_api_source.py
+++ b/src/frequenz/sdk/microgrid/_data_sourcing/microgrid_api_source.py
@@ -9,10 +9,9 @@ from collections.abc import Callable
 from typing import Any
 
 from frequenz.channels import Receiver, Sender
-from frequenz.client.common.microgrid.components import ComponentId
+from frequenz.client.common.microgrid.components import ComponentCategory, ComponentId
 from frequenz.client.microgrid import (
     BatteryData,
-    ComponentCategory,
     ComponentMetricId,
     EVChargerData,
     InverterData,

--- a/src/frequenz/sdk/microgrid/_power_distributing/_component_managers/_battery_manager.py
+++ b/src/frequenz/sdk/microgrid/_power_distributing/_component_managers/_battery_manager.py
@@ -11,11 +11,10 @@ import typing
 from datetime import timedelta
 
 from frequenz.channels import LatestValueCache, Receiver, Sender
-from frequenz.client.common.microgrid.components import ComponentId
+from frequenz.client.common.microgrid.components import ComponentCategory, ComponentId
 from frequenz.client.microgrid import (
     ApiClientError,
     BatteryData,
-    ComponentCategory,
     InverterData,
     OperationOutOfRange,
 )

--- a/src/frequenz/sdk/microgrid/_power_distributing/_component_managers/_ev_charger_manager/_ev_charger_manager.py
+++ b/src/frequenz/sdk/microgrid/_power_distributing/_component_managers/_ev_charger_manager/_ev_charger_manager.py
@@ -16,13 +16,8 @@ from frequenz.channels import (
     select,
     selected_from,
 )
-from frequenz.client.common.microgrid.components import ComponentId
-from frequenz.client.microgrid import (
-    ApiClientError,
-    ComponentCategory,
-    EVChargerData,
-    MicrogridApiClient,
-)
+from frequenz.client.common.microgrid.components import ComponentCategory, ComponentId
+from frequenz.client.microgrid import ApiClientError, EVChargerData, MicrogridApiClient
 from frequenz.quantities import Power, Voltage
 from typing_extensions import override
 

--- a/src/frequenz/sdk/microgrid/_power_distributing/_component_managers/_pv_inverter_manager/_pv_inverter_manager.py
+++ b/src/frequenz/sdk/microgrid/_power_distributing/_component_managers/_pv_inverter_manager/_pv_inverter_manager.py
@@ -9,13 +9,8 @@ import logging
 from datetime import timedelta
 
 from frequenz.channels import LatestValueCache, Sender
-from frequenz.client.common.microgrid.components import ComponentId
-from frequenz.client.microgrid import (
-    ApiClientError,
-    ComponentCategory,
-    InverterData,
-    InverterType,
-)
+from frequenz.client.common.microgrid.components import ComponentCategory, ComponentId
+from frequenz.client.microgrid import ApiClientError, InverterData, InverterType
 from frequenz.quantities import Power
 from typing_extensions import override
 

--- a/src/frequenz/sdk/microgrid/_power_distributing/_component_status/_battery_status_tracker.py
+++ b/src/frequenz/sdk/microgrid/_power_distributing/_component_status/_battery_status_tracker.py
@@ -23,12 +23,11 @@ from datetime import datetime, timedelta, timezone
 
 from frequenz.channels import Receiver, Sender, select, selected_from
 from frequenz.channels.timer import SkipMissedAndDrift, Timer
-from frequenz.client.common.microgrid.components import ComponentId
+from frequenz.client.common.microgrid.components import ComponentCategory, ComponentId
 from frequenz.client.microgrid import (
     BatteryComponentState,
     BatteryData,
     BatteryRelayState,
-    ComponentCategory,
     ComponentData,
     ErrorLevel,
     InverterComponentState,

--- a/src/frequenz/sdk/microgrid/_power_distributing/power_distributing.py
+++ b/src/frequenz/sdk/microgrid/_power_distributing/power_distributing.py
@@ -15,8 +15,8 @@ import logging
 from datetime import timedelta
 
 from frequenz.channels import Receiver, Sender
-from frequenz.client.common.microgrid.components import ComponentId
-from frequenz.client.microgrid import ComponentCategory, ComponentType, InverterType
+from frequenz.client.common.microgrid.components import ComponentCategory, ComponentId
+from frequenz.client.microgrid import ComponentType, InverterType
 from typing_extensions import override
 
 from ...actor._actor import Actor

--- a/src/frequenz/sdk/microgrid/_power_managing/_power_managing_actor.py
+++ b/src/frequenz/sdk/microgrid/_power_managing/_power_managing_actor.py
@@ -13,8 +13,8 @@ from typing import assert_never
 
 from frequenz.channels import Receiver, Sender, select, selected_from
 from frequenz.channels.timer import SkipMissedAndDrift, Timer
-from frequenz.client.common.microgrid.components import ComponentId
-from frequenz.client.microgrid import ComponentCategory, ComponentType, InverterType
+from frequenz.client.common.microgrid.components import ComponentCategory, ComponentId
+from frequenz.client.microgrid import ComponentType, InverterType
 from typing_extensions import override
 
 from ..._internal._asyncio import run_forever

--- a/src/frequenz/sdk/microgrid/_power_wrapper.py
+++ b/src/frequenz/sdk/microgrid/_power_wrapper.py
@@ -9,11 +9,12 @@ import logging
 from datetime import timedelta
 
 from frequenz.channels import Broadcast
+from frequenz.client.common.microgrid.components import ComponentCategory
 
 # pylint seems to think this is a cyclic import, but it is not.
 #
 # pylint: disable=cyclic-import
-from frequenz.client.microgrid import ComponentCategory, ComponentType
+from frequenz.client.microgrid import ComponentType
 
 from .._internal._channels import ChannelRegistry, ReceiverFetcher
 from . import _power_managing, connection_manager

--- a/src/frequenz/sdk/microgrid/component_graph.py
+++ b/src/frequenz/sdk/microgrid/component_graph.py
@@ -27,10 +27,9 @@ from abc import ABC, abstractmethod
 from collections.abc import Callable, Iterable
 
 import networkx as nx
-from frequenz.client.common.microgrid.components import ComponentId
+from frequenz.client.common.microgrid.components import ComponentCategory, ComponentId
 from frequenz.client.microgrid import (
     Component,
-    ComponentCategory,
     Connection,
     InverterType,
     MicrogridApiClient,

--- a/src/frequenz/sdk/timeseries/_grid_frequency.py
+++ b/src/frequenz/sdk/timeseries/_grid_frequency.py
@@ -9,8 +9,8 @@ import asyncio
 import logging
 
 from frequenz.channels import Receiver, Sender
-from frequenz.client.common.microgrid.components import ComponentId
-from frequenz.client.microgrid import Component, ComponentCategory, ComponentMetricId
+from frequenz.client.common.microgrid.components import ComponentCategory, ComponentId
+from frequenz.client.microgrid import Component, ComponentMetricId
 from frequenz.quantities import Frequency, Quantity
 
 from .._internal._channels import ChannelRegistry

--- a/src/frequenz/sdk/timeseries/_voltage_streamer.py
+++ b/src/frequenz/sdk/timeseries/_voltage_streamer.py
@@ -14,7 +14,8 @@ import logging
 from typing import TYPE_CHECKING
 
 from frequenz.channels import Receiver, Sender
-from frequenz.client.microgrid import Component, ComponentCategory, ComponentMetricId
+from frequenz.client.common.microgrid.components import ComponentCategory
+from frequenz.client.microgrid import Component, ComponentMetricId
 from frequenz.quantities import Quantity, Voltage
 
 from .._internal._channels import ChannelRegistry

--- a/src/frequenz/sdk/timeseries/battery_pool/_battery_pool_reference_store.py
+++ b/src/frequenz/sdk/timeseries/battery_pool/_battery_pool_reference_store.py
@@ -11,8 +11,7 @@ from datetime import timedelta
 from typing import Any
 
 from frequenz.channels import Receiver, Sender
-from frequenz.client.common.microgrid.components import ComponentId
-from frequenz.client.microgrid import ComponentCategory
+from frequenz.client.common.microgrid.components import ComponentCategory, ComponentId
 
 from ..._internal._asyncio import cancel_and_await
 from ..._internal._channels import ChannelRegistry, ReceiverFetcher

--- a/src/frequenz/sdk/timeseries/battery_pool/_component_metric_fetcher.py
+++ b/src/frequenz/sdk/timeseries/battery_pool/_component_metric_fetcher.py
@@ -14,10 +14,9 @@ from datetime import datetime, timezone
 from typing import Any, Generic, Self, TypeVar
 
 from frequenz.channels import ChannelClosedError, Receiver
-from frequenz.client.common.microgrid.components import ComponentId
+from frequenz.client.common.microgrid.components import ComponentCategory, ComponentId
 from frequenz.client.microgrid import (
     BatteryData,
-    ComponentCategory,
     ComponentData,
     ComponentMetricId,
     InverterData,

--- a/src/frequenz/sdk/timeseries/ev_charger_pool/_ev_charger_pool_reference_store.py
+++ b/src/frequenz/sdk/timeseries/ev_charger_pool/_ev_charger_pool_reference_store.py
@@ -8,8 +8,7 @@ import uuid
 from collections import abc
 
 from frequenz.channels import Broadcast, Receiver, Sender
-from frequenz.client.common.microgrid.components import ComponentId
-from frequenz.client.microgrid import ComponentCategory
+from frequenz.client.common.microgrid.components import ComponentCategory, ComponentId
 
 from ..._internal._channels import ChannelRegistry, ReceiverFetcher
 from ...microgrid import connection_manager

--- a/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_battery_power_formula.py
+++ b/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_battery_power_formula.py
@@ -6,7 +6,8 @@
 import itertools
 import logging
 
-from frequenz.client.microgrid import Component, ComponentCategory, ComponentMetricId
+from frequenz.client.common.microgrid.components import ComponentCategory
+from frequenz.client.microgrid import Component, ComponentMetricId
 from frequenz.quantities import Power
 
 from ....microgrid import connection_manager

--- a/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_chp_power_formula.py
+++ b/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_chp_power_formula.py
@@ -7,8 +7,8 @@
 import logging
 from collections import abc
 
-from frequenz.client.common.microgrid.components import ComponentId
-from frequenz.client.microgrid import ComponentCategory, ComponentMetricId
+from frequenz.client.common.microgrid.components import ComponentCategory, ComponentId
+from frequenz.client.microgrid import ComponentMetricId
 from frequenz.quantities import Power
 
 from ....microgrid import connection_manager

--- a/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_consumer_power_formula.py
+++ b/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_consumer_power_formula.py
@@ -5,7 +5,8 @@
 
 import logging
 
-from frequenz.client.microgrid import Component, ComponentCategory, ComponentMetricId
+from frequenz.client.common.microgrid.components import ComponentCategory
+from frequenz.client.microgrid import Component, ComponentMetricId
 from frequenz.quantities import Power
 
 from ....microgrid import connection_manager

--- a/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_formula_generator.py
+++ b/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_formula_generator.py
@@ -13,8 +13,8 @@ from dataclasses import dataclass
 from typing import Generic
 
 from frequenz.channels import Sender
-from frequenz.client.common.microgrid.components import ComponentId
-from frequenz.client.microgrid import Component, ComponentCategory, ComponentMetricId
+from frequenz.client.common.microgrid.components import ComponentCategory, ComponentId
+from frequenz.client.microgrid import Component, ComponentMetricId
 
 from ...._internal._channels import ChannelRegistry
 from ....microgrid import connection_manager

--- a/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_grid_current_formula.py
+++ b/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_grid_current_formula.py
@@ -3,7 +3,8 @@
 
 """Formula generator from component graph for 3-phase Grid Current."""
 
-from frequenz.client.microgrid import Component, ComponentCategory, ComponentMetricId
+from frequenz.client.common.microgrid.components import ComponentCategory
+from frequenz.client.microgrid import Component, ComponentMetricId
 from frequenz.quantities import Current
 
 from .._formula_engine import FormulaEngine, FormulaEngine3Phase

--- a/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_grid_power_3_phase_formula.py
+++ b/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_grid_power_3_phase_formula.py
@@ -3,7 +3,8 @@
 
 """Formula generator from component graph for 3-phase Grid Power."""
 
-from frequenz.client.microgrid import Component, ComponentCategory, ComponentMetricId
+from frequenz.client.common.microgrid.components import ComponentCategory
+from frequenz.client.microgrid import Component, ComponentMetricId
 from frequenz.quantities import Power
 
 from .._formula_engine import FormulaEngine, FormulaEngine3Phase

--- a/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_grid_power_formula_base.py
+++ b/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_grid_power_formula_base.py
@@ -5,7 +5,8 @@
 
 from abc import ABC, abstractmethod
 
-from frequenz.client.microgrid import Component, ComponentCategory
+from frequenz.client.common.microgrid.components import ComponentCategory
+from frequenz.client.microgrid import Component
 
 from ..._base_types import QuantityT
 from .._formula_engine import FormulaEngine

--- a/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_producer_power_formula.py
+++ b/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_producer_power_formula.py
@@ -6,7 +6,8 @@
 import logging
 from typing import Callable
 
-from frequenz.client.microgrid import Component, ComponentCategory, ComponentMetricId
+from frequenz.client.common.microgrid.components import ComponentCategory
+from frequenz.client.microgrid import Component, ComponentMetricId
 from frequenz.quantities import Power
 
 from ....microgrid import connection_manager

--- a/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_pv_power_formula.py
+++ b/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_pv_power_formula.py
@@ -5,7 +5,8 @@
 
 import logging
 
-from frequenz.client.microgrid import Component, ComponentCategory, ComponentMetricId
+from frequenz.client.common.microgrid.components import ComponentCategory
+from frequenz.client.microgrid import Component, ComponentMetricId
 from frequenz.quantities import Power
 
 from ....microgrid import connection_manager

--- a/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_simple_formula.py
+++ b/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_simple_formula.py
@@ -3,7 +3,8 @@
 
 """Formula generator from component graph."""
 
-from frequenz.client.microgrid import ComponentCategory, ComponentMetricId
+from frequenz.client.common.microgrid.components import ComponentCategory
+from frequenz.client.microgrid import ComponentMetricId
 from frequenz.quantities import Power, ReactivePower
 
 from ....microgrid import connection_manager

--- a/src/frequenz/sdk/timeseries/pv_pool/_pv_pool_reference_store.py
+++ b/src/frequenz/sdk/timeseries/pv_pool/_pv_pool_reference_store.py
@@ -9,8 +9,8 @@ import uuid
 from collections import abc
 
 from frequenz.channels import Broadcast, Receiver, Sender
-from frequenz.client.common.microgrid.components import ComponentId
-from frequenz.client.microgrid import ComponentCategory, InverterType
+from frequenz.client.common.microgrid.components import ComponentCategory, ComponentId
+from frequenz.client.microgrid import InverterType
 
 from ..._internal._channels import ChannelRegistry, ReceiverFetcher
 from ...microgrid import connection_manager

--- a/tests/microgrid/fixtures.py
+++ b/tests/microgrid/fixtures.py
@@ -12,7 +12,7 @@ from datetime import timedelta
 from typing import AsyncIterator
 
 from frequenz.channels import Sender
-from frequenz.client.microgrid import ComponentCategory
+from frequenz.client.common.microgrid.components import ComponentCategory
 from pytest_mock import MockerFixture
 
 from frequenz.sdk import microgrid

--- a/tests/microgrid/power_distributing/_component_status/test_battery_pool_status.py
+++ b/tests/microgrid/power_distributing/_component_status/test_battery_pool_status.py
@@ -7,8 +7,7 @@ from contextlib import AsyncExitStack
 from datetime import timedelta
 
 from frequenz.channels import Broadcast
-from frequenz.client.common.microgrid.components import ComponentId
-from frequenz.client.microgrid import ComponentCategory
+from frequenz.client.common.microgrid.components import ComponentCategory, ComponentId
 from pytest_mock import MockerFixture
 
 from frequenz.sdk.microgrid._power_distributing._component_pool_status_tracker import (

--- a/tests/microgrid/power_distributing/test_power_distributing.py
+++ b/tests/microgrid/power_distributing/test_power_distributing.py
@@ -12,8 +12,7 @@ from typing import TypeVar
 from unittest.mock import MagicMock
 
 from frequenz.channels import Broadcast
-from frequenz.client.common.microgrid.components import ComponentId
-from frequenz.client.microgrid import ComponentCategory
+from frequenz.client.common.microgrid.components import ComponentCategory, ComponentId
 from frequenz.quantities import Power
 from pytest_mock import MockerFixture
 

--- a/tests/microgrid/test_data_sourcing.py
+++ b/tests/microgrid/test_data_sourcing.py
@@ -12,13 +12,12 @@ from unittest import mock
 import pytest
 import pytest_mock
 from frequenz.channels import Broadcast
-from frequenz.client.common.microgrid.components import ComponentId
+from frequenz.client.common.microgrid.components import ComponentCategory, ComponentId
 from frequenz.client.microgrid import (
     BatteryComponentState,
     BatteryData,
     BatteryRelayState,
     Component,
-    ComponentCategory,
     ComponentData,
     ComponentMetricId,
     EVChargerCableState,

--- a/tests/microgrid/test_datapipeline.py
+++ b/tests/microgrid/test_datapipeline.py
@@ -9,13 +9,8 @@ from datetime import timedelta
 import async_solipsism
 import pytest
 import time_machine
-from frequenz.client.common.microgrid.components import ComponentId
-from frequenz.client.microgrid import (
-    Component,
-    ComponentCategory,
-    Connection,
-    InverterType,
-)
+from frequenz.client.common.microgrid.components import ComponentCategory, ComponentId
+from frequenz.client.microgrid import Component, Connection, InverterType
 from pytest_mock import MockerFixture
 
 from frequenz.sdk.microgrid._data_pipeline import _DataPipeline

--- a/tests/microgrid/test_graph.py
+++ b/tests/microgrid/test_graph.py
@@ -10,10 +10,9 @@
 from unittest import mock
 
 import pytest
-from frequenz.client.common.microgrid.components import ComponentId
+from frequenz.client.common.microgrid.components import ComponentCategory, ComponentId
 from frequenz.client.microgrid import (
     Component,
-    ComponentCategory,
     ComponentMetadata,
     Connection,
     Fuse,

--- a/tests/microgrid/test_grid.py
+++ b/tests/microgrid/test_grid.py
@@ -6,8 +6,7 @@
 from contextlib import AsyncExitStack
 
 import frequenz.client.microgrid as client
-from frequenz.client.common.microgrid.components import ComponentId
-from frequenz.client.microgrid import ComponentCategory
+from frequenz.client.common.microgrid.components import ComponentCategory, ComponentId
 from frequenz.quantities import Current, Power, Quantity, ReactivePower
 from pytest_mock import MockerFixture
 

--- a/tests/microgrid/test_microgrid_api.py
+++ b/tests/microgrid/test_microgrid_api.py
@@ -11,14 +11,8 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from frequenz.client.common.microgrid import MicrogridId
-from frequenz.client.common.microgrid.components import ComponentId
-from frequenz.client.microgrid import (
-    Component,
-    ComponentCategory,
-    Connection,
-    Location,
-    Metadata,
-)
+from frequenz.client.common.microgrid.components import ComponentCategory, ComponentId
+from frequenz.client.microgrid import Component, Connection, Location, Metadata
 
 from frequenz.sdk.microgrid import connection_manager
 

--- a/tests/timeseries/_battery_pool/test_battery_pool.py
+++ b/tests/timeseries/_battery_pool/test_battery_pool.py
@@ -20,8 +20,7 @@ import async_solipsism
 import pytest
 import time_machine
 from frequenz.channels import Receiver, Sender
-from frequenz.client.common.microgrid.components import ComponentId
-from frequenz.client.microgrid import ComponentCategory
+from frequenz.client.common.microgrid.components import ComponentCategory, ComponentId
 from frequenz.quantities import Energy, Percentage, Power, Temperature
 from pytest_mock import MockerFixture
 

--- a/tests/timeseries/mock_microgrid.py
+++ b/tests/timeseries/mock_microgrid.py
@@ -11,10 +11,9 @@ from datetime import datetime, timedelta, timezone
 from types import TracebackType
 from typing import Coroutine
 
-from frequenz.client.common.microgrid.components import ComponentId
+from frequenz.client.common.microgrid.components import ComponentCategory, ComponentId
 from frequenz.client.microgrid import (
     Component,
-    ComponentCategory,
     ComponentData,
     Connection,
     EVChargerCableState,

--- a/tests/utils/component_graph_utils.py
+++ b/tests/utils/component_graph_utils.py
@@ -6,13 +6,8 @@
 
 from dataclasses import dataclass
 
-from frequenz.client.common.microgrid.components import ComponentId
-from frequenz.client.microgrid import (
-    Component,
-    ComponentCategory,
-    Connection,
-    InverterType,
-)
+from frequenz.client.common.microgrid.components import ComponentCategory, ComponentId
+from frequenz.client.microgrid import Component, Connection, InverterType
 
 
 @dataclass

--- a/tests/utils/graph_generator.py
+++ b/tests/utils/graph_generator.py
@@ -6,10 +6,9 @@
 from dataclasses import replace
 from typing import Any, overload
 
-from frequenz.client.common.microgrid.components import ComponentId
+from frequenz.client.common.microgrid.components import ComponentCategory, ComponentId
 from frequenz.client.microgrid import (
     Component,
-    ComponentCategory,
     ComponentType,
     Connection,
     GridMetadata,

--- a/tests/utils/mock_microgrid_client.py
+++ b/tests/utils/mock_microgrid_client.py
@@ -8,11 +8,10 @@ from unittest.mock import AsyncMock, MagicMock
 
 from frequenz.channels import Broadcast, Receiver
 from frequenz.client.common.microgrid import MicrogridId
-from frequenz.client.common.microgrid.components import ComponentId
+from frequenz.client.common.microgrid.components import ComponentCategory, ComponentId
 from frequenz.client.microgrid import (
     BatteryData,
     Component,
-    ComponentCategory,
     ComponentData,
     Connection,
     EVChargerData,


### PR DESCRIPTION
This changes the code to use the `ComponentCategory` defined in the common
client.
Unfortunately i was a bit premature as the microgrid client itself doesn't use
it yet, so marking this as blocked until the microgrid client is updated.

blocked by https://github.com/frequenz-floss/frequenz-client-microgrid-python/issues/160
