### PR TITLE
Log reason for  service stop

### DIFF
--- a/src/frequenz/sdk/actor/_actor.py
+++ b/src/frequenz/sdk/actor/_actor.py
@@ -153,5 +153,8 @@ class Actor(BackgroundService, abc.ABC):
         Args:
             msg: The message to be passed to the tasks being cancelled.
         """
+        if msg is not None:
+            _logger.info("Actor %s cancelled, reason: %s", self, msg)
+
         self._is_cancelled = True
         return super().cancel(msg)

--- a/src/frequenz/sdk/actor/_background_service.py
+++ b/src/frequenz/sdk/actor/_background_service.py
@@ -6,8 +6,11 @@
 import abc
 import asyncio
 import collections.abc
+import logging
 from types import TracebackType
 from typing import Any, Self
+
+_logger = logging.getLogger(__name__)
 
 
 class BackgroundService(abc.ABC):
@@ -167,6 +170,10 @@ class BackgroundService(abc.ABC):
         Args:
             msg: The message to be passed to the tasks being cancelled.
         """
+        _logger.debug(
+            "Service %s cancelled%s", self, f": {msg}" if msg is not None else ""
+        )
+
         for task in self._tasks:
             task.cancel(msg)
 


### PR DESCRIPTION
Actor has `info` log because this log is important to see workflow. Log is printed only if `msg` is not None, to avoid log duplication (actor prints that it is cancelled in run method - and this log was useful many times.)

Background service has debug log, because `info` would log many misleading logs during normal runtime, which might be confusing. And those logs are only useful during debugging.