### PR TITLE
Fix log when multiple batteries are attached to an inverter

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -30,3 +30,5 @@
 ## Bug Fixes
 
 - When using the new wall clock timer in the resampmler, it will now resync to the system time if it drifts away for more than a resample period, and do dynamic adjustments to the timer if the monotonic clock has a small drift compared to the wall clock.
+
+- A power distributor logging issue is fixed, that was causing the power for multiple batteries connected to the same inverter to be reported incorrectly.

--- a/src/frequenz/sdk/microgrid/_power_distributing/_component_managers/_battery_manager.py
+++ b/src/frequenz/sdk/microgrid/_power_distributing/_component_managers/_battery_manager.py
@@ -266,19 +266,26 @@ class BatteryManager(ComponentManager):  # pylint: disable=too-many-instance-att
             Result from the microgrid API.
         """
         distributed_power_value = request.power - distribution.remaining_power
-        battery_distribution: dict[ComponentId, Power] = {}
+        battery_distribution: dict[frozenset[ComponentId], Power] = {}
         battery_ids: set[ComponentId] = set()
         for inverter_id, dist in distribution.distribution.items():
             for battery_id in self._inv_bats_map[inverter_id]:
                 battery_ids.add(battery_id)
-                battery_distribution[battery_id] = (
-                    battery_distribution.get(battery_id, Power.zero()) + dist
-                )
-        _logger.debug(
-            "Distributing power %s between the batteries %s",
-            distributed_power_value,
-            str(battery_distribution),
-        )
+            battery_distribution[self._inv_bats_map[inverter_id]] = dist
+        if _logger.isEnabledFor(logging.DEBUG):
+            _logger.debug(
+                "Distributing power %s between the batteries: %s",
+                distributed_power_value,
+                ", ".join(
+                    (
+                        str(next(iter(cids)))
+                        if len(cids) == 1
+                        else f"({', '.join(str(cid) for cid in cids)})"
+                    )
+                    + f": {power}"
+                    for cids, power in battery_distribution.items()
+                ),
+            )
 
         failed_power, failed_batteries = await self._set_distributed_power(
             distribution, self._api_power_request_timeout

--- a/src/frequenz/sdk/microgrid/_power_distributing/_component_managers/_battery_manager.py
+++ b/src/frequenz/sdk/microgrid/_power_distributing/_component_managers/_battery_manager.py
@@ -267,8 +267,10 @@ class BatteryManager(ComponentManager):  # pylint: disable=too-many-instance-att
         """
         distributed_power_value = request.power - distribution.remaining_power
         battery_distribution: dict[ComponentId, Power] = {}
+        battery_ids: set[ComponentId] = set()
         for inverter_id, dist in distribution.distribution.items():
             for battery_id in self._inv_bats_map[inverter_id]:
+                battery_ids.add(battery_id)
                 battery_distribution[battery_id] = (
                     battery_distribution.get(battery_id, Power.zero()) + dist
                 )
@@ -284,7 +286,7 @@ class BatteryManager(ComponentManager):  # pylint: disable=too-many-instance-att
 
         response: Success | PartialFailure
         if len(failed_batteries) > 0:
-            succeed_batteries = set(battery_distribution.keys()) - failed_batteries
+            succeed_batteries = battery_ids - failed_batteries
             response = PartialFailure(
                 request=request,
                 succeeded_power=distributed_power_value - failed_power,
@@ -294,7 +296,7 @@ class BatteryManager(ComponentManager):  # pylint: disable=too-many-instance-att
                 excess_power=distribution.remaining_power,
             )
         else:
-            succeed_batteries = set(battery_distribution.keys())
+            succeed_batteries = battery_ids
             response = Success(
                 request=request,
                 succeeded_power=distributed_power_value,


### PR DESCRIPTION
Without this, when 10 kW is distributed to 3 batteries, 2 of them
attached to a single inverter, the debug log displayed the same power
for the two batteries, totalling to higher than what was requested,
which is misleading (formatted for readability):

    Distributing power 10 kW between the batteries {
        ComponentId(1005): Power(value=6720.751321413104, exponent=0),
        ComponentId(1004): Power(value=6720.751321413104, exponent=0),
        ComponentId(1001): Power(value=3279.248678586895, exponent=0)
    }

With this change, the log looks like this:

    Distributing power 10 kW between the batteries: (CID1004, CID1005): 6.72 kW, CID1001: 3.28 kW

Also improved the formatting.