### PR TITLE
Update to use the microgrid API v0.18

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,7 +6,25 @@
 
 ## Upgrading
 
-<!-- Here goes notes on how to upgrade from previous versions, including deprecations and what they should be replaced with -->
+- The SDK now depends on the `frequenz-client-microgrid` v0.18.x series.
+
+    * Check the release notes for the client [v0.18].
+    * There were a lot of changes, so it might be also worth having a quick look at the microgrid API [v0.17][api-v0.17] and [v0.18][api-v0.17] releases.
+    * Checking out the API common releases [v0.6][common-v0.6], [v0.7][common-v0.7], [v0.8][common-v0.8] might also be worthwhile, at least if you find any errors about renamed or missing types.
+    * Although many of the changes in lower layer are hidden by the SDK, there are some changes that can't be hidden away. For example the `Metric` enum had some renames, and `Component.component_id` was renamed to `Component.id`. Also, there is a new component class hierarchy.
+
+- `ComponentGraph` methods arguments were renamed to better reflect what they expect.
+
+    * The `components()` method now uses `matching_ids` and `matching_types` instead of `component_ids` and `component_categories` respectively. `matching_types` takes types inheriting from `Component` instead of categories, for example `Battery` or `BatteryInverter`.
+    * The `connections()` methods now take `matching_sources` and `matching_destinations` instead of `start` and `end` respectively. This is to match the new names in `ComponentConnection`.
+    * All arguments for both methods can now receiver arbitrary iterables instead of `set`s, and can also accept a single value.
+
+[v0.18]: https://github.com/frequenz-floss/frequenz-client-microgrid-python/releases/tag/v0.18.0
+[api-v0.17]: https://github.com/frequenz-floss/frequenz-api-microgrid/releases/tag/v0.17.0
+[api-v0.18]: https://github.com/frequenz-floss/frequenz-api-microgrid/releases/tag/v0.18.0
+[common-v0.6]: https://github.com/frequenz-floss/frequenz-api-common/releases/tag/v0.6.0
+[common-v0.7]: https://github.com/frequenz-floss/frequenz-api-common/releases/tag/v0.7.0
+[common-v0.8]: https://github.com/frequenz-floss/frequenz-api-common/releases/tag/v0.8.0
 
 ## New Features
 

--- a/benchmarks/power_distribution/power_distributor.py
+++ b/benchmarks/power_distribution/power_distributor.py
@@ -13,7 +13,7 @@ from typing import Any
 
 from frequenz.channels import Broadcast
 from frequenz.client.common.microgrid.components import ComponentId
-from frequenz.client.microgrid import Component, ComponentCategory
+from frequenz.client.microgrid.component import Battery
 from frequenz.quantities import Power
 
 from frequenz.sdk import microgrid
@@ -116,8 +116,7 @@ async def run_test(  # pylint: disable=too-many-locals
     battery_status_channel = Broadcast[ComponentPoolStatus](name="battery-status")
     power_result_channel = Broadcast[Result](name="power-result")
     async with PowerDistributingActor(
-        component_category=ComponentCategory.BATTERY,
-        component_type=None,
+        component_type=Battery,
         requests_receiver=power_request_channel.new_receiver(),
         results_sender=power_result_channel.new_sender(),
         component_pool_status_sender=battery_status_channel.new_sender(),
@@ -143,8 +142,8 @@ async def run() -> None:
         ResamplerConfig2(resampling_period=timedelta(seconds=1.0)),
     )
 
-    all_batteries: set[Component] = connection_manager.get().component_graph.components(
-        component_categories={ComponentCategory.BATTERY}
+    all_batteries = connection_manager.get().component_graph.components(
+        matching_types={Battery},
     )
     batteries_ids = {c.id for c in all_batteries}
     # Take some time to get data from components

--- a/benchmarks/power_distribution/power_distributor.py
+++ b/benchmarks/power_distribution/power_distributor.py
@@ -143,7 +143,7 @@ async def run() -> None:
     )
 
     all_batteries = connection_manager.get().component_graph.components(
-        matching_types={Battery},
+        matching_types=Battery
     )
     batteries_ids = {c.id for c in all_batteries}
     # Take some time to get data from components

--- a/benchmarks/power_distribution/power_distributor.py
+++ b/benchmarks/power_distribution/power_distributor.py
@@ -146,7 +146,7 @@ async def run() -> None:
     all_batteries: set[Component] = connection_manager.get().component_graph.components(
         component_categories={ComponentCategory.BATTERY}
     )
-    batteries_ids = {c.component_id for c in all_batteries}
+    batteries_ids = {c.id for c in all_batteries}
     # Take some time to get data from components
     await asyncio.sleep(4)
     with open("/dev/stdout", "w", encoding="utf-8") as csvfile:

--- a/benchmarks/timeseries/benchmark_datasourcing.py
+++ b/benchmarks/timeseries/benchmark_datasourcing.py
@@ -17,7 +17,7 @@ from time import perf_counter
 from typing import Any
 
 from frequenz.channels import Broadcast, Receiver, ReceiverStoppedError
-from frequenz.client.microgrid import ComponentMetricId
+from frequenz.client.microgrid.metrics import Metric
 
 from frequenz.sdk import microgrid
 from frequenz.sdk._internal._channels import ChannelRegistry
@@ -37,9 +37,9 @@ except ImportError:
     sys.exit(1)
 
 COMPONENT_METRIC_IDS = [
-    ComponentMetricId.CURRENT_PHASE_1,
-    ComponentMetricId.CURRENT_PHASE_2,
-    ComponentMetricId.CURRENT_PHASE_3,
+    Metric.AC_CURRENT_PHASE_1,
+    Metric.AC_CURRENT_PHASE_2,
+    Metric.AC_CURRENT_PHASE_3,
 ]
 
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -119,7 +119,7 @@ plugins:
             - https://docs.python.org/3/objects.inv
             - https://frequenz-floss.github.io/frequenz-channels-python/v1/objects.inv
             - https://frequenz-floss.github.io/frequenz-client-common-python/v0.3/objects.inv
-            - https://frequenz-floss.github.io/frequenz-client-microgrid-python/v0.9/objects.inv
+            - https://frequenz-floss.github.io/frequenz-client-microgrid-python/v0.18/objects.inv
             - https://frequenz-floss.github.io/frequenz-core-python/v1/objects.inv
             - https://frequenz-floss.github.io/frequenz-quantities-python/v1/objects.inv
             - https://lovasoa.github.io/marshmallow_dataclass/html/objects.inv

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,8 +29,8 @@ dependencies = [
   # Make sure to update the mkdocs.yml file when
   # changing the version
   # (plugins.mkdocstrings.handlers.python.import)
-  "frequenz-client-microgrid >= 0.9.0, < 0.10.0",
-  "frequenz-client-common >= 0.3.2, < 0.4.0",
+  "frequenz-client-microgrid >= 0.18.0, < 0.19.0",
+  "frequenz-client-common >= 0.3.6, < 0.4.0",
   "frequenz-channels >= 1.6.1, < 2.0.0",
   "frequenz-quantities[marshmallow] >= 1.0.0, < 2.0.0",
   "networkx >= 2.8, < 4",

--- a/src/frequenz/sdk/microgrid/_data_pipeline.py
+++ b/src/frequenz/sdk/microgrid/_data_pipeline.py
@@ -18,7 +18,7 @@ from datetime import timedelta
 
 from frequenz.channels import Broadcast, Sender
 from frequenz.client.common.microgrid.components import ComponentId
-from frequenz.client.microgrid import ComponentCategory, InverterType
+from frequenz.client.microgrid.component import Battery, EvCharger, SolarInverter
 
 from frequenz.sdk.microgrid._power_managing._base_classes import Algorithm, DefaultPower
 
@@ -105,23 +105,25 @@ class _DataPipeline:  # pylint: disable=too-many-instance-attributes
             self._channel_registry,
             api_power_request_timeout=api_power_request_timeout,
             power_manager_algorithm=Algorithm.SHIFTING_MATRYOSHKA,
-            component_category=ComponentCategory.BATTERY,
             default_power=DefaultPower.ZERO,
+            component_class=Battery,
         )
         self._ev_power_wrapper = PowerWrapper(
             self._channel_registry,
             api_power_request_timeout=api_power_request_timeout,
             power_manager_algorithm=Algorithm.MATRYOSHKA,
-            component_category=ComponentCategory.EV_CHARGER,
             default_power=DefaultPower.MAX,
+            component_class=EvCharger,
         )
         self._pv_power_wrapper = PowerWrapper(
             self._channel_registry,
             api_power_request_timeout=api_power_request_timeout,
             power_manager_algorithm=Algorithm.MATRYOSHKA,
-            component_category=ComponentCategory.INVERTER,
-            component_type=InverterType.SOLAR,
             default_power=DefaultPower.MIN,
+            # Using SolarInverter might be too specific, maybe we need to also pass
+            # HybridInverter, see
+            # https://github.com/frequenz-floss/frequenz-sdk-python/issues/1285
+            component_class=SolarInverter,
         )
 
         self._logical_meter: LogicalMeter | None = None

--- a/src/frequenz/sdk/microgrid/_data_sourcing/__init__.py
+++ b/src/frequenz/sdk/microgrid/_data_sourcing/__init__.py
@@ -3,11 +3,13 @@
 
 """The DataSourcingActor."""
 
-from ._component_metric_request import ComponentMetricId, ComponentMetricRequest
+from frequenz.client.microgrid.metrics import Metric
+
+from ._component_metric_request import ComponentMetricRequest
 from .data_sourcing import DataSourcingActor
 
 __all__ = [
-    "ComponentMetricId",
+    "Metric",
     "ComponentMetricRequest",
     "DataSourcingActor",
 ]

--- a/src/frequenz/sdk/microgrid/_data_sourcing/_component_metric_request.py
+++ b/src/frequenz/sdk/microgrid/_data_sourcing/_component_metric_request.py
@@ -7,9 +7,11 @@ from dataclasses import dataclass
 from datetime import datetime
 
 from frequenz.client.common.microgrid.components import ComponentId
-from frequenz.client.microgrid import ComponentMetricId
+from frequenz.client.microgrid.metrics import Metric
 
-__all__ = ["ComponentMetricRequest", "ComponentMetricId"]
+from frequenz.sdk.microgrid._old_component_data import TransitionalMetric
+
+__all__ = ["ComponentMetricRequest", "Metric"]
 
 
 @dataclass
@@ -25,7 +27,7 @@ class ComponentMetricRequest:
     metric. For example, requesters can use different `namespace` values to subscribe to
     raw or resampled data streams separately. This ensures that each requester receives
     the appropriate type of data without interference. Requests with the same
-    `namespace`, `component_id`, and `metric_id` will use the same channel, preventing
+    `namespace`, `component_id`, and `metric` will use the same channel, preventing
     unnecessary duplication of data streams.
 
     The requester and provider must use the same channel name so that they can
@@ -40,7 +42,7 @@ class ComponentMetricRequest:
     component_id: ComponentId
     """The ID of the requested component."""
 
-    metric_id: ComponentMetricId
+    metric: Metric | TransitionalMetric
     """The ID of the requested component's metric."""
 
     start_time: datetime | None
@@ -60,7 +62,7 @@ class ComponentMetricRequest:
             "component_metric_request<"
             f"namespace={self.namespace},"
             f"component_id={self.component_id},"
-            f"metric_id={self.metric_id.name}"
+            f"metric={self.metric.name}"
             f"{start}"
             ">"
         )

--- a/src/frequenz/sdk/microgrid/_data_sourcing/microgrid_api_source.py
+++ b/src/frequenz/sdk/microgrid/_data_sourcing/microgrid_api_source.py
@@ -10,9 +10,7 @@ from typing import Any
 
 from frequenz.channels import Receiver, Sender
 from frequenz.client.common.microgrid.components import ComponentId
-from frequenz.client.microgrid import (
-    ComponentCategory,
-)
+from frequenz.client.microgrid.component import ComponentCategory
 from frequenz.client.microgrid.metrics import Metric
 from frequenz.quantities import Quantity
 
@@ -140,7 +138,7 @@ class MicrogridApiSource:
             registry: A channel registry.  To be replaced by a singleton
                 instance.
         """
-        self._comp_categories_cache: dict[ComponentId, ComponentCategory] = {}
+        self._comp_categories_cache: dict[ComponentId, ComponentCategory | int] = {}
 
         self.comp_data_receivers: dict[ComponentId, Receiver[Any]] = {}
         """The dictionary of component IDs to data receivers."""
@@ -155,7 +153,7 @@ class MicrogridApiSource:
 
     async def _get_component_category(
         self, comp_id: ComponentId
-    ) -> ComponentCategory | None:
+    ) -> ComponentCategory | int | None:
         """Get the component category of the given component.
 
         Args:
@@ -280,7 +278,7 @@ class MicrogridApiSource:
     async def _check_requested_component_and_metrics(
         self,
         comp_id: ComponentId,
-        category: ComponentCategory,
+        category: ComponentCategory | int,
         requests: dict[Metric | TransitionalMetric, list[ComponentMetricRequest]],
     ) -> None:
         """Check if the requested component and metrics are valid.
@@ -312,7 +310,7 @@ class MicrogridApiSource:
             raise ValueError(err)
 
     def _get_data_extraction_method(
-        self, category: ComponentCategory, metric: Metric | TransitionalMetric
+        self, category: ComponentCategory | int, metric: Metric | TransitionalMetric
     ) -> Callable[[Any], float]:
         """Get the data extraction method for the given metric.
 
@@ -341,7 +339,7 @@ class MicrogridApiSource:
 
     def _get_metric_senders(
         self,
-        category: ComponentCategory,
+        category: ComponentCategory | int,
         requests: dict[Metric | TransitionalMetric, list[ComponentMetricRequest]],
     ) -> list[tuple[Callable[[Any], float], list[Sender[Sample[Quantity]]]]]:
         """Get channel senders from the channel registry for each requested metric.
@@ -371,7 +369,7 @@ class MicrogridApiSource:
     async def _handle_data_stream(
         self,
         comp_id: ComponentId,
-        category: ComponentCategory,
+        category: ComponentCategory | int,
     ) -> None:
         """Stream component data and send the requested metrics out.
 
@@ -436,14 +434,14 @@ class MicrogridApiSource:
                 "Unexpected error while handling data stream for component %d (%s), "
                 "component data is not being streamed anymore",
                 comp_id,
-                category.name,
+                category,
             )
             raise
 
     async def _update_streams(
         self,
         comp_id: ComponentId,
-        category: ComponentCategory,
+        category: ComponentCategory | int,
     ) -> None:
         """Update the requested metric streams for the given component.
 
@@ -456,7 +454,7 @@ class MicrogridApiSource:
 
         self.comp_data_tasks[comp_id] = asyncio.create_task(
             run_forever(lambda: self._handle_data_stream(comp_id, category)),
-            name=f"{type(self).__name__}._update_stream({comp_id=}, {category.name})",
+            name=f"{type(self).__name__}._update_stream({comp_id=}, {category})",
         )
 
     async def add_metric(self, request: ComponentMetricRequest) -> None:

--- a/src/frequenz/sdk/microgrid/_data_sourcing/microgrid_api_source.py
+++ b/src/frequenz/sdk/microgrid/_data_sourcing/microgrid_api_source.py
@@ -13,123 +13,114 @@ from frequenz.client.common.microgrid.components import ComponentId
 from frequenz.client.microgrid import (
     BatteryData,
     ComponentCategory,
-    ComponentMetricId,
     EVChargerData,
     InverterData,
     MeterData,
 )
+from frequenz.client.microgrid.metrics import Metric
 from frequenz.quantities import Quantity
 
 from ..._internal._asyncio import run_forever
 from ..._internal._channels import ChannelRegistry
 from ...microgrid import connection_manager
 from ...timeseries import Sample
+from .._old_component_data import (
+    TransitionalMetric,
+)
 from ._component_metric_request import ComponentMetricRequest
 
 _logger = logging.getLogger(__name__)
 
-_MeterDataMethods: dict[ComponentMetricId, Callable[[MeterData], float]] = {
-    ComponentMetricId.ACTIVE_POWER: lambda msg: msg.active_power,
-    ComponentMetricId.ACTIVE_POWER_PHASE_1: lambda msg: msg.active_power_per_phase[0],
-    ComponentMetricId.ACTIVE_POWER_PHASE_2: lambda msg: msg.active_power_per_phase[1],
-    ComponentMetricId.ACTIVE_POWER_PHASE_3: lambda msg: msg.active_power_per_phase[2],
-    ComponentMetricId.CURRENT_PHASE_1: lambda msg: msg.current_per_phase[0],
-    ComponentMetricId.CURRENT_PHASE_2: lambda msg: msg.current_per_phase[1],
-    ComponentMetricId.CURRENT_PHASE_3: lambda msg: msg.current_per_phase[2],
-    ComponentMetricId.VOLTAGE_PHASE_1: lambda msg: msg.voltage_per_phase[0],
-    ComponentMetricId.VOLTAGE_PHASE_2: lambda msg: msg.voltage_per_phase[1],
-    ComponentMetricId.VOLTAGE_PHASE_3: lambda msg: msg.voltage_per_phase[2],
-    ComponentMetricId.FREQUENCY: lambda msg: msg.frequency,
-    ComponentMetricId.REACTIVE_POWER: lambda msg: msg.reactive_power,
-    ComponentMetricId.REACTIVE_POWER_PHASE_1: lambda msg: msg.reactive_power_per_phase[
-        0
-    ],
-    ComponentMetricId.REACTIVE_POWER_PHASE_2: lambda msg: msg.reactive_power_per_phase[
-        1
-    ],
-    ComponentMetricId.REACTIVE_POWER_PHASE_3: lambda msg: msg.reactive_power_per_phase[
-        2
-    ],
+_MeterDataMethods: dict[Metric | TransitionalMetric, Callable[[MeterData], float]] = {
+    Metric.AC_ACTIVE_POWER: lambda msg: msg.active_power,
+    Metric.AC_ACTIVE_POWER_PHASE_1: lambda msg: msg.active_power_per_phase[0],
+    Metric.AC_ACTIVE_POWER_PHASE_2: lambda msg: msg.active_power_per_phase[1],
+    Metric.AC_ACTIVE_POWER_PHASE_3: lambda msg: msg.active_power_per_phase[2],
+    Metric.AC_CURRENT_PHASE_1: lambda msg: msg.current_per_phase[0],
+    Metric.AC_CURRENT_PHASE_2: lambda msg: msg.current_per_phase[1],
+    Metric.AC_CURRENT_PHASE_3: lambda msg: msg.current_per_phase[2],
+    Metric.AC_VOLTAGE_PHASE_1_N: lambda msg: msg.voltage_per_phase[0],
+    Metric.AC_VOLTAGE_PHASE_2_N: lambda msg: msg.voltage_per_phase[1],
+    Metric.AC_VOLTAGE_PHASE_3_N: lambda msg: msg.voltage_per_phase[2],
+    Metric.AC_FREQUENCY: lambda msg: msg.frequency,
+    Metric.AC_REACTIVE_POWER: lambda msg: msg.reactive_power,
+    Metric.AC_REACTIVE_POWER_PHASE_1: lambda msg: msg.reactive_power_per_phase[0],
+    Metric.AC_REACTIVE_POWER_PHASE_2: lambda msg: msg.reactive_power_per_phase[1],
+    Metric.AC_REACTIVE_POWER_PHASE_3: lambda msg: msg.reactive_power_per_phase[2],
 }
 
-_BatteryDataMethods: dict[ComponentMetricId, Callable[[BatteryData], float]] = {
-    ComponentMetricId.SOC: lambda msg: msg.soc,
-    ComponentMetricId.SOC_LOWER_BOUND: lambda msg: msg.soc_lower_bound,
-    ComponentMetricId.SOC_UPPER_BOUND: lambda msg: msg.soc_upper_bound,
-    ComponentMetricId.CAPACITY: lambda msg: msg.capacity,
-    ComponentMetricId.POWER_INCLUSION_LOWER_BOUND: lambda msg: (
+_BatteryDataMethods: dict[
+    Metric | TransitionalMetric, Callable[[BatteryData], float]
+] = {
+    Metric.BATTERY_SOC_PCT: lambda msg: msg.soc,
+    TransitionalMetric.SOC_LOWER_BOUND: lambda msg: msg.soc_lower_bound,
+    TransitionalMetric.SOC_UPPER_BOUND: lambda msg: msg.soc_upper_bound,
+    Metric.BATTERY_CAPACITY: lambda msg: msg.capacity,
+    TransitionalMetric.POWER_INCLUSION_LOWER_BOUND: lambda msg: (
         msg.power_inclusion_lower_bound
     ),
-    ComponentMetricId.POWER_EXCLUSION_LOWER_BOUND: lambda msg: (
+    TransitionalMetric.POWER_EXCLUSION_LOWER_BOUND: lambda msg: (
         msg.power_exclusion_lower_bound
     ),
-    ComponentMetricId.POWER_EXCLUSION_UPPER_BOUND: lambda msg: (
+    TransitionalMetric.POWER_EXCLUSION_UPPER_BOUND: lambda msg: (
         msg.power_exclusion_upper_bound
     ),
-    ComponentMetricId.POWER_INCLUSION_UPPER_BOUND: lambda msg: (
+    TransitionalMetric.POWER_INCLUSION_UPPER_BOUND: lambda msg: (
         msg.power_inclusion_upper_bound
     ),
-    ComponentMetricId.TEMPERATURE: lambda msg: msg.temperature,
+    Metric.BATTERY_TEMPERATURE: lambda msg: msg.temperature,
 }
 
-_InverterDataMethods: dict[ComponentMetricId, Callable[[InverterData], float]] = {
-    ComponentMetricId.ACTIVE_POWER: lambda msg: msg.active_power,
-    ComponentMetricId.ACTIVE_POWER_PHASE_1: lambda msg: msg.active_power_per_phase[0],
-    ComponentMetricId.ACTIVE_POWER_PHASE_2: lambda msg: msg.active_power_per_phase[1],
-    ComponentMetricId.ACTIVE_POWER_PHASE_3: lambda msg: msg.active_power_per_phase[2],
-    ComponentMetricId.ACTIVE_POWER_INCLUSION_LOWER_BOUND: lambda msg: (
+_InverterDataMethods: dict[
+    Metric | TransitionalMetric, Callable[[InverterData], float]
+] = {
+    Metric.AC_ACTIVE_POWER: lambda msg: msg.active_power,
+    Metric.AC_ACTIVE_POWER_PHASE_1: lambda msg: msg.active_power_per_phase[0],
+    Metric.AC_ACTIVE_POWER_PHASE_2: lambda msg: msg.active_power_per_phase[1],
+    Metric.AC_ACTIVE_POWER_PHASE_3: lambda msg: msg.active_power_per_phase[2],
+    TransitionalMetric.ACTIVE_POWER_INCLUSION_LOWER_BOUND: lambda msg: (
         msg.active_power_inclusion_lower_bound
     ),
-    ComponentMetricId.ACTIVE_POWER_EXCLUSION_LOWER_BOUND: lambda msg: (
+    TransitionalMetric.ACTIVE_POWER_EXCLUSION_LOWER_BOUND: lambda msg: (
         msg.active_power_exclusion_lower_bound
     ),
-    ComponentMetricId.ACTIVE_POWER_EXCLUSION_UPPER_BOUND: lambda msg: (
+    TransitionalMetric.ACTIVE_POWER_EXCLUSION_UPPER_BOUND: lambda msg: (
         msg.active_power_exclusion_upper_bound
     ),
-    ComponentMetricId.ACTIVE_POWER_INCLUSION_UPPER_BOUND: lambda msg: (
+    TransitionalMetric.ACTIVE_POWER_INCLUSION_UPPER_BOUND: lambda msg: (
         msg.active_power_inclusion_upper_bound
     ),
-    ComponentMetricId.CURRENT_PHASE_1: lambda msg: msg.current_per_phase[0],
-    ComponentMetricId.CURRENT_PHASE_2: lambda msg: msg.current_per_phase[1],
-    ComponentMetricId.CURRENT_PHASE_3: lambda msg: msg.current_per_phase[2],
-    ComponentMetricId.VOLTAGE_PHASE_1: lambda msg: msg.voltage_per_phase[0],
-    ComponentMetricId.VOLTAGE_PHASE_2: lambda msg: msg.voltage_per_phase[1],
-    ComponentMetricId.VOLTAGE_PHASE_3: lambda msg: msg.voltage_per_phase[2],
-    ComponentMetricId.FREQUENCY: lambda msg: msg.frequency,
-    ComponentMetricId.REACTIVE_POWER: lambda msg: msg.reactive_power,
-    ComponentMetricId.REACTIVE_POWER_PHASE_1: lambda msg: msg.reactive_power_per_phase[
-        0
-    ],
-    ComponentMetricId.REACTIVE_POWER_PHASE_2: lambda msg: msg.reactive_power_per_phase[
-        1
-    ],
-    ComponentMetricId.REACTIVE_POWER_PHASE_3: lambda msg: msg.reactive_power_per_phase[
-        2
-    ],
+    Metric.AC_CURRENT_PHASE_1: lambda msg: msg.current_per_phase[0],
+    Metric.AC_CURRENT_PHASE_2: lambda msg: msg.current_per_phase[1],
+    Metric.AC_CURRENT_PHASE_3: lambda msg: msg.current_per_phase[2],
+    Metric.AC_VOLTAGE_PHASE_1_N: lambda msg: msg.voltage_per_phase[0],
+    Metric.AC_VOLTAGE_PHASE_2_N: lambda msg: msg.voltage_per_phase[1],
+    Metric.AC_VOLTAGE_PHASE_3_N: lambda msg: msg.voltage_per_phase[2],
+    Metric.AC_FREQUENCY: lambda msg: msg.frequency,
+    Metric.AC_REACTIVE_POWER: lambda msg: msg.reactive_power,
+    Metric.AC_REACTIVE_POWER_PHASE_1: lambda msg: msg.reactive_power_per_phase[0],
+    Metric.AC_REACTIVE_POWER_PHASE_2: lambda msg: msg.reactive_power_per_phase[1],
+    Metric.AC_REACTIVE_POWER_PHASE_3: lambda msg: msg.reactive_power_per_phase[2],
 }
 
-_EVChargerDataMethods: dict[ComponentMetricId, Callable[[EVChargerData], float]] = {
-    ComponentMetricId.ACTIVE_POWER: lambda msg: msg.active_power,
-    ComponentMetricId.ACTIVE_POWER_PHASE_1: lambda msg: msg.active_power_per_phase[0],
-    ComponentMetricId.ACTIVE_POWER_PHASE_2: lambda msg: msg.active_power_per_phase[1],
-    ComponentMetricId.ACTIVE_POWER_PHASE_3: lambda msg: msg.active_power_per_phase[2],
-    ComponentMetricId.CURRENT_PHASE_1: lambda msg: msg.current_per_phase[0],
-    ComponentMetricId.CURRENT_PHASE_2: lambda msg: msg.current_per_phase[1],
-    ComponentMetricId.CURRENT_PHASE_3: lambda msg: msg.current_per_phase[2],
-    ComponentMetricId.VOLTAGE_PHASE_1: lambda msg: msg.voltage_per_phase[0],
-    ComponentMetricId.VOLTAGE_PHASE_2: lambda msg: msg.voltage_per_phase[1],
-    ComponentMetricId.VOLTAGE_PHASE_3: lambda msg: msg.voltage_per_phase[2],
-    ComponentMetricId.FREQUENCY: lambda msg: msg.frequency,
-    ComponentMetricId.REACTIVE_POWER: lambda msg: msg.reactive_power,
-    ComponentMetricId.REACTIVE_POWER_PHASE_1: lambda msg: msg.reactive_power_per_phase[
-        0
-    ],
-    ComponentMetricId.REACTIVE_POWER_PHASE_2: lambda msg: msg.reactive_power_per_phase[
-        1
-    ],
-    ComponentMetricId.REACTIVE_POWER_PHASE_3: lambda msg: msg.reactive_power_per_phase[
-        2
-    ],
+_EVChargerDataMethods: dict[
+    Metric | TransitionalMetric, Callable[[EVChargerData], float]
+] = {
+    Metric.AC_ACTIVE_POWER: lambda msg: msg.active_power,
+    Metric.AC_ACTIVE_POWER_PHASE_1: lambda msg: msg.active_power_per_phase[0],
+    Metric.AC_ACTIVE_POWER_PHASE_2: lambda msg: msg.active_power_per_phase[1],
+    Metric.AC_ACTIVE_POWER_PHASE_3: lambda msg: msg.active_power_per_phase[2],
+    Metric.AC_CURRENT_PHASE_1: lambda msg: msg.current_per_phase[0],
+    Metric.AC_CURRENT_PHASE_2: lambda msg: msg.current_per_phase[1],
+    Metric.AC_CURRENT_PHASE_3: lambda msg: msg.current_per_phase[2],
+    Metric.AC_VOLTAGE_PHASE_1_N: lambda msg: msg.voltage_per_phase[0],
+    Metric.AC_VOLTAGE_PHASE_2_N: lambda msg: msg.voltage_per_phase[1],
+    Metric.AC_VOLTAGE_PHASE_3_N: lambda msg: msg.voltage_per_phase[2],
+    Metric.AC_FREQUENCY: lambda msg: msg.frequency,
+    Metric.AC_REACTIVE_POWER: lambda msg: msg.reactive_power,
+    Metric.AC_REACTIVE_POWER_PHASE_1: lambda msg: msg.reactive_power_per_phase[0],
+    Metric.AC_REACTIVE_POWER_PHASE_2: lambda msg: msg.reactive_power_per_phase[1],
+    Metric.AC_REACTIVE_POWER_PHASE_3: lambda msg: msg.reactive_power_per_phase[2],
 }
 
 
@@ -159,7 +150,7 @@ class MicrogridApiSource:
 
         self._registry = registry
         self._req_streaming_metrics: dict[
-            ComponentId, dict[ComponentMetricId, list[ComponentMetricRequest]]
+            ComponentId, dict[Metric | TransitionalMetric, list[ComponentMetricRequest]]
         ] = {}
 
     async def _get_component_category(
@@ -189,7 +180,7 @@ class MicrogridApiSource:
     async def _check_battery_request(
         self,
         comp_id: ComponentId,
-        requests: dict[ComponentMetricId, list[ComponentMetricRequest]],
+        requests: dict[Metric | TransitionalMetric, list[ComponentMetricRequest]],
     ) -> None:
         """Check if the requests are valid Battery metrics.
 
@@ -214,7 +205,7 @@ class MicrogridApiSource:
     async def _check_ev_charger_request(
         self,
         comp_id: ComponentId,
-        requests: dict[ComponentMetricId, list[ComponentMetricRequest]],
+        requests: dict[Metric | TransitionalMetric, list[ComponentMetricRequest]],
     ) -> None:
         """Check if the requests are valid EV Charger metrics.
 
@@ -239,7 +230,7 @@ class MicrogridApiSource:
     async def _check_inverter_request(
         self,
         comp_id: ComponentId,
-        requests: dict[ComponentMetricId, list[ComponentMetricRequest]],
+        requests: dict[Metric | TransitionalMetric, list[ComponentMetricRequest]],
     ) -> None:
         """Check if the requests are valid Inverter metrics.
 
@@ -264,7 +255,7 @@ class MicrogridApiSource:
     async def _check_meter_request(
         self,
         comp_id: ComponentId,
-        requests: dict[ComponentMetricId, list[ComponentMetricRequest]],
+        requests: dict[Metric | TransitionalMetric, list[ComponentMetricRequest]],
     ) -> None:
         """Check if the requests are valid Meter metrics.
 
@@ -290,7 +281,7 @@ class MicrogridApiSource:
         self,
         comp_id: ComponentId,
         category: ComponentCategory,
-        requests: dict[ComponentMetricId, list[ComponentMetricRequest]],
+        requests: dict[Metric | TransitionalMetric, list[ComponentMetricRequest]],
     ) -> None:
         """Check if the requested component and metrics are valid.
 
@@ -321,7 +312,7 @@ class MicrogridApiSource:
             raise ValueError(err)
 
     def _get_data_extraction_method(
-        self, category: ComponentCategory, metric: ComponentMetricId
+        self, category: ComponentCategory, metric: Metric | TransitionalMetric
     ) -> Callable[[Any], float]:
         """Get the data extraction method for the given metric.
 
@@ -351,7 +342,7 @@ class MicrogridApiSource:
     def _get_metric_senders(
         self,
         category: ComponentCategory,
-        requests: dict[ComponentMetricId, list[ComponentMetricRequest]],
+        requests: dict[Metric | TransitionalMetric, list[ComponentMetricRequest]],
     ) -> list[tuple[Callable[[Any], float], list[Sender[Sample[Quantity]]]]]:
         """Get channel senders from the channel registry for each requested metric.
 
@@ -484,15 +475,15 @@ class MicrogridApiSource:
             return
 
         self._req_streaming_metrics.setdefault(comp_id, {}).setdefault(
-            request.metric_id, []
+            request.metric, []
         )
 
-        for existing_request in self._req_streaming_metrics[comp_id][request.metric_id]:
+        for existing_request in self._req_streaming_metrics[comp_id][request.metric]:
             if existing_request.get_channel_name() == request.get_channel_name():
                 # the requested metric is already being handled, so nothing to do.
                 return
 
-        self._req_streaming_metrics[comp_id][request.metric_id].append(request)
+        self._req_streaming_metrics[comp_id][request.metric].append(request)
 
         await self._update_streams(
             comp_id,

--- a/src/frequenz/sdk/microgrid/_data_sourcing/microgrid_api_source.py
+++ b/src/frequenz/sdk/microgrid/_data_sourcing/microgrid_api_source.py
@@ -170,7 +170,7 @@ class MicrogridApiSource:
 
         api = connection_manager.get().api_client
         for comp in await api.list_components():
-            self._comp_categories_cache[comp.component_id] = comp.category
+            self._comp_categories_cache[comp.id] = comp.category
 
         if comp_id in self._comp_categories_cache:
             return self._comp_categories_cache[comp_id]

--- a/src/frequenz/sdk/microgrid/_data_sourcing/microgrid_api_source.py
+++ b/src/frequenz/sdk/microgrid/_data_sourcing/microgrid_api_source.py
@@ -11,11 +11,7 @@ from typing import Any
 from frequenz.channels import Receiver, Sender
 from frequenz.client.common.microgrid.components import ComponentId
 from frequenz.client.microgrid import (
-    BatteryData,
     ComponentCategory,
-    EVChargerData,
-    InverterData,
-    MeterData,
 )
 from frequenz.client.microgrid.metrics import Metric
 from frequenz.quantities import Quantity
@@ -25,6 +21,10 @@ from ..._internal._channels import ChannelRegistry
 from ...microgrid import connection_manager
 from ...timeseries import Sample
 from .._old_component_data import (
+    BatteryData,
+    EVChargerData,
+    InverterData,
+    MeterData,
     TransitionalMetric,
 )
 from ._component_metric_request import ComponentMetricRequest
@@ -169,7 +169,7 @@ class MicrogridApiSource:
             return self._comp_categories_cache[comp_id]
 
         api = connection_manager.get().api_client
-        for comp in await api.components():
+        for comp in await api.list_components():
             self._comp_categories_cache[comp.component_id] = comp.category
 
         if comp_id in self._comp_categories_cache:
@@ -198,8 +198,8 @@ class MicrogridApiSource:
                 _logger.error(err)
                 raise ValueError(err)
         if comp_id not in self.comp_data_receivers:
-            self.comp_data_receivers[comp_id] = (
-                await connection_manager.get().api_client.battery_data(comp_id)
+            self.comp_data_receivers[comp_id] = BatteryData.subscribe(
+                connection_manager.get().api_client, comp_id
             )
 
     async def _check_ev_charger_request(
@@ -223,8 +223,8 @@ class MicrogridApiSource:
                 _logger.error(err)
                 raise ValueError(err)
         if comp_id not in self.comp_data_receivers:
-            self.comp_data_receivers[comp_id] = (
-                await connection_manager.get().api_client.ev_charger_data(comp_id)
+            self.comp_data_receivers[comp_id] = EVChargerData.subscribe(
+                connection_manager.get().api_client, comp_id
             )
 
     async def _check_inverter_request(
@@ -248,8 +248,8 @@ class MicrogridApiSource:
                 _logger.error(err)
                 raise ValueError(err)
         if comp_id not in self.comp_data_receivers:
-            self.comp_data_receivers[comp_id] = (
-                await connection_manager.get().api_client.inverter_data(comp_id)
+            self.comp_data_receivers[comp_id] = InverterData.subscribe(
+                connection_manager.get().api_client, comp_id
             )
 
     async def _check_meter_request(
@@ -273,8 +273,8 @@ class MicrogridApiSource:
                 _logger.error(err)
                 raise ValueError(err)
         if comp_id not in self.comp_data_receivers:
-            self.comp_data_receivers[comp_id] = (
-                await connection_manager.get().api_client.meter_data(comp_id)
+            self.comp_data_receivers[comp_id] = MeterData.subscribe(
+                connection_manager.get().api_client, comp_id
             )
 
     async def _check_requested_component_and_metrics(

--- a/src/frequenz/sdk/microgrid/_old_component_data.py
+++ b/src/frequenz/sdk/microgrid/_old_component_data.py
@@ -160,7 +160,7 @@ class ComponentData(ABC):
         from .. import microgrid
 
         components = microgrid.connection_manager.get().component_graph.components(
-            matching_ids={component_id}
+            matching_ids=component_id
         )
         if not components:
             raise ValueError(f"Unable to find component with {component_id}")

--- a/src/frequenz/sdk/microgrid/_old_component_data.py
+++ b/src/frequenz/sdk/microgrid/_old_component_data.py
@@ -1,0 +1,1290 @@
+# License: MIT
+# Copyright © 2025 Frequenz Energy-as-a-Service GmbH
+
+"""Component data types for data coming from a microgrid.
+
+This is a transitional module for migrating from the microgrid API v0.15 to v0.17.
+It maps the new component data types to the old ones, so the rest of the code can
+be updated incrementally.
+
+This module should be removed once the migration is complete.
+"""
+
+# pylint: disable=too-many-lines,fixme
+
+from __future__ import annotations
+
+import logging
+import math
+from abc import ABC, abstractmethod
+from collections.abc import Set
+from dataclasses import dataclass
+from datetime import datetime
+from enum import Enum
+from typing import ClassVar, Self, TypeAlias, TypeGuard, TypeVar, assert_never, cast
+
+from frequenz.channels import Receiver
+from frequenz.client.common.microgrid.components import ComponentId
+from frequenz.client.microgrid import MicrogridApiClient
+from frequenz.client.microgrid.component import (
+    ComponentCategory,
+    ComponentDataSamples,
+    ComponentErrorCode,
+    ComponentStateCode,
+    ComponentStateSample,
+)
+from frequenz.client.microgrid.metrics import Bounds, Metric, MetricSample
+from typing_extensions import override
+
+_logger = logging.getLogger(__name__)
+
+T = TypeVar("T", bound="ComponentData")
+
+PhaseTuple: TypeAlias = tuple[float, float, float]
+
+DATA_STREAM_BUFFER_SIZE: int = 50
+
+
+class TransitionalMetric(Enum):
+    """An enum representing the metrics we had in v0.15 but are not a metric in v0.17."""
+
+    SOC_LOWER_BOUND = "soc_lower_bound"
+    """Lower bound of state of charge."""
+    SOC_UPPER_BOUND = "soc_upper_bound"
+    """Upper bound of state of charge."""
+
+    POWER_INCLUSION_LOWER_BOUND = "power_inclusion_lower_bound"
+    """Power inclusion lower bound."""
+    POWER_EXCLUSION_LOWER_BOUND = "power_exclusion_lower_bound"
+    """Power exclusion lower bound."""
+    POWER_EXCLUSION_UPPER_BOUND = "power_exclusion_upper_bound"
+    """Power exclusion upper bound."""
+    POWER_INCLUSION_UPPER_BOUND = "power_inclusion_upper_bound"
+    """Power inclusion upper bound."""
+
+    ACTIVE_POWER_INCLUSION_LOWER_BOUND = "active_power_inclusion_lower_bound"
+    """Active power inclusion lower bound."""
+    ACTIVE_POWER_EXCLUSION_LOWER_BOUND = "active_power_exclusion_lower_bound"
+    """Active power exclusion lower bound."""
+    ACTIVE_POWER_EXCLUSION_UPPER_BOUND = "active_power_exclusion_upper_bound"
+    """Active power exclusion upper bound."""
+    ACTIVE_POWER_INCLUSION_UPPER_BOUND = "active_power_inclusion_upper_bound"
+    """Active power inclusion upper bound."""
+
+
+@dataclass(kw_only=True)
+class ComponentData(ABC):
+    """A private base class for strongly typed component data classes."""
+
+    component_id: ComponentId
+    """The ID identifying this component in the microgrid."""
+
+    timestamp: datetime
+    """The timestamp of when the data was measured."""
+
+    states: Set[ComponentStateCode | int] = frozenset()
+    """The states of the component."""
+
+    warnings: Set[ComponentErrorCode | int] = frozenset()
+    """The warnings of the component."""
+
+    errors: Set[ComponentErrorCode | int] = frozenset()
+    """The errors of the component."""
+
+    CATEGORY: ClassVar[ComponentCategory] = ComponentCategory.UNSPECIFIED
+    """The category of this component."""
+
+    METRICS: ClassVar[frozenset[Metric]] = frozenset()
+    """The metrics of this component."""
+
+    @abstractmethod
+    def to_samples(self: Self) -> ComponentDataSamples:
+        """Convert the component data to a component data object."""
+
+    @staticmethod
+    def _from_samples(class_: type[T], /, samples: ComponentDataSamples) -> T:
+        """Create a new instance from a component data object."""
+        if not samples.metric_samples:
+            raise ValueError("No metrics in the samples.")
+
+        # FIXME: This might not be true forever, but the service sends all metrics with
+        # the same timestamp for now, and it is very convenient to map the received data
+        # to the old component data metrics packets, which had only one timestamp.
+        # When we move away frome these old_component_data wrappers, we should not
+        # assume only one metric sample can come per telemetry message anymore.
+        timestamp = samples.metric_samples[-1].sampled_at
+        for sample in samples.metric_samples[:-1]:
+            if sample.sampled_at != timestamp:
+                _logger.warning(
+                    "ComponentData has multiple timestamps. Using the last one. Samples: %r",
+                    samples,
+                )
+                break
+
+        if not samples.states:
+            return class_(component_id=samples.component_id, timestamp=timestamp)
+
+        # FIXME: Same as with metric samples, for now we get only one, and it is super
+        # convenient to map to component data, but we should not assume this when moving
+        # away from the legacy component data wrappers.
+        if len(samples.states) > 1:
+            _logger.warning(
+                "ComponentData has more than one state. Using the last one. States: %r",
+                samples.states,
+            )
+
+        return class_(
+            component_id=samples.component_id,
+            timestamp=timestamp,
+            states=samples.states[-1].states,
+            warnings=samples.states[-1].warnings,
+            errors=samples.states[-1].errors,
+        )
+
+    @classmethod
+    @abstractmethod
+    def from_samples(cls, samples: ComponentDataSamples) -> Self:
+        """Create a new instance from a component data object."""
+
+    @classmethod
+    def _check_category(cls, component_id: ComponentId) -> None:
+        """Check if the given component_id is of the expected type.
+
+        Args:
+            component_id: Component id to check.
+
+        Raises:
+            ValueError: if the given id is unknown or has a different type.
+        """
+        # pylint: disable-next=import-outside-toplevel,cyclic-import
+        from .. import microgrid
+
+        components = microgrid.connection_manager.get().component_graph.components(
+            filter_by_ids={component_id}
+        )
+        if not components:
+            raise ValueError(f"Unable to find component with {component_id}")
+        if len(components) > 1:
+            raise ValueError(f"Multiple components with id {component_id}")
+        component = components.pop()
+        if component.category != cls.CATEGORY:
+            raise ValueError(
+                f"Component with {component_id} is a {component.category}, "
+                f"not a {cls.CATEGORY}."
+            )
+
+    @classmethod
+    def subscribe(
+        cls,
+        api_client: MicrogridApiClient,
+        component_id: ComponentId,
+        *,
+        buffer_size: int = DATA_STREAM_BUFFER_SIZE,
+    ) -> Receiver[Self]:
+        """Subscribe to the component data stream."""
+        cls._check_category(component_id)
+
+        def _is_valid(messages: Self | Exception) -> TypeGuard[Self]:
+            return not isinstance(messages, Exception)
+
+        receiver = api_client.receive_component_data_samples_stream(
+            component_id, cls.METRICS, buffer_size=buffer_size
+        )
+
+        return receiver.map(cls._receive_logging_errors).filter(_is_valid)
+
+    # This needs to be a classmethod because otherwise it seems like mypy can't
+    # guarantee that the Self returned by this function is the same Self in the
+    # subscribe() method.
+    @classmethod
+    def _receive_logging_errors(
+        cls, samples: ComponentDataSamples, /
+    ) -> Self | Exception:
+        try:
+            return cls.from_samples(samples)
+        except Exception as exc:  # pylint: disable=broad-except
+            _logger.exception(
+                "Error while creating %r from samples: %r", cls.__name__, samples
+            )
+            return exc
+
+
+@dataclass(kw_only=True)
+class MeterData(ComponentData):
+    """A wrapper class for holding meter data."""
+
+    # FIXME: All of this have now a default of 0.0 because this is what it was doing when
+    # we used the API v0.15, as we accessed the fields without checking if the fields
+    # really existed, so the default protobuf value of 0.0 for floats was used.
+    # When moving away from these legacy component data wrappers, this should not be
+    # a problem anymore, as we will just get the data we get.
+    active_power: float = 0.0
+    """The total active 3-phase AC power, in Watts (W).
+
+    Represented in the passive sign convention.
+
+    * Positive means consumption from the grid.
+    * Negative means supply into the grid.
+    """
+
+    active_power_per_phase: PhaseTuple = (0.0, 0.0, 0.0)
+    """The per-phase AC active power for phase 1, 2, and 3 respectively, in Watt (W).
+
+    Represented in the passive sign convention.
+
+    * Positive means consumption from the grid.
+    * Negative means supply into the grid.
+    """
+
+    reactive_power: float = 0.0
+    """The total reactive 3-phase AC power, in Volt-Ampere Reactive (VAr).
+
+    * Positive power means capacitive (current leading w.r.t. voltage).
+    * Negative power means inductive (current lagging w.r.t. voltage).
+    """
+
+    reactive_power_per_phase: PhaseTuple = (0.0, 0.0, 0.0)
+    """The per-phase AC reactive power, in Volt-Ampere Reactive (VAr).
+
+    The provided values are for phase 1, 2, and 3 respectively.
+
+    * Positive power means capacitive (current leading w.r.t. voltage).
+    * Negative power means inductive (current lagging w.r.t. voltage).
+    """
+
+    current_per_phase: PhaseTuple = (0.0, 0.0, 0.0)
+    """AC current in Amperes (A) for phase/line 1,2 and 3 respectively.
+
+    Represented in the passive sign convention.
+
+    * Positive means consumption from the grid.
+    * Negative means supply into the grid.
+    """
+
+    voltage_per_phase: PhaseTuple = (0.0, 0.0, 0.0)
+    """The ac voltage in volts (v) between the line and the neutral wire for phase/line
+        1,2 and 3 respectively.
+    """
+
+    frequency: float = 0.0
+    """The AC power frequency in Hertz (Hz)."""
+
+    CATEGORY: ClassVar[ComponentCategory] = ComponentCategory.METER
+    """The category of this component."""
+
+    METRICS: ClassVar[frozenset[Metric]] = frozenset(
+        [
+            Metric.AC_ACTIVE_POWER,
+            Metric.AC_ACTIVE_POWER_PHASE_1,
+            Metric.AC_ACTIVE_POWER_PHASE_2,
+            Metric.AC_ACTIVE_POWER_PHASE_3,
+            Metric.AC_REACTIVE_POWER,
+            Metric.AC_REACTIVE_POWER_PHASE_1,
+            Metric.AC_REACTIVE_POWER_PHASE_2,
+            Metric.AC_REACTIVE_POWER_PHASE_3,
+            Metric.AC_CURRENT_PHASE_1,
+            Metric.AC_CURRENT_PHASE_2,
+            Metric.AC_CURRENT_PHASE_3,
+            Metric.AC_VOLTAGE_PHASE_1_N,
+            Metric.AC_VOLTAGE_PHASE_2_N,
+            Metric.AC_VOLTAGE_PHASE_3_N,
+            Metric.AC_FREQUENCY,
+        ]
+    )
+    """The metrics of this component."""
+
+    @override
+    @classmethod
+    def from_samples(cls, samples: ComponentDataSamples) -> Self:
+        """Create a new instance from a component data object."""
+        if not samples.metric_samples:
+            raise ValueError("No metrics in the samples.")
+
+        self = cls._from_samples(cls, samples)
+
+        active_power_per_phase: list[float] = [0.0, 0.0, 0.0]
+        reactive_power_per_phase: list[float] = [0.0, 0.0, 0.0]
+        current_per_phase: list[float] = [0.0, 0.0, 0.0]
+        voltage_per_phase: list[float] = [0.0, 0.0, 0.0]
+
+        for sample in samples.metric_samples:
+            match sample.metric:
+                case Metric.AC_ACTIVE_POWER:
+                    self.active_power = sample.as_single_value() or 0.0
+                case Metric.AC_ACTIVE_POWER_PHASE_1:
+                    active_power_per_phase[0] = sample.as_single_value() or 0.0
+                case Metric.AC_ACTIVE_POWER_PHASE_2:
+                    active_power_per_phase[1] = sample.as_single_value() or 0.0
+                case Metric.AC_ACTIVE_POWER_PHASE_3:
+                    active_power_per_phase[2] = sample.as_single_value() or 0.0
+                case Metric.AC_REACTIVE_POWER_PHASE_1:
+                    reactive_power_per_phase[0] = sample.as_single_value() or 0.0
+                case Metric.AC_REACTIVE_POWER_PHASE_2:
+                    reactive_power_per_phase[1] = sample.as_single_value() or 0.0
+                case Metric.AC_REACTIVE_POWER_PHASE_3:
+                    reactive_power_per_phase[2] = sample.as_single_value() or 0.0
+                case Metric.AC_REACTIVE_POWER:
+                    self.reactive_power = sample.as_single_value() or 0.0
+                case Metric.AC_CURRENT_PHASE_1:
+                    current_per_phase[0] = sample.as_single_value() or 0.0
+                case Metric.AC_CURRENT_PHASE_2:
+                    current_per_phase[1] = sample.as_single_value() or 0.0
+                case Metric.AC_CURRENT_PHASE_3:
+                    current_per_phase[2] = sample.as_single_value() or 0.0
+                case Metric.AC_VOLTAGE_PHASE_1_N:
+                    voltage_per_phase[0] = sample.as_single_value() or 0.0
+                case Metric.AC_VOLTAGE_PHASE_2_N:
+                    voltage_per_phase[1] = sample.as_single_value() or 0.0
+                case Metric.AC_VOLTAGE_PHASE_3_N:
+                    voltage_per_phase[2] = sample.as_single_value() or 0.0
+                case Metric.AC_FREQUENCY:
+                    self.frequency = sample.as_single_value() or 0.0
+                case unexpected:
+                    _logger.warning(
+                        "Unexpected metric %s in meter data sample: %r",
+                        unexpected,
+                        sample,
+                    )
+
+        self.active_power_per_phase = cast(PhaseTuple, tuple(active_power_per_phase))
+        self.reactive_power_per_phase = cast(
+            PhaseTuple, tuple(reactive_power_per_phase)
+        )
+        self.current_per_phase = cast(PhaseTuple, tuple(current_per_phase))
+        self.voltage_per_phase = cast(PhaseTuple, tuple(voltage_per_phase))
+
+        return self
+
+    @override
+    def to_samples(self) -> ComponentDataSamples:
+        """Convert the component data to a component data object."""
+        return ComponentDataSamples(
+            component_id=self.component_id,
+            metric_samples=[
+                MetricSample(
+                    sampled_at=self.timestamp, metric=metric, value=value, bounds=[]
+                )
+                for metric, value in [
+                    (Metric.AC_ACTIVE_POWER, self.active_power),
+                    (Metric.AC_ACTIVE_POWER_PHASE_1, self.active_power_per_phase[0]),
+                    (Metric.AC_ACTIVE_POWER_PHASE_2, self.active_power_per_phase[1]),
+                    (Metric.AC_ACTIVE_POWER_PHASE_3, self.active_power_per_phase[2]),
+                    (Metric.AC_REACTIVE_POWER, self.reactive_power),
+                    (
+                        Metric.AC_REACTIVE_POWER_PHASE_1,
+                        self.reactive_power_per_phase[0],
+                    ),
+                    (
+                        Metric.AC_REACTIVE_POWER_PHASE_2,
+                        self.reactive_power_per_phase[1],
+                    ),
+                    (
+                        Metric.AC_REACTIVE_POWER_PHASE_3,
+                        self.reactive_power_per_phase[2],
+                    ),
+                    (Metric.AC_CURRENT_PHASE_1, self.current_per_phase[0]),
+                    (Metric.AC_CURRENT_PHASE_2, self.current_per_phase[1]),
+                    (Metric.AC_CURRENT_PHASE_3, self.current_per_phase[2]),
+                    (Metric.AC_VOLTAGE_PHASE_1_N, self.voltage_per_phase[0]),
+                    (Metric.AC_VOLTAGE_PHASE_2_N, self.voltage_per_phase[1]),
+                    (Metric.AC_VOLTAGE_PHASE_3_N, self.voltage_per_phase[2]),
+                    (Metric.AC_FREQUENCY, self.frequency),
+                ]
+            ],
+            states=[
+                ComponentStateSample(
+                    sampled_at=self.timestamp,
+                    states=frozenset(self.states),
+                    warnings=frozenset(self.warnings),
+                    errors=frozenset(self.errors),
+                )
+            ],
+        )
+
+
+@dataclass(kw_only=True)
+class BatteryData(ComponentData):  # pylint: disable=too-many-instance-attributes
+    """A wrapper class for holding battery data."""
+
+    soc: float = 0.0
+    """Battery's overall SoC in percent (%)."""
+
+    soc_lower_bound: float = 0.0
+    """The SoC below which discharge commands will be blocked by the system,
+        in percent (%).
+    """
+
+    soc_upper_bound: float = 0.0
+    """The SoC above which charge commands will be blocked by the system,
+        in percent (%).
+    """
+
+    capacity: float = 0.0
+    """The capacity of the battery in Wh (Watt-hour)."""
+
+    power_inclusion_lower_bound: float = 0.0
+    """Lower inclusion bound for battery power in watts.
+
+    This is the lower limit of the range within which power requests are allowed for the
+    battery.
+
+    See [`frequenz.api.common.metrics_pb2.Metric.system_inclusion_bounds`][] and
+    [`frequenz.api.common.metrics_pb2.Metric.system_exclusion_bounds`][] for more
+    details.
+    """
+
+    power_exclusion_lower_bound: float = 0.0
+    """Lower exclusion bound for battery power in watts.
+
+    This is the lower limit of the range within which power requests are not allowed for
+    the battery.
+
+    See [`frequenz.api.common.metrics_pb2.Metric.system_inclusion_bounds`][] and
+    [`frequenz.api.common.metrics_pb2.Metric.system_exclusion_bounds`][] for more
+    details.
+    """
+
+    power_inclusion_upper_bound: float = 0.0
+    """Upper inclusion bound for battery power in watts.
+
+    This is the upper limit of the range within which power requests are allowed for the
+    battery.
+
+    See [`frequenz.api.common.metrics_pb2.Metric.system_inclusion_bounds`][] and
+    [`frequenz.api.common.metrics_pb2.Metric.system_exclusion_bounds`][] for more
+    details.
+    """
+
+    power_exclusion_upper_bound: float = 0.0
+    """Upper exclusion bound for battery power in watts.
+
+    This is the upper limit of the range within which power requests are not allowed for
+    the battery.
+
+    See [`frequenz.api.common.metrics_pb2.Metric.system_inclusion_bounds`][] and
+    [`frequenz.api.common.metrics_pb2.Metric.system_exclusion_bounds`][] for more
+    details.
+    """
+
+    temperature: float = 0.0
+    """The (average) temperature reported by the battery, in Celsius (°C)."""
+
+    CATEGORY: ClassVar[ComponentCategory] = ComponentCategory.BATTERY
+
+    METRICS: ClassVar[frozenset[Metric]] = frozenset(
+        [
+            Metric.BATTERY_SOC_PCT,
+            Metric.DC_POWER,
+            Metric.BATTERY_CAPACITY,
+            Metric.BATTERY_TEMPERATURE,
+        ]
+    )
+    """The metrics of this component."""
+
+    @override
+    @classmethod
+    def from_samples(cls, samples: ComponentDataSamples) -> Self:
+        """Create a new instance from a component data object."""
+        if not samples.metric_samples:
+            raise ValueError("No metrics in the samples.")
+
+        self = cls._from_samples(cls, samples)
+
+        for sample in samples.metric_samples:
+            value = sample.as_single_value() or 0.0
+            match sample.metric:
+                case Metric.BATTERY_SOC_PCT:
+                    self.soc = value
+                    if sample.bounds:
+                        # Update power bounds from the SOC metric bounds,
+                        # FIXME: We assume only one range is present
+                        # If one bound is None, we assume 0 to match the previous
+                        # behavior of v0.15, but this should eventually be fixed when
+                        # moving away from these legacy wrappers.
+                        if len(sample.bounds) > 1 and (
+                            sample.bounds[1].lower != 0.0
+                            or sample.bounds[1].upper != 0.0
+                        ):
+                            _logger.warning(
+                                "Too many bounds found in sample, a maximum of 1 is "
+                                "supported for SOC, using only the first: %r",
+                                sample,
+                            )
+                        self.soc_lower_bound = sample.bounds[0].lower or 0.0
+                        self.soc_upper_bound = sample.bounds[0].upper or 0.0
+                case Metric.DC_POWER:
+                    (
+                        self.power_inclusion_lower_bound,
+                        self.power_inclusion_upper_bound,
+                        self.power_exclusion_lower_bound,
+                        self.power_exclusion_upper_bound,
+                    ) = _bound_ranges_to_inclusion_exclusion(
+                        sample.bounds, "DC_POWER", sample
+                    )
+                case Metric.BATTERY_CAPACITY:
+                    self.capacity = value
+                case Metric.BATTERY_TEMPERATURE:
+                    self.temperature = value
+                case unexpected:
+                    _logger.warning(
+                        "Unexpected metric %s in battery data sample: %r",
+                        unexpected,
+                        sample,
+                    )
+
+        return self
+
+    @override
+    def to_samples(self) -> ComponentDataSamples:
+        """Convert the component data to a component data object."""
+        return ComponentDataSamples(
+            component_id=self.component_id,
+            metric_samples=[
+                MetricSample(
+                    sampled_at=self.timestamp, metric=metric, value=value, bounds=bounds
+                )
+                for metric, value, bounds in [
+                    (
+                        Metric.BATTERY_SOC_PCT,
+                        self.soc,
+                        _inclusion_exclusion_bounds_to_ranges(
+                            self.soc_lower_bound, self.soc_upper_bound, 0.0, 0.0
+                        ),
+                    ),
+                    (
+                        Metric.DC_POWER,
+                        None,
+                        _inclusion_exclusion_bounds_to_ranges(
+                            self.power_inclusion_lower_bound,
+                            self.power_inclusion_upper_bound,
+                            self.power_exclusion_lower_bound,
+                            self.power_exclusion_upper_bound,
+                        ),
+                    ),
+                    (Metric.BATTERY_CAPACITY, self.capacity, []),
+                    (Metric.BATTERY_TEMPERATURE, self.temperature, []),
+                ]
+            ],
+            states=[
+                ComponentStateSample(
+                    sampled_at=self.timestamp,
+                    states=frozenset(self.states),
+                    warnings=frozenset(self.warnings),
+                    errors=frozenset(self.errors),
+                )
+            ],
+        )
+
+
+@dataclass(kw_only=True)
+class InverterData(ComponentData):  # pylint: disable=too-many-instance-attributes
+    """A wrapper class for holding inverter data."""
+
+    active_power: float = 0.0
+    """The total active 3-phase AC power, in Watts (W).
+
+    Represented in the passive sign convention.
+
+    * Positive means consumption from the grid.
+    * Negative means supply into the grid.
+    """
+
+    active_power_per_phase: PhaseTuple = (0.0, 0.0, 0.0)
+    """The per-phase AC active power for phase 1, 2, and 3 respectively, in Watt (W).
+
+    Represented in the passive sign convention.
+
+    * Positive means consumption from the grid.
+    * Negative means supply into the grid.
+    """
+
+    reactive_power: float = 0.0
+    """The total reactive 3-phase AC power, in Volt-Ampere Reactive (VAr).
+
+    * Positive power means capacitive (current leading w.r.t. voltage).
+    * Negative power means inductive (current lagging w.r.t. voltage).
+    """
+
+    reactive_power_per_phase: PhaseTuple = (0.0, 0.0, 0.0)
+    """The per-phase AC reactive power, in Volt-Ampere Reactive (VAr).
+
+    The provided values are for phase 1, 2, and 3 respectively.
+
+    * Positive power means capacitive (current leading w.r.t. voltage).
+    * Negative power means inductive (current lagging w.r.t. voltage).
+    """
+
+    current_per_phase: PhaseTuple = (0.0, 0.0, 0.0)
+    """AC current in Amperes (A) for phase/line 1, 2 and 3 respectively.
+
+    Represented in the passive sign convention.
+
+    * Positive means consumption from the grid.
+    * Negative means supply into the grid.
+    """
+
+    voltage_per_phase: PhaseTuple = (0.0, 0.0, 0.0)
+    """The AC voltage in Volts (V) between the line and the neutral wire for
+       phase/line 1, 2 and 3 respectively.
+    """
+
+    active_power_inclusion_lower_bound: float = 0.0
+    """Lower inclusion bound for inverter power in watts.
+
+    This is the lower limit of the range within which power requests are allowed for the
+    inverter.
+
+    See [`frequenz.api.common.metrics_pb2.Metric.system_inclusion_bounds`][] and
+    [`frequenz.api.common.metrics_pb2.Metric.system_exclusion_bounds`][] for more
+    details.
+    """
+
+    active_power_exclusion_lower_bound: float = 0.0
+    """Lower exclusion bound for inverter power in watts.
+
+    This is the lower limit of the range within which power requests are not allowed for
+    the inverter.
+
+    See [`frequenz.api.common.metrics_pb2.Metric.system_inclusion_bounds`][] and
+    [`frequenz.api.common.metrics_pb2.Metric.system_exclusion_bounds`][] for more
+    details.
+    """
+
+    active_power_inclusion_upper_bound: float = 0.0
+    """Upper inclusion bound for inverter power in watts.
+
+    This is the upper limit of the range within which power requests are allowed for the
+    inverter.
+
+    See [`frequenz.api.common.metrics_pb2.Metric.system_inclusion_bounds`][] and
+    [`frequenz.api.common.metrics_pb2.Metric.system_exclusion_bounds`][] for more
+    details.
+    """
+
+    active_power_exclusion_upper_bound: float = 0.0
+    """Upper exclusion bound for inverter power in watts.
+
+    This is the upper limit of the range within which power requests are not allowed for
+    the inverter.
+
+    See [`frequenz.api.common.metrics_pb2.Metric.system_inclusion_bounds`][] and
+    [`frequenz.api.common.metrics_pb2.Metric.system_exclusion_bounds`][] for more
+    details.
+    """
+
+    frequency: float = 0.0
+    """AC frequency, in Hertz (Hz)."""
+
+    CATEGORY: ClassVar[ComponentCategory] = ComponentCategory.INVERTER
+
+    METRICS: ClassVar[frozenset[Metric]] = frozenset(
+        [
+            Metric.AC_ACTIVE_POWER,
+            Metric.AC_ACTIVE_POWER_PHASE_1,
+            Metric.AC_ACTIVE_POWER_PHASE_2,
+            Metric.AC_ACTIVE_POWER_PHASE_3,
+            Metric.AC_REACTIVE_POWER,
+            Metric.AC_REACTIVE_POWER_PHASE_1,
+            Metric.AC_REACTIVE_POWER_PHASE_2,
+            Metric.AC_REACTIVE_POWER_PHASE_3,
+            Metric.AC_CURRENT_PHASE_1,
+            Metric.AC_CURRENT_PHASE_2,
+            Metric.AC_CURRENT_PHASE_3,
+            Metric.AC_VOLTAGE_PHASE_1_N,
+            Metric.AC_VOLTAGE_PHASE_2_N,
+            Metric.AC_VOLTAGE_PHASE_3_N,
+            Metric.AC_FREQUENCY,
+        ]
+    )
+    """The metrics of this component."""
+
+    @override
+    @classmethod
+    def from_samples(cls, samples: ComponentDataSamples) -> Self:
+        """Create a new instance from a component data object."""
+        if not samples.metric_samples:
+            raise ValueError("No metrics in the samples.")
+
+        self = cls._from_samples(cls, samples)
+
+        active_power_per_phase: list[float] = [0.0, 0.0, 0.0]
+        reactive_power_per_phase: list[float] = [0.0, 0.0, 0.0]
+        current_per_phase: list[float] = [0.0, 0.0, 0.0]
+        voltage_per_phase: list[float] = [0.0, 0.0, 0.0]
+
+        for sample in samples.metric_samples:
+            value = sample.as_single_value() or 0.0
+            match sample.metric:
+                case Metric.AC_ACTIVE_POWER:
+                    self.active_power = value
+                    (
+                        self.active_power_inclusion_lower_bound,
+                        self.active_power_inclusion_upper_bound,
+                        self.active_power_exclusion_lower_bound,
+                        self.active_power_exclusion_upper_bound,
+                    ) = _bound_ranges_to_inclusion_exclusion(
+                        sample.bounds, "AC_ACTIVE_POWER", sample
+                    )
+                case Metric.AC_ACTIVE_POWER_PHASE_1:
+                    active_power_per_phase[0] = value
+                case Metric.AC_ACTIVE_POWER_PHASE_2:
+                    active_power_per_phase[1] = value
+                case Metric.AC_ACTIVE_POWER_PHASE_3:
+                    active_power_per_phase[2] = value
+                case Metric.AC_REACTIVE_POWER:
+                    self.reactive_power = value
+                case Metric.AC_REACTIVE_POWER_PHASE_1:
+                    reactive_power_per_phase[0] = value
+                case Metric.AC_REACTIVE_POWER_PHASE_2:
+                    reactive_power_per_phase[1] = value
+                case Metric.AC_REACTIVE_POWER_PHASE_3:
+                    reactive_power_per_phase[2] = value
+                case Metric.AC_CURRENT_PHASE_1:
+                    current_per_phase[0] = value
+                case Metric.AC_CURRENT_PHASE_2:
+                    current_per_phase[1] = value
+                case Metric.AC_CURRENT_PHASE_3:
+                    current_per_phase[2] = value
+                case Metric.AC_VOLTAGE_PHASE_1_N:
+                    voltage_per_phase[0] = value
+                case Metric.AC_VOLTAGE_PHASE_2_N:
+                    voltage_per_phase[1] = value
+                case Metric.AC_VOLTAGE_PHASE_3_N:
+                    voltage_per_phase[2] = value
+                case Metric.AC_FREQUENCY:
+                    self.frequency = value
+                case unexpected:
+                    _logger.warning(
+                        "Unexpected metric %s in inverter data sample: %r",
+                        unexpected,
+                        sample,
+                    )
+
+        self.active_power_per_phase = cast(PhaseTuple, tuple(active_power_per_phase))
+        self.reactive_power_per_phase = cast(
+            PhaseTuple, tuple(reactive_power_per_phase)
+        )
+        self.current_per_phase = cast(PhaseTuple, tuple(current_per_phase))
+        self.voltage_per_phase = cast(PhaseTuple, tuple(voltage_per_phase))
+
+        return self
+
+    @override
+    def to_samples(self) -> ComponentDataSamples:
+        """Convert the component data to a component data object."""
+        return ComponentDataSamples(
+            component_id=self.component_id,
+            metric_samples=[
+                MetricSample(
+                    sampled_at=self.timestamp,
+                    metric=Metric.AC_ACTIVE_POWER,
+                    value=self.active_power,
+                    bounds=_inclusion_exclusion_bounds_to_ranges(
+                        self.active_power_inclusion_lower_bound,
+                        self.active_power_inclusion_upper_bound,
+                        self.active_power_exclusion_lower_bound,
+                        self.active_power_exclusion_upper_bound,
+                    ),
+                ),
+                *(
+                    MetricSample(
+                        sampled_at=self.timestamp, metric=metric, value=value, bounds=[]
+                    )
+                    for metric, value in [
+                        (
+                            Metric.AC_ACTIVE_POWER_PHASE_1,
+                            self.active_power_per_phase[0],
+                        ),
+                        (
+                            Metric.AC_ACTIVE_POWER_PHASE_2,
+                            self.active_power_per_phase[1],
+                        ),
+                        (
+                            Metric.AC_ACTIVE_POWER_PHASE_3,
+                            self.active_power_per_phase[2],
+                        ),
+                        (Metric.AC_REACTIVE_POWER, self.reactive_power),
+                        (
+                            Metric.AC_REACTIVE_POWER_PHASE_1,
+                            self.reactive_power_per_phase[0],
+                        ),
+                        (
+                            Metric.AC_REACTIVE_POWER_PHASE_2,
+                            self.reactive_power_per_phase[1],
+                        ),
+                        (
+                            Metric.AC_REACTIVE_POWER_PHASE_3,
+                            self.reactive_power_per_phase[2],
+                        ),
+                        (Metric.AC_CURRENT_PHASE_1, self.current_per_phase[0]),
+                        (Metric.AC_CURRENT_PHASE_2, self.current_per_phase[1]),
+                        (Metric.AC_CURRENT_PHASE_3, self.current_per_phase[2]),
+                        (Metric.AC_VOLTAGE_PHASE_1_N, self.voltage_per_phase[0]),
+                        (Metric.AC_VOLTAGE_PHASE_2_N, self.voltage_per_phase[1]),
+                        (Metric.AC_VOLTAGE_PHASE_3_N, self.voltage_per_phase[2]),
+                        (Metric.AC_FREQUENCY, self.frequency),
+                    ]
+                ),
+            ],
+            states=[
+                ComponentStateSample(
+                    sampled_at=self.timestamp,
+                    states=frozenset(self.states),
+                    warnings=frozenset(self.warnings),
+                    errors=frozenset(self.errors),
+                )
+            ],
+        )
+
+
+@dataclass(kw_only=True)
+class EVChargerData(ComponentData):  # pylint: disable=too-many-instance-attributes
+    """A wrapper class for holding ev_charger data."""
+
+    active_power: float = 0.0
+    """The total active 3-phase AC power, in Watts (W).
+
+    Represented in the passive sign convention.
+
+    * Positive means consumption from the grid.
+    * Negative means supply into the grid.
+    """
+
+    active_power_per_phase: PhaseTuple = (0.0, 0.0, 0.0)
+    """The per-phase AC active power for phase 1, 2, and 3 respectively, in Watt (W).
+
+    Represented in the passive sign convention.
+
+    * Positive means consumption from the grid.
+    * Negative means supply into the grid.
+    """
+
+    current_per_phase: PhaseTuple = (0.0, 0.0, 0.0)
+    """AC current in Amperes (A) for phase/line 1,2 and 3 respectively.
+
+    Represented in the passive sign convention.
+
+    * Positive means consumption from the grid.
+    * Negative means supply into the grid.
+    """
+
+    reactive_power: float = 0.0
+    """The total reactive 3-phase AC power, in Volt-Ampere Reactive (VAr).
+
+    * Positive power means capacitive (current leading w.r.t. voltage).
+    * Negative power means inductive (current lagging w.r.t. voltage).
+    """
+
+    reactive_power_per_phase: PhaseTuple = (0.0, 0.0, 0.0)
+    """The per-phase AC reactive power, in Volt-Ampere Reactive (VAr).
+
+    The provided values are for phase 1, 2, and 3 respectively.
+
+    * Positive power means capacitive (current leading w.r.t. voltage).
+    * Negative power means inductive (current lagging w.r.t. voltage).
+    """
+
+    voltage_per_phase: PhaseTuple = (0.0, 0.0, 0.0)
+    """The AC voltage in Volts (V) between the line and the neutral
+        wire for phase/line 1,2 and 3 respectively.
+    """
+
+    active_power_inclusion_lower_bound: float = 0.0
+    """Lower inclusion bound for EV charger power in watts.
+
+    This is the lower limit of the range within which power requests are allowed for the
+    EV charger.
+
+    See [`frequenz.api.common.metrics_pb2.Metric.system_inclusion_bounds`][] and
+    [`frequenz.api.common.metrics_pb2.Metric.system_exclusion_bounds`][] for more
+    details.
+    """
+
+    active_power_exclusion_lower_bound: float = 0.0
+    """Lower exclusion bound for EV charger power in watts.
+
+    This is the lower limit of the range within which power requests are not allowed for
+    the EV charger.
+
+    See [`frequenz.api.common.metrics_pb2.Metric.system_inclusion_bounds`][] and
+    [`frequenz.api.common.metrics_pb2.Metric.system_exclusion_bounds`][] for more
+    details.
+    """
+
+    active_power_inclusion_upper_bound: float = 0.0
+    """Upper inclusion bound for EV charger power in watts.
+
+    This is the upper limit of the range within which power requests are allowed for the
+    EV charger.
+
+    See [`frequenz.api.common.metrics_pb2.Metric.system_inclusion_bounds`][] and
+    [`frequenz.api.common.metrics_pb2.Metric.system_exclusion_bounds`][] for more
+    details.
+    """
+
+    active_power_exclusion_upper_bound: float = 0.0
+    """Upper exclusion bound for EV charger power in watts.
+
+    This is the upper limit of the range within which power requests are not allowed for
+    the EV charger.
+
+    See [`frequenz.api.common.metrics_pb2.Metric.system_inclusion_bounds`][] and
+    [`frequenz.api.common.metrics_pb2.Metric.system_exclusion_bounds`][] for more
+    details.
+    """
+
+    frequency: float = 0.0
+    """AC frequency, in Hertz (Hz)."""
+
+    CATEGORY: ClassVar[ComponentCategory] = ComponentCategory.EV_CHARGER
+    """The category of this component."""
+
+    METRICS: ClassVar[frozenset[Metric]] = frozenset(
+        [
+            Metric.AC_ACTIVE_POWER,
+            Metric.AC_ACTIVE_POWER_PHASE_1,
+            Metric.AC_ACTIVE_POWER_PHASE_2,
+            Metric.AC_ACTIVE_POWER_PHASE_3,
+            Metric.AC_REACTIVE_POWER,
+            Metric.AC_REACTIVE_POWER_PHASE_1,
+            Metric.AC_REACTIVE_POWER_PHASE_2,
+            Metric.AC_REACTIVE_POWER_PHASE_3,
+            Metric.AC_CURRENT_PHASE_1,
+            Metric.AC_CURRENT_PHASE_2,
+            Metric.AC_CURRENT_PHASE_3,
+            Metric.AC_VOLTAGE_PHASE_1_N,
+            Metric.AC_VOLTAGE_PHASE_2_N,
+            Metric.AC_VOLTAGE_PHASE_3_N,
+            Metric.AC_FREQUENCY,
+        ]
+    )
+    """The metrics of this component."""
+
+    @override
+    @classmethod
+    def from_samples(cls, samples: ComponentDataSamples) -> Self:
+        """Create a new instance from a component data object."""
+        if not samples.metric_samples:
+            raise ValueError("No metrics in the samples.")
+
+        self = cls._from_samples(cls, samples)
+
+        active_power_per_phase: list[float] = [0.0, 0.0, 0.0]
+        reactive_power_per_phase: list[float] = [0.0, 0.0, 0.0]
+        current_per_phase: list[float] = [0.0, 0.0, 0.0]
+        voltage_per_phase: list[float] = [0.0, 0.0, 0.0]
+
+        for sample in samples.metric_samples:
+            value = sample.as_single_value() or 0.0
+            match sample.metric:
+                case Metric.AC_ACTIVE_POWER:
+                    self.active_power = value
+                    (
+                        self.active_power_inclusion_lower_bound,
+                        self.active_power_inclusion_upper_bound,
+                        self.active_power_exclusion_lower_bound,
+                        self.active_power_exclusion_upper_bound,
+                    ) = _bound_ranges_to_inclusion_exclusion(
+                        sample.bounds, "AC_ACTIVE_POWER", sample
+                    )
+                case Metric.AC_ACTIVE_POWER_PHASE_1:
+                    active_power_per_phase[0] = value
+                case Metric.AC_ACTIVE_POWER_PHASE_2:
+                    active_power_per_phase[1] = value
+                case Metric.AC_ACTIVE_POWER_PHASE_3:
+                    active_power_per_phase[2] = value
+                case Metric.AC_REACTIVE_POWER:
+                    self.reactive_power = value
+                case Metric.AC_REACTIVE_POWER_PHASE_1:
+                    reactive_power_per_phase[0] = value
+                case Metric.AC_REACTIVE_POWER_PHASE_2:
+                    reactive_power_per_phase[1] = value
+                case Metric.AC_REACTIVE_POWER_PHASE_3:
+                    reactive_power_per_phase[2] = value
+                case Metric.AC_CURRENT_PHASE_1:
+                    current_per_phase[0] = value
+                case Metric.AC_CURRENT_PHASE_2:
+                    current_per_phase[1] = value
+                case Metric.AC_CURRENT_PHASE_3:
+                    current_per_phase[2] = value
+                case Metric.AC_VOLTAGE_PHASE_1_N:
+                    voltage_per_phase[0] = value
+                case Metric.AC_VOLTAGE_PHASE_2_N:
+                    voltage_per_phase[1] = value
+                case Metric.AC_VOLTAGE_PHASE_3_N:
+                    voltage_per_phase[2] = value
+                case Metric.AC_FREQUENCY:
+                    self.frequency = value
+                case unexpected:
+                    _logger.warning(
+                        "Unexpected metric %s in ev charger data sample: %r",
+                        unexpected,
+                        sample,
+                    )
+
+        self.active_power_per_phase = cast(PhaseTuple, tuple(active_power_per_phase))
+        self.reactive_power_per_phase = cast(
+            PhaseTuple, tuple(reactive_power_per_phase)
+        )
+        self.current_per_phase = cast(PhaseTuple, tuple(current_per_phase))
+        self.voltage_per_phase = cast(PhaseTuple, tuple(voltage_per_phase))
+
+        return self
+
+    @override
+    def to_samples(self) -> ComponentDataSamples:
+        """Convert the component data to a component data object."""
+        return ComponentDataSamples(
+            component_id=self.component_id,
+            metric_samples=[
+                MetricSample(
+                    sampled_at=self.timestamp,
+                    metric=Metric.AC_ACTIVE_POWER,
+                    value=self.active_power,
+                    bounds=_inclusion_exclusion_bounds_to_ranges(
+                        self.active_power_inclusion_lower_bound,
+                        self.active_power_inclusion_upper_bound,
+                        self.active_power_exclusion_lower_bound,
+                        self.active_power_exclusion_upper_bound,
+                    ),
+                ),
+                *(
+                    MetricSample(
+                        sampled_at=self.timestamp, metric=metric, value=value, bounds=[]
+                    )
+                    for metric, value in [
+                        (
+                            Metric.AC_ACTIVE_POWER_PHASE_1,
+                            self.active_power_per_phase[0],
+                        ),
+                        (
+                            Metric.AC_ACTIVE_POWER_PHASE_2,
+                            self.active_power_per_phase[1],
+                        ),
+                        (
+                            Metric.AC_ACTIVE_POWER_PHASE_3,
+                            self.active_power_per_phase[2],
+                        ),
+                        (Metric.AC_REACTIVE_POWER, self.reactive_power),
+                        (
+                            Metric.AC_REACTIVE_POWER_PHASE_1,
+                            self.reactive_power_per_phase[0],
+                        ),
+                        (
+                            Metric.AC_REACTIVE_POWER_PHASE_2,
+                            self.reactive_power_per_phase[1],
+                        ),
+                        (
+                            Metric.AC_REACTIVE_POWER_PHASE_3,
+                            self.reactive_power_per_phase[2],
+                        ),
+                        (Metric.AC_CURRENT_PHASE_1, self.current_per_phase[0]),
+                        (Metric.AC_CURRENT_PHASE_2, self.current_per_phase[1]),
+                        (Metric.AC_CURRENT_PHASE_3, self.current_per_phase[2]),
+                        (Metric.AC_VOLTAGE_PHASE_1_N, self.voltage_per_phase[0]),
+                        (Metric.AC_VOLTAGE_PHASE_2_N, self.voltage_per_phase[1]),
+                        (Metric.AC_VOLTAGE_PHASE_3_N, self.voltage_per_phase[2]),
+                        (Metric.AC_FREQUENCY, self.frequency),
+                    ]
+                ),
+            ],
+            states=[
+                ComponentStateSample(
+                    sampled_at=self.timestamp,
+                    states=frozenset(self.states),
+                    warnings=frozenset(self.warnings),
+                    errors=frozenset(self.errors),
+                )
+            ],
+        )
+
+    def is_ev_connected(self) -> bool:
+        """Check whether an EV is connected to the charger.
+
+        Returns:
+            When the charger is not in an error state, whether an EV is connected to
+                the charger.
+        """
+        has_error = ComponentStateCode.ERROR in self.states
+        is_authorized = (
+            ComponentErrorCode.UNAUTHORIZED not in self.errors
+            and ComponentErrorCode.UNAUTHORIZED not in self.warnings
+        )
+        is_connected_at_ev = bool(
+            {
+                ComponentStateCode.EV_CHARGING_CABLE_LOCKED_AT_EV,
+                ComponentStateCode.EV_CHARGING_CABLE_PLUGGED_AT_EV,
+            }
+            & self.states
+        )
+        is_connected_at_station = bool(
+            {
+                ComponentStateCode.EV_CHARGING_CABLE_LOCKED_AT_STATION,
+                ComponentStateCode.EV_CHARGING_CABLE_PLUGGED_AT_STATION,
+            }
+            & self.states
+        )
+
+        return (
+            not has_error
+            and is_authorized
+            and is_connected_at_ev
+            and is_connected_at_station
+        )
+
+
+def _bound_ranges_to_inclusion_exclusion(
+    bounds: list[Bounds], name: str, sample: MetricSample
+) -> tuple[float, float, float, float]:
+    """Convert a list of bounds to inclusion and exclusion bounds.
+
+        Args:
+            bounds: A list of bounds.
+    name: The name of the metric (for logging purposes).
+            sample: The sample containing the bounds (for logging purposes).
+
+        Returns:
+            A tuple containing the inclusion lower bound, inclusion upper bound,
+                exclusion lower bound, and exclusion upper bound.
+    """
+    match bounds:
+        case []:
+            return (0.0, 0.0, 0.0, 0.0)
+        case [inclusion_bound]:
+            return (
+                inclusion_bound.lower or 0.0,
+                inclusion_bound.upper or 0.0,
+                0.0,
+                0.0,
+            )
+        case list():
+            if len(bounds) > 2:
+                _logger.warning(
+                    "Too many bounds found in sample, a "
+                    "maximum of 2 are supported for %s, "
+                    "using only the first 2: %r",
+                    name,
+                    sample,
+                )
+            range1, range2 = bounds[:2]
+            return (
+                range1.lower or 0.0,
+                range2.upper or 0.0,
+                range1.upper or 0.0,
+                range2.lower or 0.0,
+            )
+        case unexpected:
+            assert_never(unexpected)
+
+
+def _try_create_bounds(lower: float, upper: float, description: str) -> list[Bounds]:
+    """Safely create a bounds object, handling any exceptions gracefully.
+
+    Args:
+        lower: Lower bound value
+        upper: Upper bound value
+        description: Description for logging
+
+    Returns:
+        List containing the created Bounds object or an empty list if creation failed.
+    """
+    try:
+        return [Bounds(lower=lower, upper=upper)]
+    except ValueError as exc:
+        _logger.warning(
+            "Ignoring invalid %s bounds [%s, %s]: %s",
+            description,
+            lower,
+            upper,
+            exc,
+            stack_info=True,
+        )
+        return []
+
+
+def _inclusion_exclusion_bounds_to_ranges(
+    inclusion_lower_bound: float,
+    inclusion_upper_bound: float,
+    exclusion_lower_bound: float,
+    exclusion_upper_bound: float,
+) -> list[Bounds]:
+    """Convert inclusion and exclusion bounds to ranges.
+
+    Args:
+        inclusion_lower_bound: The lower limit of the range within which power requests
+            are allowed for the component.
+        inclusion_upper_bound: The upper limit of the range within which power requests
+            are allowed for the component.
+        exclusion_lower_bound: The lower limit of the range within which power requests
+            are not allowed for the component.
+        exclusion_upper_bound: The upper limit of the range within which power requests
+            are not allowed for the component.
+
+    Returns:
+        A list of bounds.
+    """
+    ranges: list[Bounds] = []
+    if exclusion_lower_bound == 0.0 and exclusion_upper_bound == 0.0:
+        if inclusion_lower_bound == 0.0 and inclusion_upper_bound == 0.0:
+            # No bounds are present at all
+            return []
+        # Only inclusion bounds are present
+        return _try_create_bounds(
+            inclusion_lower_bound, inclusion_upper_bound, "inclusion"
+        )
+
+    if inclusion_lower_bound == 0.0 and inclusion_upper_bound == 0.0:
+        # There are exclusion bounds, but no inclusion bounds, we create 2 ranges, one
+        # from -inf to exclusion_lower_bound and one from exclusion_upper_bound to +inf
+        ranges.extend(
+            _try_create_bounds(
+                float("-inf"), exclusion_lower_bound, "exclusion lower bound"
+            )
+        )
+        ranges.extend(
+            _try_create_bounds(
+                exclusion_upper_bound, float("+inf"), "exclusion upper bound"
+            )
+        )
+        return ranges
+
+    # First range: from inclusion_lower_bound to exclusion_lower_bound.
+    # If either value is NaN, skip the ordering check. Is not entirely clear what to do
+    # with NaN, but this is the old behavior so we are keeping it for now.
+    if (
+        math.isnan(inclusion_lower_bound)
+        or math.isnan(exclusion_lower_bound)
+        or inclusion_lower_bound <= exclusion_lower_bound
+    ):
+        ranges.extend(
+            _try_create_bounds(
+                inclusion_lower_bound, exclusion_lower_bound, "first range"
+            )
+        )
+    else:
+        _logger.warning(
+            "Inclusion lower bound (%s) is greater than exclusion lower bound (%s), "
+            "skipping this bound in the ranges",
+            inclusion_lower_bound,
+            exclusion_lower_bound,
+        )
+    # Second range: from exclusion_upper_bound to inclusion_upper_bound.
+    if (
+        math.isnan(exclusion_upper_bound)
+        or math.isnan(inclusion_upper_bound)
+        or exclusion_upper_bound <= inclusion_upper_bound
+    ):
+        ranges.extend(
+            _try_create_bounds(
+                exclusion_upper_bound, inclusion_upper_bound, "second range"
+            )
+        )
+    else:
+        _logger.warning(
+            "Inclusion upper bound (%s) is less than exclusion upper bound (%s), "
+            "no second range to add",
+            inclusion_upper_bound,
+            exclusion_upper_bound,
+        )
+
+    return ranges

--- a/src/frequenz/sdk/microgrid/_old_component_data.py
+++ b/src/frequenz/sdk/microgrid/_old_component_data.py
@@ -160,7 +160,7 @@ class ComponentData(ABC):
         from .. import microgrid
 
         components = microgrid.connection_manager.get().component_graph.components(
-            filter_by_ids={component_id}
+            matching_ids={component_id}
         )
         if not components:
             raise ValueError(f"Unable to find component with {component_id}")

--- a/src/frequenz/sdk/microgrid/_power_distributing/_component_managers/_battery_manager.py
+++ b/src/frequenz/sdk/microgrid/_power_distributing/_component_managers/_battery_manager.py
@@ -12,11 +12,8 @@ from datetime import datetime, timedelta
 
 from frequenz.channels import LatestValueCache, Receiver, Sender
 from frequenz.client.common.microgrid.components import ComponentId
-from frequenz.client.microgrid import (
-    ApiClientError,
-    ComponentCategory,
-    OperationOutOfRange,
-)
+from frequenz.client.microgrid import ApiClientError, OperationOutOfRange
+from frequenz.client.microgrid.component import Battery, Inverter
 from frequenz.quantities import Power
 from typing_extensions import override
 
@@ -85,7 +82,9 @@ def _get_battery_inverter_mappings(
         inverters: set[ComponentId] = set(
             component.id
             for component in component_graph.predecessors(battery_id)
-            if component.category == ComponentCategory.INVERTER
+            # Using Inverter is way too general, see
+            # https://github.com/frequenz-floss/frequenz-sdk-python/issues/1285
+            if isinstance(component, Inverter)
         )
 
         if len(inverters) == 0:
@@ -147,7 +146,7 @@ class BatteryManager(ComponentManager):  # pylint: disable=too-many-instance-att
         self._results_sender = results_sender
         self._api_power_request_timeout = api_power_request_timeout
         self._batteries = connection_manager.get().component_graph.components(
-            component_categories={ComponentCategory.BATTERY}
+            matching_types={Battery}
         )
         self._battery_ids = {battery.id for battery in self._batteries}
 

--- a/src/frequenz/sdk/microgrid/_power_distributing/_component_managers/_battery_manager.py
+++ b/src/frequenz/sdk/microgrid/_power_distributing/_component_managers/_battery_manager.py
@@ -309,10 +309,10 @@ class BatteryManager(ComponentManager):  # pylint: disable=too-many-instance-att
 
     async def _create_channels(self) -> None:
         """Create channels to get data of components in microgrid."""
-        api = connection_manager.get().api_client
+        client = connection_manager.get().api_client
         manager_id = f"{type(self).__name__}«{hex(id(self))}»"
         for battery_id, inverter_ids in self._bat_invs_map.items():
-            bat_recv: Receiver[BatteryData] = BatteryData.subscribe(api, battery_id)
+            bat_recv: Receiver[BatteryData] = BatteryData.subscribe(client, battery_id)
             self._battery_caches[battery_id] = LatestValueCache(
                 bat_recv,
                 unique_id=f"{manager_id}:battery«{battery_id}»",
@@ -320,7 +320,7 @@ class BatteryManager(ComponentManager):  # pylint: disable=too-many-instance-att
 
             for inverter_id in inverter_ids:
                 inv_recv: Receiver[InverterData] = InverterData.subscribe(
-                    api, inverter_id
+                    client, inverter_id
                 )
                 self._inverter_caches[inverter_id] = LatestValueCache(
                     inv_recv, unique_id=f"{manager_id}:inverter«{inverter_id}»"
@@ -635,11 +635,11 @@ class BatteryManager(ComponentManager):  # pylint: disable=too-many-instance-att
             Tuple where first element is total failed power, and the second element
             set of batteries that failed.
         """
-        api = connection_manager.get().api_client
+        client = connection_manager.get().api_client
 
         tasks = {
             inverter_id: asyncio.create_task(
-                api.set_component_power_active(inverter_id, power.as_watts())
+                client.set_component_power_active(inverter_id, power.as_watts())
             )
             for inverter_id, power in distribution.distribution.items()
             if power != Power.zero()

--- a/src/frequenz/sdk/microgrid/_power_distributing/_component_managers/_battery_manager.py
+++ b/src/frequenz/sdk/microgrid/_power_distributing/_component_managers/_battery_manager.py
@@ -8,21 +8,20 @@ import collections.abc
 import logging
 import math
 import typing
-from datetime import timedelta
+from datetime import datetime, timedelta
 
 from frequenz.channels import LatestValueCache, Receiver, Sender
 from frequenz.client.common.microgrid.components import ComponentId
 from frequenz.client.microgrid import (
     ApiClientError,
-    BatteryData,
     ComponentCategory,
-    InverterData,
     OperationOutOfRange,
 )
 from frequenz.quantities import Power
 from typing_extensions import override
 
 from ... import connection_manager
+from ..._old_component_data import BatteryData, InverterData
 from .._component_pool_status_tracker import ComponentPoolStatusTracker
 from .._component_status import BatteryStatusTracker, ComponentPoolStatus
 from .._distribution_algorithm import (
@@ -313,14 +312,16 @@ class BatteryManager(ComponentManager):  # pylint: disable=too-many-instance-att
         api = connection_manager.get().api_client
         manager_id = f"{type(self).__name__}«{hex(id(self))}»"
         for battery_id, inverter_ids in self._bat_invs_map.items():
-            bat_recv: Receiver[BatteryData] = await api.battery_data(battery_id)
+            bat_recv: Receiver[BatteryData] = BatteryData.subscribe(api, battery_id)
             self._battery_caches[battery_id] = LatestValueCache(
                 bat_recv,
                 unique_id=f"{manager_id}:battery«{battery_id}»",
             )
 
             for inverter_id in inverter_ids:
-                inv_recv: Receiver[InverterData] = await api.inverter_data(inverter_id)
+                inv_recv: Receiver[InverterData] = InverterData.subscribe(
+                    api, inverter_id
+                )
                 self._inverter_caches[inverter_id] = LatestValueCache(
                     inv_recv, unique_id=f"{manager_id}:inverter«{inverter_id}»"
                 )
@@ -638,7 +639,7 @@ class BatteryManager(ComponentManager):  # pylint: disable=too-many-instance-att
 
         tasks = {
             inverter_id: asyncio.create_task(
-                api.set_power(inverter_id, power.as_watts())
+                api.set_component_power_active(inverter_id, power.as_watts())
             )
             for inverter_id, power in distribution.distribution.items()
             if power != Power.zero()
@@ -681,7 +682,7 @@ class BatteryManager(ComponentManager):  # pylint: disable=too-many-instance-att
 
     def _parse_result(
         self,
-        tasks: dict[ComponentId, asyncio.Task[None]],
+        tasks: dict[ComponentId, asyncio.Task[datetime | None]],
         distribution: dict[ComponentId, Power],
         request_timeout: timedelta,
     ) -> tuple[Power, set[ComponentId]]:

--- a/src/frequenz/sdk/microgrid/_power_distributing/_component_managers/_battery_manager.py
+++ b/src/frequenz/sdk/microgrid/_power_distributing/_component_managers/_battery_manager.py
@@ -83,7 +83,7 @@ def _get_battery_inverter_mappings(
 
     for battery_id in battery_ids:
         inverters: set[ComponentId] = set(
-            component.component_id
+            component.id
             for component in component_graph.predecessors(battery_id)
             if component.category == ComponentCategory.INVERTER
         )
@@ -96,7 +96,7 @@ def _get_battery_inverter_mappings(
         if bat_bats_map is not None:
             bat_bats_map.setdefault(battery_id, set()).update(
                 set(
-                    component.component_id
+                    component.id
                     for inverter in inverters
                     for component in component_graph.successors(inverter)
                 )
@@ -149,7 +149,7 @@ class BatteryManager(ComponentManager):  # pylint: disable=too-many-instance-att
         self._batteries = connection_manager.get().component_graph.components(
             component_categories={ComponentCategory.BATTERY}
         )
-        self._battery_ids = {battery.component_id for battery in self._batteries}
+        self._battery_ids = {battery.id for battery in self._batteries}
 
         maps = _get_battery_inverter_mappings(self._battery_ids)
 

--- a/src/frequenz/sdk/microgrid/_power_distributing/_component_managers/_battery_manager.py
+++ b/src/frequenz/sdk/microgrid/_power_distributing/_component_managers/_battery_manager.py
@@ -146,7 +146,7 @@ class BatteryManager(ComponentManager):  # pylint: disable=too-many-instance-att
         self._results_sender = results_sender
         self._api_power_request_timeout = api_power_request_timeout
         self._batteries = connection_manager.get().component_graph.components(
-            matching_types={Battery}
+            matching_types=Battery
         )
         self._battery_ids = {battery.id for battery in self._batteries}
 

--- a/src/frequenz/sdk/microgrid/_power_distributing/_component_managers/_ev_charger_manager/_ev_charger_manager.py
+++ b/src/frequenz/sdk/microgrid/_power_distributing/_component_managers/_ev_charger_manager/_ev_charger_manager.py
@@ -113,7 +113,7 @@ class EVChargerManager(ComponentManager):
     def _get_ev_charger_ids(self) -> collections.abc.Set[ComponentId]:
         """Return the IDs of all EV chargers present in the component graph."""
         return {
-            evc.component_id
+            evc.id
             for evc in connection_manager.get().component_graph.components(
                 component_categories={ComponentCategory.EV_CHARGER}
             )

--- a/src/frequenz/sdk/microgrid/_power_distributing/_component_managers/_ev_charger_manager/_ev_charger_manager.py
+++ b/src/frequenz/sdk/microgrid/_power_distributing/_component_managers/_ev_charger_manager/_ev_charger_manager.py
@@ -20,7 +20,6 @@ from frequenz.client.common.microgrid.components import ComponentId
 from frequenz.client.microgrid import (
     ApiClientError,
     ComponentCategory,
-    EVChargerData,
     MicrogridApiClient,
 )
 from frequenz.quantities import Power, Voltage
@@ -30,6 +29,7 @@ from ....._internal._asyncio import run_forever
 from ....._internal._math import is_close_to_zero
 from .....timeseries import Sample3Phase
 from .... import _data_pipeline, connection_manager
+from ...._old_component_data import EVChargerData
 from ..._component_pool_status_tracker import ComponentPoolStatusTracker
 from ..._component_status import ComponentPoolStatus, EVChargerStatusTracker
 from ...request import Request
@@ -224,7 +224,7 @@ class EVChargerManager(ComponentManager):
         """Run the main event loop of the EV charger manager."""
         api = connection_manager.get().api_client
         ev_charger_data_rx = merge(
-            *[await api.ev_charger_data(evc_id) for evc_id in self._ev_charger_ids]
+            *(EVChargerData.subscribe(api, evc_id) for evc_id in self._ev_charger_ids)
         )
         target_power_rx = self._target_power_channel.new_receiver()
         latest_target_powers: dict[ComponentId, Power] = {}
@@ -309,10 +309,10 @@ class EVChargerManager(ComponentManager):
             Power distribution result, corresponding to the result of the API
                 request.
         """
-        tasks: dict[ComponentId, asyncio.Task[None]] = {}
+        tasks: dict[ComponentId, asyncio.Task[datetime | None]] = {}
         for component_id, power in target_power_changes.items():
             tasks[component_id] = asyncio.create_task(
-                api.set_power(component_id, power.as_watts())
+                api.set_component_power_active(component_id, power.as_watts())
             )
         _, pending = await asyncio.wait(
             tasks.values(),

--- a/src/frequenz/sdk/microgrid/_power_distributing/_component_managers/_ev_charger_manager/_ev_charger_manager.py
+++ b/src/frequenz/sdk/microgrid/_power_distributing/_component_managers/_ev_charger_manager/_ev_charger_manager.py
@@ -112,7 +112,7 @@ class EVChargerManager(ComponentManager):
         return {
             evc.id
             for evc in connection_manager.get().component_graph.components(
-                matching_types={EvCharger}
+                matching_types=EvCharger
             )
         }
 

--- a/src/frequenz/sdk/microgrid/_power_distributing/_component_managers/_ev_charger_manager/_ev_charger_manager.py
+++ b/src/frequenz/sdk/microgrid/_power_distributing/_component_managers/_ev_charger_manager/_ev_charger_manager.py
@@ -17,11 +17,8 @@ from frequenz.channels import (
     selected_from,
 )
 from frequenz.client.common.microgrid.components import ComponentId
-from frequenz.client.microgrid import (
-    ApiClientError,
-    ComponentCategory,
-    MicrogridApiClient,
-)
+from frequenz.client.microgrid import ApiClientError, MicrogridApiClient
+from frequenz.client.microgrid.component import EvCharger
 from frequenz.quantities import Power, Voltage
 from typing_extensions import override
 
@@ -115,7 +112,7 @@ class EVChargerManager(ComponentManager):
         return {
             evc.id
             for evc in connection_manager.get().component_graph.components(
-                component_categories={ComponentCategory.EV_CHARGER}
+                matching_types={EvCharger}
             )
         }
 

--- a/src/frequenz/sdk/microgrid/_power_distributing/_component_managers/_ev_charger_manager/_states.py
+++ b/src/frequenz/sdk/microgrid/_power_distributing/_component_managers/_ev_charger_manager/_states.py
@@ -9,8 +9,9 @@ from datetime import datetime
 from typing import Iterable
 
 from frequenz.client.common.microgrid.components import ComponentId
-from frequenz.client.microgrid import EVChargerData
 from frequenz.quantities import Power
+
+from ...._old_component_data import EVChargerData
 
 
 @dataclass

--- a/src/frequenz/sdk/microgrid/_power_distributing/_component_managers/_pv_inverter_manager/_pv_inverter_manager.py
+++ b/src/frequenz/sdk/microgrid/_power_distributing/_component_managers/_pv_inverter_manager/_pv_inverter_manager.py
@@ -255,6 +255,6 @@ class PVManager(ComponentManager):
         return {
             inv.id
             for inv in connection_manager.get().component_graph.components(
-                matching_types={SolarInverter}
+                matching_types=SolarInverter
             )
         }

--- a/src/frequenz/sdk/microgrid/_power_distributing/_component_managers/_pv_inverter_manager/_pv_inverter_manager.py
+++ b/src/frequenz/sdk/microgrid/_power_distributing/_component_managers/_pv_inverter_manager/_pv_inverter_manager.py
@@ -10,11 +10,8 @@ from datetime import datetime, timedelta
 
 from frequenz.channels import LatestValueCache, Sender
 from frequenz.client.common.microgrid.components import ComponentId
-from frequenz.client.microgrid import (
-    ApiClientError,
-    ComponentCategory,
-    InverterType,
-)
+from frequenz.client.microgrid import ApiClientError
+from frequenz.client.microgrid.component import SolarInverter
 from frequenz.quantities import Power
 from typing_extensions import override
 
@@ -258,7 +255,6 @@ class PVManager(ComponentManager):
         return {
             inv.id
             for inv in connection_manager.get().component_graph.components(
-                component_categories={ComponentCategory.INVERTER}
+                matching_types={SolarInverter}
             )
-            if inv.type == InverterType.SOLAR
         }

--- a/src/frequenz/sdk/microgrid/_power_distributing/_component_managers/_pv_inverter_manager/_pv_inverter_manager.py
+++ b/src/frequenz/sdk/microgrid/_power_distributing/_component_managers/_pv_inverter_manager/_pv_inverter_manager.py
@@ -256,7 +256,7 @@ class PVManager(ComponentManager):
     def _get_pv_inverter_ids(self) -> collections.abc.Set[ComponentId]:
         """Return the IDs of all PV inverters present in the component graph."""
         return {
-            inv.component_id
+            inv.id
             for inv in connection_manager.get().component_graph.components(
                 component_categories={ComponentCategory.INVERTER}
             )

--- a/src/frequenz/sdk/microgrid/_power_distributing/_component_managers/_pv_inverter_manager/_pv_inverter_manager.py
+++ b/src/frequenz/sdk/microgrid/_power_distributing/_component_managers/_pv_inverter_manager/_pv_inverter_manager.py
@@ -6,14 +6,13 @@
 import asyncio
 import collections.abc
 import logging
-from datetime import timedelta
+from datetime import datetime, timedelta
 
 from frequenz.channels import LatestValueCache, Sender
 from frequenz.client.common.microgrid.components import ComponentId
 from frequenz.client.microgrid import (
     ApiClientError,
     ComponentCategory,
-    InverterData,
     InverterType,
 )
 from frequenz.quantities import Power
@@ -21,6 +20,7 @@ from typing_extensions import override
 
 from ....._internal._math import is_close_to_zero
 from .... import connection_manager
+from ...._old_component_data import InverterData
 from ..._component_pool_status_tracker import ComponentPoolStatusTracker
 from ..._component_status import ComponentPoolStatus, PVInverterStatusTracker
 from ...request import Request
@@ -79,7 +79,7 @@ class PVManager(ComponentManager):
         """Start the PV inverter manager."""
         self._component_data_caches = {
             inv_id: LatestValueCache(
-                await connection_manager.get().api_client.inverter_data(inv_id),
+                InverterData.subscribe(connection_manager.get().api_client, inv_id),
                 unique_id=f"{type(self).__name__}«{hex(id(self))}»:inverter«{inv_id}»",
             )
             for inv_id in self._pv_inverter_ids
@@ -188,10 +188,10 @@ class PVManager(ComponentManager):
         remaining_power: Power,
     ) -> None:
         api_client = connection_manager.get().api_client
-        tasks: dict[ComponentId, asyncio.Task[None]] = {}
+        tasks: dict[ComponentId, asyncio.Task[datetime | None]] = {}
         for component_id, power in allocations.items():
             tasks[component_id] = asyncio.create_task(
-                api_client.set_power(component_id, power.as_watts())
+                api_client.set_component_power_active(component_id, power.as_watts())
             )
         _, pending = await asyncio.wait(
             tasks.values(),

--- a/src/frequenz/sdk/microgrid/_power_distributing/_component_status/_battery_status_tracker.py
+++ b/src/frequenz/sdk/microgrid/_power_distributing/_component_status/_battery_status_tracker.py
@@ -27,10 +27,10 @@ from frequenz.client.common.microgrid.components import ComponentId
 from frequenz.client.microgrid import (
     BatteryComponentState,
     BatteryRelayState,
-    ComponentCategory,
     ErrorLevel,
     InverterComponentState,
 )
+from frequenz.client.microgrid.component import Inverter
 from typing_extensions import override
 
 from frequenz.sdk._internal._asyncio import run_forever
@@ -486,7 +486,9 @@ class BatteryStatusTracker(ComponentStatusTracker, BackgroundService):
             (
                 comp.id
                 for comp in graph.predecessors(battery_id)
-                if comp.category == ComponentCategory.INVERTER
+                # Using Inverter is way too general, see
+                # https://github.com/frequenz-floss/frequenz-sdk-python/issues/1285
+                if isinstance(comp, Inverter)
             ),
             None,
         )

--- a/src/frequenz/sdk/microgrid/_power_distributing/_component_status/_battery_status_tracker.py
+++ b/src/frequenz/sdk/microgrid/_power_distributing/_component_status/_battery_status_tracker.py
@@ -26,13 +26,10 @@ from frequenz.channels.timer import SkipMissedAndDrift, Timer
 from frequenz.client.common.microgrid.components import ComponentId
 from frequenz.client.microgrid import (
     BatteryComponentState,
-    BatteryData,
     BatteryRelayState,
     ComponentCategory,
-    ComponentData,
     ErrorLevel,
     InverterComponentState,
-    InverterData,
 )
 from typing_extensions import override
 
@@ -40,6 +37,7 @@ from frequenz.sdk._internal._asyncio import run_forever
 
 from ....actor._background_service import BackgroundService
 from ... import connection_manager
+from ..._old_component_data import BatteryData, ComponentData, InverterData
 from ._blocking_status import BlockingStatus
 from ._component_status import (
     ComponentStatus,
@@ -255,8 +253,10 @@ class BatteryStatusTracker(ComponentStatusTracker, BackgroundService):
         """
         api_client = connection_manager.get().api_client
 
-        battery_receiver = await api_client.battery_data(self._battery.component_id)
-        inverter_receiver = await api_client.inverter_data(self._inverter.component_id)
+        battery_receiver = BatteryData.subscribe(api_client, self._battery.component_id)
+        inverter_receiver = InverterData.subscribe(
+            api_client, self._inverter.component_id
+        )
 
         battery = battery_receiver
         battery_timer = self._battery.data_recv_timer

--- a/src/frequenz/sdk/microgrid/_power_distributing/_component_status/_battery_status_tracker.py
+++ b/src/frequenz/sdk/microgrid/_power_distributing/_component_status/_battery_status_tracker.py
@@ -24,13 +24,7 @@ from datetime import datetime, timedelta, timezone
 from frequenz.channels import Receiver, Sender, select, selected_from
 from frequenz.channels.timer import SkipMissedAndDrift, Timer
 from frequenz.client.common.microgrid.components import ComponentId
-from frequenz.client.microgrid import (
-    BatteryComponentState,
-    BatteryRelayState,
-    ErrorLevel,
-    InverterComponentState,
-)
-from frequenz.client.microgrid.component import Inverter
+from frequenz.client.microgrid.component import ComponentStateCode, Inverter
 from typing_extensions import override
 
 from frequenz.sdk._internal._asyncio import run_forever
@@ -70,28 +64,34 @@ class BatteryStatusTracker(ComponentStatusTracker, BackgroundService):
     Status updates are sent out only when there is a status change.
     """
 
-    _battery_valid_relay: set[BatteryRelayState] = {BatteryRelayState.CLOSED}
+    _battery_valid_relay: frozenset[ComponentStateCode] = frozenset(
+        [ComponentStateCode.RELAY_CLOSED]
+    )
     """The list of valid relay states of a battery.
 
     A working battery in any other battery relay state will be reported as failing.
     """
 
-    _battery_valid_state: set[BatteryComponentState] = {
-        BatteryComponentState.IDLE,
-        BatteryComponentState.CHARGING,
-        BatteryComponentState.DISCHARGING,
-    }
+    _battery_valid_state: frozenset[ComponentStateCode] = frozenset(
+        [
+            ComponentStateCode.READY,
+            ComponentStateCode.CHARGING,
+            ComponentStateCode.DISCHARGING,
+        ]
+    )
     """The list of valid states of a battery.
 
     A working battery in any other battery state will be reported as failing.
     """
 
-    _inverter_valid_state: set[InverterComponentState] = {
-        InverterComponentState.STANDBY,
-        InverterComponentState.IDLE,
-        InverterComponentState.CHARGING,
-        InverterComponentState.DISCHARGING,
-    }
+    _inverter_valid_state: frozenset[ComponentStateCode] = frozenset(
+        [
+            ComponentStateCode.STANDBY,
+            ComponentStateCode.READY,
+            ComponentStateCode.CHARGING,
+            ComponentStateCode.DISCHARGING,
+        ]
+    )
     """The list of valid states of an inverter.
 
     A working inverter in any other inverter state will be reported as failing.
@@ -371,15 +371,13 @@ class BatteryStatusTracker(ComponentStatusTracker, BackgroundService):
         Returns:
             True if message has no critical error, False otherwise.
         """
-        critical = ErrorLevel.CRITICAL
-        critical_err = next((err for err in msg.errors if err.level == critical), None)
-        if critical_err is not None:
+        if msg.errors:
             last_status = self._last_status  # pylint: disable=protected-access
             if last_status == ComponentStatusEnum.WORKING:
                 _logger.warning(
-                    "Component %d has critical error: %s",
+                    "Component %d has errors: %s",
                     msg.component_id,
-                    str(critical_err),
+                    str(msg.errors),
                 )
             return False
         return True
@@ -394,14 +392,15 @@ class BatteryStatusTracker(ComponentStatusTracker, BackgroundService):
             True if inverter is in correct state. False otherwise.
         """
         # Component state is not exposed to the user.
-        state = msg.component_state
+        component_states = msg.states
         # pylint: disable-next=protected-access
-        if state not in BatteryStatusTracker._inverter_valid_state:
+        valid_states = BatteryStatusTracker._inverter_valid_state
+        if not component_states & valid_states:
             if self._last_status == ComponentStatusEnum.WORKING:
                 _logger.warning(
-                    "Inverter %d has invalid state: %s",
+                    "Inverter %d has invalid states: %s",
                     msg.component_id,
-                    state.name,
+                    msg.states,
                 )
             return False
         return True
@@ -416,25 +415,27 @@ class BatteryStatusTracker(ComponentStatusTracker, BackgroundService):
             True if battery is in correct state. False otherwise.
         """
         # Component state is not exposed to the user.
-        state = msg.component_state
+        component_states = msg.states
         # pylint: disable-next=protected-access
-        if state not in BatteryStatusTracker._battery_valid_state:
+        valid_states = BatteryStatusTracker._battery_valid_state
+        if not component_states & valid_states:
             if self._last_status == ComponentStatusEnum.WORKING:
                 _logger.warning(
-                    "Battery %d has invalid state: %s",
+                    "Battery %d has invalid states: %s, expected: %s",
                     self.battery_id,
-                    state.name,
+                    msg.states,
+                    valid_states,
                 )
             return False
 
         # Component state is not exposed to the user.
-        relay_state = msg.relay_state
-        if relay_state not in BatteryStatusTracker._battery_valid_relay:
+        if not msg.states & BatteryStatusTracker._battery_valid_relay:
             if self._last_status == ComponentStatusEnum.WORKING:
                 _logger.warning(
-                    "Battery %d has invalid relay state: %s",
+                    "Battery %d has invalid states: %s, expected: %s",
                     self.battery_id,
-                    relay_state.name,
+                    msg.states,
+                    BatteryStatusTracker._battery_valid_relay,
                 )
             return False
         return True

--- a/src/frequenz/sdk/microgrid/_power_distributing/_component_status/_battery_status_tracker.py
+++ b/src/frequenz/sdk/microgrid/_power_distributing/_component_status/_battery_status_tracker.py
@@ -484,7 +484,7 @@ class BatteryStatusTracker(ComponentStatusTracker, BackgroundService):
         graph = connection_manager.get().component_graph
         return next(
             (
-                comp.component_id
+                comp.id
                 for comp in graph.predecessors(battery_id)
                 if comp.category == ComponentCategory.INVERTER
             ),

--- a/src/frequenz/sdk/microgrid/_power_distributing/_component_status/_ev_charger_status_tracker.py
+++ b/src/frequenz/sdk/microgrid/_power_distributing/_component_status/_ev_charger_status_tracker.py
@@ -14,13 +14,13 @@ from frequenz.client.common.microgrid.components import ComponentId
 from frequenz.client.microgrid import (
     EVChargerCableState,
     EVChargerComponentState,
-    EVChargerData,
 )
 from typing_extensions import override
 
 from ...._internal._asyncio import run_forever
 from ....actor._background_service import BackgroundService
 from ... import connection_manager
+from ..._old_component_data import EVChargerData
 from ._blocking_status import BlockingStatus
 from ._component_status import (
     ComponentStatus,
@@ -149,8 +149,9 @@ class EVChargerStatusTracker(ComponentStatusTracker, BackgroundService):
 
     async def _run(self) -> None:
         """Run the status tracker."""
-        api_client = connection_manager.get().api_client
-        ev_data_rx = await api_client.ev_charger_data(self._component_id)
+        ev_data_rx = EVChargerData.subscribe(
+            connection_manager.get().api_client, self._component_id
+        )
         set_power_result_rx = self._set_power_result_receiver
         missing_data_timer = Timer(self._max_data_age, SkipMissedAndDrift())
 

--- a/src/frequenz/sdk/microgrid/_power_distributing/_component_status/_ev_charger_status_tracker.py
+++ b/src/frequenz/sdk/microgrid/_power_distributing/_component_status/_ev_charger_status_tracker.py
@@ -11,10 +11,7 @@ from datetime import datetime, timedelta, timezone
 from frequenz.channels import Receiver, Sender, select, selected_from
 from frequenz.channels.timer import SkipMissedAndDrift, Timer
 from frequenz.client.common.microgrid.components import ComponentId
-from frequenz.client.microgrid import (
-    EVChargerCableState,
-    EVChargerComponentState,
-)
+from frequenz.client.microgrid.component import ComponentStateCode
 from typing_extensions import override
 
 from ...._internal._asyncio import run_forever
@@ -87,14 +84,16 @@ class EVChargerStatusTracker(ComponentStatusTracker, BackgroundService):
 
     def _is_working(self, ev_data: EVChargerData) -> bool:
         """Return whether the given data indicates that the component is working."""
-        return ev_data.cable_state in (
-            EVChargerCableState.EV_PLUGGED,
-            EVChargerCableState.EV_LOCKED,
-        ) and ev_data.component_state in (
-            EVChargerComponentState.READY,
-            EVChargerComponentState.CHARGING,
-            EVChargerComponentState.DISCHARGING,
+        is_connected = ev_data.is_ev_connected()
+        is_ok = bool(
+            {
+                ComponentStateCode.READY,
+                ComponentStateCode.CHARGING,
+                ComponentStateCode.DISCHARGING,
+            }
+            & ev_data.states
         )
+        return is_connected and is_ok
 
     def _is_stale(self, ev_data: EVChargerData) -> bool:
         """Return whether the given data is stale."""
@@ -123,11 +122,9 @@ class EVChargerStatusTracker(ComponentStatusTracker, BackgroundService):
 
         if self._last_status == ComponentStatusEnum.WORKING:
             _logger.warning(
-                "EV charger %s is in NOT_WORKING state. "
-                "Cable state: %s, component state: %s",
+                "EV charger %s is in NOT_WORKING state. component states: %s",
                 self._component_id,
-                ev_data.cable_state,
-                ev_data.component_state,
+                ev_data.states,
             )
         return ComponentStatusEnum.NOT_WORKING
 

--- a/src/frequenz/sdk/microgrid/_power_distributing/_component_status/_pv_inverter_status_tracker.py
+++ b/src/frequenz/sdk/microgrid/_power_distributing/_component_status/_pv_inverter_status_tracker.py
@@ -10,12 +10,13 @@ from datetime import datetime, timedelta, timezone
 from frequenz.channels import Receiver, Sender, select, selected_from
 from frequenz.channels.timer import SkipMissedAndDrift, Timer
 from frequenz.client.common.microgrid.components import ComponentId
-from frequenz.client.microgrid import InverterComponentState, InverterData
+from frequenz.client.microgrid import ComponentStateCode
 from typing_extensions import override
 
 from ...._internal._asyncio import run_forever
 from ....actor._background_service import BackgroundService
 from ... import connection_manager
+from ..._old_component_data import InverterData
 from ._blocking_status import BlockingStatus
 from ._component_status import (
     ComponentStatus,
@@ -141,8 +142,9 @@ class PVInverterStatusTracker(ComponentStatusTracker, BackgroundService):
 
     async def _run(self) -> None:
         """Run the status tracker."""
-        api_client = connection_manager.get().api_client
-        pv_data_rx = await api_client.inverter_data(self._component_id)
+        pv_data_rx = InverterData.subscribe(
+            connection_manager.get().api_client, self._component_id
+        )
         set_power_result_rx = self._set_power_result_receiver
         missing_data_timer = Timer(self._max_data_age, SkipMissedAndDrift())
 

--- a/src/frequenz/sdk/microgrid/_power_distributing/_component_status/_pv_inverter_status_tracker.py
+++ b/src/frequenz/sdk/microgrid/_power_distributing/_component_status/_pv_inverter_status_tracker.py
@@ -10,7 +10,7 @@ from datetime import datetime, timedelta, timezone
 from frequenz.channels import Receiver, Sender, select, selected_from
 from frequenz.channels.timer import SkipMissedAndDrift, Timer
 from frequenz.client.common.microgrid.components import ComponentId
-from frequenz.client.microgrid import ComponentStateCode
+from frequenz.client.microgrid.component import ComponentStateCode
 from typing_extensions import override
 
 from ...._internal._asyncio import run_forever
@@ -84,11 +84,14 @@ class PVInverterStatusTracker(ComponentStatusTracker, BackgroundService):
 
     def _is_working(self, pv_data: InverterData) -> bool:
         """Return whether the given data indicates that the PV inverter is working."""
-        return pv_data.component_state in (
-            InverterComponentState.DISCHARGING,
-            InverterComponentState.CHARGING,
-            InverterComponentState.IDLE,
-            InverterComponentState.STANDBY,
+        return bool(
+            {
+                ComponentStateCode.DISCHARGING,
+                ComponentStateCode.CHARGING,
+                ComponentStateCode.READY,
+                ComponentStateCode.STANDBY,
+            }
+            & pv_data.states
         )
 
     def _is_stale(self, pv_data: InverterData) -> bool:
@@ -134,9 +137,9 @@ class PVInverterStatusTracker(ComponentStatusTracker, BackgroundService):
 
         if self._last_status == ComponentStatusEnum.WORKING:
             _logger.warning(
-                "PV inverter %s is in NOT_WORKING state.  Component state: %s",
+                "PV inverter %s is in NOT_WORKING state.  Component states: %s",
                 self._component_id,
-                pv_data.component_state,
+                pv_data.states,
             )
         return ComponentStatusEnum.NOT_WORKING
 

--- a/src/frequenz/sdk/microgrid/_power_distributing/_distribution_algorithm/_battery_distribution_algorithm.py
+++ b/src/frequenz/sdk/microgrid/_power_distributing/_distribution_algorithm/_battery_distribution_algorithm.py
@@ -9,10 +9,10 @@ from dataclasses import dataclass
 from typing import NamedTuple, Sequence
 
 from frequenz.client.common.microgrid.components import ComponentId
-from frequenz.client.microgrid import BatteryData, InverterData
 from frequenz.quantities import Power
 
 from ...._internal._math import is_close_to_zero
+from ..._old_component_data import BatteryData, InverterData
 from ..result import PowerBounds
 
 _logger = logging.getLogger(__name__)

--- a/src/frequenz/sdk/microgrid/_power_distributing/power_distributing.py
+++ b/src/frequenz/sdk/microgrid/_power_distributing/power_distributing.py
@@ -12,7 +12,7 @@ distributing the power between the components and sends the results back to it.
 
 import asyncio
 import logging
-from datetime import timedelta
+from datetime import datetime, timedelta
 
 from frequenz.channels import Receiver, Sender
 from frequenz.client.common.microgrid.components import ComponentId
@@ -101,7 +101,9 @@ class PowerDistributingActor(Actor):  # pylint: disable=too-many-instance-attrib
         self._result_sender = results_sender
         self._api_power_request_timeout = api_power_request_timeout
 
-        self._processing_tasks: dict[frozenset[ComponentId], asyncio.Task[None]] = {}
+        self._processing_tasks: dict[
+            frozenset[ComponentId], asyncio.Task[datetime | None]
+        ] = {}
         """Track the power request tasks currently being processed."""
 
         self._pending_requests: dict[frozenset[ComponentId], Request] = {}
@@ -176,7 +178,7 @@ class PowerDistributingActor(Actor):  # pylint: disable=too-many-instance-attrib
         self,
         req_id: frozenset[ComponentId],
         request: Request,
-        task: asyncio.Task[None],
+        task: asyncio.Task[datetime | None],
     ) -> None:
         """Handle the completion of a power request task.
 

--- a/src/frequenz/sdk/microgrid/_power_distributing/power_distributing.py
+++ b/src/frequenz/sdk/microgrid/_power_distributing/power_distributing.py
@@ -13,10 +13,11 @@ distributing the power between the components and sends the results back to it.
 import asyncio
 import logging
 from datetime import datetime, timedelta
+from typing import assert_never
 
 from frequenz.channels import Receiver, Sender
 from frequenz.client.common.microgrid.components import ComponentId
-from frequenz.client.microgrid import ComponentCategory, ComponentType, InverterType
+from frequenz.client.microgrid.component import Battery, EvCharger, SolarInverter
 from typing_extensions import override
 
 from ...actor._actor import Actor
@@ -60,18 +61,19 @@ class PowerDistributingActor(Actor):  # pylint: disable=too-many-instance-attrib
 
     def __init__(  # pylint: disable=too-many-arguments
         self,
+        component_type: type[Battery | EvCharger | SolarInverter],
         requests_receiver: Receiver[Request],
         results_sender: Sender[Result],
         component_pool_status_sender: Sender[ComponentPoolStatus],
         *,
         api_power_request_timeout: timedelta,
-        component_category: ComponentCategory,
-        component_type: ComponentType | None = None,
         name: str | None = None,
     ) -> None:
         """Create actor instance.
 
         Args:
+            component_type: The class of the components that this actor is
+                responsible for.
             requests_receiver: Receiver for receiving power requests from the power
                 manager.
             results_sender: Sender for sending results to the power manager.
@@ -79,24 +81,11 @@ class PowerDistributingActor(Actor):  # pylint: disable=too-many-instance-attrib
                 components are expected to be working.
             api_power_request_timeout: Timeout to use when making power requests to
                 the microgrid API.
-            component_category: The category of the components that this actor is
-                responsible for.
-            component_type: The type of the component of the given category that this
-                actor is responsible for.  This is used only when the component category
-                is not enough to uniquely identify the component.  For example, when the
-                category is `ComponentCategory.INVERTER`, the type is needed to identify
-                the inverter as a solar inverter or a battery inverter.  This can be
-                `None` when the component category is enough to uniquely identify the
-                component.
             name: The name of the actor. If `None`, `str(id(self))` will be used. This
                 is used mostly for debugging purposes.
-
-        Raises:
-            ValueError: If the given component category is not supported.
         """
         super().__init__(name=name)
-        self._component_category = component_category
-        self._component_type = component_type
+        self._component_class = component_type
         self._requests_receiver = requests_receiver
         self._result_sender = results_sender
         self._api_power_request_timeout = api_power_request_timeout
@@ -114,25 +103,20 @@ class PowerDistributingActor(Actor):  # pylint: disable=too-many-instance-attrib
         """
 
         self._component_manager: ComponentManager
-        if component_category == ComponentCategory.BATTERY:
+        if issubclass(component_type, Battery):
             self._component_manager = BatteryManager(
                 component_pool_status_sender, results_sender, api_power_request_timeout
             )
-        elif component_category == ComponentCategory.EV_CHARGER:
+        elif issubclass(component_type, EvCharger):
             self._component_manager = EVChargerManager(
                 component_pool_status_sender, results_sender, api_power_request_timeout
             )
-        elif (
-            component_category == ComponentCategory.INVERTER
-            and component_type == InverterType.SOLAR
-        ):
+        elif issubclass(component_type, SolarInverter):
             self._component_manager = PVManager(
                 component_pool_status_sender, results_sender, api_power_request_timeout
             )
         else:
-            raise ValueError(
-                f"PowerDistributor doesn't support controlling: {component_category}"
-            )
+            assert_never(component_type)
 
     @override
     async def _run(self) -> None:

--- a/src/frequenz/sdk/microgrid/_power_managing/_power_managing_actor.py
+++ b/src/frequenz/sdk/microgrid/_power_managing/_power_managing_actor.py
@@ -14,7 +14,7 @@ from typing import assert_never
 from frequenz.channels import Receiver, Sender, select, selected_from
 from frequenz.channels.timer import SkipMissedAndDrift, Timer
 from frequenz.client.common.microgrid.components import ComponentId
-from frequenz.client.microgrid import ComponentCategory, ComponentType, InverterType
+from frequenz.client.microgrid.component import Battery, EvCharger, SolarInverter
 from typing_extensions import override
 
 from ..._internal._asyncio import run_forever
@@ -49,8 +49,7 @@ class PowerManagingActor(Actor):
         channel_registry: ChannelRegistry,
         algorithm: Algorithm,
         default_power: DefaultPower,
-        component_category: ComponentCategory,
-        component_type: ComponentType | None = None,
+        component_class: type[Battery | EvCharger | SolarInverter],
     ):
         """Create a new instance of the power manager.
 
@@ -64,19 +63,10 @@ class PowerManagingActor(Actor):
             channel_registry: The channel registry.
             algorithm: The power management algorithm to use.
             default_power: The default power to use for the components.
-            component_category: The category of the component this power manager
-                instance is going to support.
-            component_type: The type of the component of the given category that this
-                actor is responsible for.  This is used only when the component category
-                is not enough to uniquely identify the component.  For example, when the
-                category is `ComponentCategory.INVERTER`, the type is needed to identify
-                the inverter as a solar inverter or a battery inverter.  This can be
-                `None` when the component category is enough to uniquely identify the
-                component.
+            component_class: The class of component this instance is going to support.
         """
-        self._component_category = component_category
-        self._component_type = component_type
         self._default_power = default_power
+        self._component_class = component_class
         self._bounds_subscription_receiver = bounds_subscription_receiver
         self._power_distributing_requests_sender = power_distributing_requests_sender
         self._power_distributing_results_receiver = power_distributing_results_receiver
@@ -153,39 +143,32 @@ class PowerManagingActor(Actor):
 
         Args:
             component_ids: The component IDs for which to add a bounds tracker.
-
-        Raises:
-            NotImplementedError: When the pool type is not supported.
         """
         bounds_receiver: Receiver[SystemBounds]
-        if self._component_category is ComponentCategory.BATTERY:
+        if issubclass(self._component_class, Battery):
             battery_pool = _data_pipeline.new_battery_pool(
                 priority=-sys.maxsize - 1, component_ids=component_ids
             )
             # pylint: disable-next=protected-access
             bounds_receiver = battery_pool._system_power_bounds.new_receiver()
-        elif self._component_category is ComponentCategory.EV_CHARGER:
+        elif issubclass(self._component_class, EvCharger):
             ev_charger_pool = _data_pipeline.new_ev_charger_pool(
                 priority=-sys.maxsize - 1, component_ids=component_ids
             )
             # pylint: disable-next=protected-access
             bounds_receiver = ev_charger_pool._system_power_bounds.new_receiver()
-        elif (
-            self._component_category is ComponentCategory.INVERTER
-            and self._component_type is InverterType.SOLAR
-        ):
+        elif issubclass(self._component_class, SolarInverter):
             pv_pool = _data_pipeline.new_pv_pool(
                 priority=-sys.maxsize - 1, component_ids=component_ids
             )
             # pylint: disable-next=protected-access
             bounds_receiver = pv_pool._system_power_bounds.new_receiver()
         else:
-            err = (
-                "PowerManagingActor: Unsupported component category: "
-                f"{self._component_category}"
+            _logger.error(
+                "PowerManagingActor: Unsupported component class: %s",
+                self._component_class.__name__,
             )
-            _logger.error(err)
-            raise NotImplementedError(err)
+            assert_never(self._component_class)
 
         self._system_bounds[component_ids] = SystemBounds(
             timestamp=datetime.now(tz=timezone.utc),

--- a/src/frequenz/sdk/microgrid/_power_wrapper.py
+++ b/src/frequenz/sdk/microgrid/_power_wrapper.py
@@ -9,7 +9,7 @@ import logging
 from datetime import timedelta
 
 from frequenz.channels import Broadcast
-from frequenz.client.microgrid import ComponentCategory, ComponentType
+from frequenz.client.microgrid.component import Battery, EvCharger, SolarInverter
 
 from .._internal._channels import ChannelRegistry, ReceiverFetcher
 
@@ -40,8 +40,7 @@ class PowerWrapper:  # pylint: disable=too-many-instance-attributes
         api_power_request_timeout: timedelta,
         power_manager_algorithm: Algorithm,
         default_power: DefaultPower,
-        component_category: ComponentCategory,
-        component_type: ComponentType | None = None,
+        component_class: type[Battery | EvCharger | SolarInverter],
     ):
         """Initialize the power control.
 
@@ -51,20 +50,11 @@ class PowerWrapper:  # pylint: disable=too-many-instance-attributes
                 the microgrid API.
             power_manager_algorithm: The power management algorithm to use.
             default_power: The default power to use for the components.
-            component_category: The category of the components that actors started by
-                this instance of the PowerWrapper will be responsible for.
-            component_type: The type of the component of the given category that this
-                actor is responsible for.  This is used only when the component category
-                is not enough to uniquely identify the component.  For example, when the
-                category is `ComponentCategory.INVERTER`, the type is needed to identify
-                the inverter as a solar inverter or a battery inverter.  This can be
-                `None` when the component category is enough to uniquely identify the
-                component.
+            component_class: The class of the component to manage.
         """
         self._default_power = default_power
-        self._component_category = component_category
-        self._component_type = component_type
         self._power_manager_algorithm = power_manager_algorithm
+        self._component_class = component_class
         self._channel_registry = channel_registry
         self._api_power_request_timeout = api_power_request_timeout
 
@@ -97,21 +87,18 @@ class PowerWrapper:  # pylint: disable=too-many-instance-attributes
         # Currently the power managing actor only supports batteries.  The below
         # constraint needs to be relaxed if the actor is extended to support other
         # components.
-        if not component_graph.components(
-            component_categories={self._component_category}
-        ):
+        if not component_graph.components(matching_types={self._component_class}):
             _logger.warning(
                 "No %s found in the component graph. "
                 "The power managing actor will not be started.",
-                self._component_category,
+                self._component_class.__name__,
             )
             return
 
         self._power_managing_actor = _power_managing.PowerManagingActor(
             default_power=self._default_power,
-            component_category=self._component_category,
-            component_type=self._component_type,
             algorithm=self._power_manager_algorithm,
+            component_class=self._component_class,
             proposals_receiver=self.proposal_channel.new_receiver(),
             bounds_subscription_receiver=(
                 self.bounds_subscription_channel.new_receiver()
@@ -132,13 +119,11 @@ class PowerWrapper:  # pylint: disable=too-many-instance-attributes
             return
 
         component_graph = connection_manager.get().component_graph
-        if not component_graph.components(
-            component_categories={self._component_category}
-        ):
+        if not component_graph.components(matching_types={self._component_class}):
             _logger.warning(
                 "No %s found in the component graph. "
                 "The power distributing actor will not be started.",
-                self._component_category,
+                self._component_class.__name__,
             )
             return
 
@@ -146,8 +131,7 @@ class PowerWrapper:  # pylint: disable=too-many-instance-attributes
         # Until the PowerManager is implemented, support for multiple use-case actors
         # will not be available in the high level interface.
         self._power_distributing_actor = PowerDistributingActor(
-            component_category=self._component_category,
-            component_type=self._component_type,
+            component_type=self._component_class,
             api_power_request_timeout=self._api_power_request_timeout,
             requests_receiver=self._power_distribution_requests_channel.new_receiver(),
             results_sender=self._power_distribution_results_channel.new_sender(),

--- a/src/frequenz/sdk/microgrid/_power_wrapper.py
+++ b/src/frequenz/sdk/microgrid/_power_wrapper.py
@@ -87,7 +87,7 @@ class PowerWrapper:  # pylint: disable=too-many-instance-attributes
         # Currently the power managing actor only supports batteries.  The below
         # constraint needs to be relaxed if the actor is extended to support other
         # components.
-        if not component_graph.components(matching_types={self._component_class}):
+        if not component_graph.components(matching_types=self._component_class):
             _logger.warning(
                 "No %s found in the component graph. "
                 "The power managing actor will not be started.",
@@ -119,7 +119,7 @@ class PowerWrapper:  # pylint: disable=too-many-instance-attributes
             return
 
         component_graph = connection_manager.get().component_graph
-        if not component_graph.components(matching_types={self._component_class}):
+        if not component_graph.components(matching_types=self._component_class):
             _logger.warning(
                 "No %s found in the component graph. "
                 "The power distributing actor will not be started.",

--- a/src/frequenz/sdk/microgrid/component_graph.py
+++ b/src/frequenz/sdk/microgrid/component_graph.py
@@ -24,7 +24,7 @@ flow of power.
 import asyncio
 import logging
 from abc import ABC, abstractmethod
-from collections.abc import Callable, Iterable, Set
+from collections.abc import Callable, Iterable
 
 import networkx as nx
 from frequenz.client.common.microgrid.components import ComponentId
@@ -83,8 +83,8 @@ class ComponentGraph(ABC):
     @abstractmethod
     def connections(
         self,
-        matching_sources: set[ComponentId] | None = None,
-        matching_destinations: set[ComponentId] | None = None,
+        matching_sources: Iterable[ComponentId] | ComponentId | None = None,
+        matching_destinations: Iterable[ComponentId] | ComponentId | None = None,
     ) -> set[ComponentConnection]:
         """Fetch the connections between microgrid components.
 
@@ -399,27 +399,15 @@ class _MicrogridComponentGraph(
             The set of components currently connected to the microgrid, filtered by
                 the provided `matching_ids` and `matching_types` values.
         """
-        match matching_ids:
-            case ComponentId():
-                matching_ids = {matching_ids}
-            case Set():
-                pass
-            case Iterable():
-                matching_ids = set(matching_ids)
-
-        match matching_types:
-            case type():
-                matching_types = {matching_types}
-            case Set():
-                pass
-            case Iterable():
-                matching_types = set(matching_types)
+        matching_ids = _comp_ids_to_iter(matching_ids)
+        if isinstance(matching_types, type):
+            matching_types = {matching_types}
 
         selection: Iterable[Component]
         selection_ids = (
             self._graph.nodes
             if matching_ids is None
-            else matching_ids & self._graph.nodes
+            else set(matching_ids) & self._graph.nodes
         )
         selection = (self._graph.nodes[i][_DATA_KEY] for i in selection_ids)
 
@@ -433,8 +421,8 @@ class _MicrogridComponentGraph(
     @override
     def connections(
         self,
-        matching_sources: set[ComponentId] | None = None,
-        matching_destinations: set[ComponentId] | None = None,
+        matching_sources: Iterable[ComponentId] | ComponentId | None = None,
+        matching_destinations: Iterable[ComponentId] | ComponentId | None = None,
     ) -> set[ComponentConnection]:
         """Fetch the connections between microgrid components.
 
@@ -447,6 +435,9 @@ class _MicrogridComponentGraph(
             The set of connections between components in the microgrid, filtered by
                 the provided `matching_sources` and `matching_destinations` choices.
         """
+        matching_sources = _comp_ids_to_iter(matching_sources)
+        matching_destinations = _comp_ids_to_iter(matching_destinations)
+
         match (matching_sources, matching_destinations):
             case (None, None):
                 selection = self._graph.edges
@@ -1128,3 +1119,11 @@ class _MicrogridComponentGraph(
             raise InvalidGraphError(
                 f"Leaf components with graph successors: {with_successors}"
             )
+
+
+def _comp_ids_to_iter(
+    ids: Iterable[ComponentId] | ComponentId | None,
+) -> Iterable[ComponentId] | None:
+    if isinstance(ids, ComponentId):
+        return (ids,)
+    return ids

--- a/src/frequenz/sdk/microgrid/component_graph.py
+++ b/src/frequenz/sdk/microgrid/component_graph.py
@@ -35,6 +35,7 @@ from frequenz.client.microgrid import (
     InverterType,
     MicrogridApiClient,
 )
+from typing_extensions import override
 
 _logger = logging.getLogger(__name__)
 
@@ -372,6 +373,7 @@ class _MicrogridComponentGraph(
         self.refresh_from(components, connections)
         self.validate()
 
+    @override
     def components(
         self,
         component_ids: set[ComponentId] | None = None,
@@ -401,6 +403,7 @@ class _MicrogridComponentGraph(
 
         return set(selection)
 
+    @override
     def connections(
         self,
         start: set[ComponentId] | None = None,
@@ -430,6 +433,7 @@ class _MicrogridComponentGraph(
 
         return set(self._graph.edges[i][_DATA_KEY] for i in selection_ids)
 
+    @override
     def predecessors(self, component_id: ComponentId) -> set[Component]:
         """Fetch the graph predecessors of the specified component.
 
@@ -454,6 +458,7 @@ class _MicrogridComponentGraph(
 
         return set(map(lambda idx: self._graph.nodes[idx][_DATA_KEY], predecessors_ids))
 
+    @override
     def successors(self, component_id: ComponentId) -> set[Component]:
         """Fetch the graph successors of the specified component.
 
@@ -567,6 +572,7 @@ class _MicrogridComponentGraph(
         self._validate_intermediary_components()
         self._validate_leaf_components()
 
+    @override
     def is_grid_meter(self, component: Component) -> bool:
         """Check if the specified component is a grid meter.
 
@@ -593,6 +599,7 @@ class _MicrogridComponentGraph(
         grid_successors = self.successors(predecessor.component_id)
         return len(grid_successors) == 1
 
+    @override
     def is_pv_inverter(self, component: Component) -> bool:
         """Check if the specified component is a PV inverter.
 
@@ -607,6 +614,7 @@ class _MicrogridComponentGraph(
             and component.type == InverterType.SOLAR
         )
 
+    @override
     def is_pv_meter(self, component: Component) -> bool:
         """Check if the specified component is a PV meter.
 
@@ -630,6 +638,7 @@ class _MicrogridComponentGraph(
             )
         )
 
+    @override
     def is_pv_chain(self, component: Component) -> bool:
         """Check if the specified component is part of a PV chain.
 
@@ -644,6 +653,7 @@ class _MicrogridComponentGraph(
         """
         return self.is_pv_inverter(component) or self.is_pv_meter(component)
 
+    @override
     def is_ev_charger(self, component: Component) -> bool:
         """Check if the specified component is an EV charger.
 
@@ -655,6 +665,7 @@ class _MicrogridComponentGraph(
         """
         return component.category == ComponentCategory.EV_CHARGER
 
+    @override
     def is_ev_charger_meter(self, component: Component) -> bool:
         """Check if the specified component is an EV charger meter.
 
@@ -675,6 +686,7 @@ class _MicrogridComponentGraph(
             and all(self.is_ev_charger(successor) for successor in successors)
         )
 
+    @override
     def is_ev_charger_chain(self, component: Component) -> bool:
         """Check if the specified component is part of an EV charger chain.
 
@@ -689,6 +701,7 @@ class _MicrogridComponentGraph(
         """
         return self.is_ev_charger(component) or self.is_ev_charger_meter(component)
 
+    @override
     def is_battery_inverter(self, component: Component) -> bool:
         """Check if the specified component is a battery inverter.
 
@@ -703,6 +716,7 @@ class _MicrogridComponentGraph(
             and component.type == InverterType.BATTERY
         )
 
+    @override
     def is_battery_meter(self, component: Component) -> bool:
         """Check if the specified component is a battery meter.
 
@@ -723,6 +737,7 @@ class _MicrogridComponentGraph(
             and all(self.is_battery_inverter(successor) for successor in successors)
         )
 
+    @override
     def is_battery_chain(self, component: Component) -> bool:
         """Check if the specified component is part of a battery chain.
 
@@ -737,6 +752,7 @@ class _MicrogridComponentGraph(
         """
         return self.is_battery_inverter(component) or self.is_battery_meter(component)
 
+    @override
     def is_chp(self, component: Component) -> bool:
         """Check if the specified component is a CHP.
 
@@ -748,6 +764,7 @@ class _MicrogridComponentGraph(
         """
         return component.category == ComponentCategory.CHP
 
+    @override
     def is_chp_meter(self, component: Component) -> bool:
         """Check if the specified component is a CHP meter.
 
@@ -768,6 +785,7 @@ class _MicrogridComponentGraph(
             and all(self.is_chp(successor) for successor in successors)
         )
 
+    @override
     def is_chp_chain(self, component: Component) -> bool:
         """Check if the specified component is part of a CHP chain.
 
@@ -781,6 +799,7 @@ class _MicrogridComponentGraph(
         """
         return self.is_chp(component) or self.is_chp_meter(component)
 
+    @override
     def dfs(
         self,
         current_node: Component,
@@ -816,6 +835,7 @@ class _MicrogridComponentGraph(
 
         return component
 
+    @override
     def find_first_descendant_component(
         self,
         *,

--- a/src/frequenz/sdk/microgrid/component_graph.py
+++ b/src/frequenz/sdk/microgrid/component_graph.py
@@ -28,12 +28,22 @@ from collections.abc import Callable, Iterable
 
 import networkx as nx
 from frequenz.client.common.microgrid.components import ComponentId
-from frequenz.client.microgrid import (
+from frequenz.client.microgrid import MicrogridApiClient
+from frequenz.client.microgrid.component import (
+    Battery,
+    BatteryInverter,
+    Chp,
     Component,
     ComponentCategory,
     Connection,
-    InverterType,
-    MicrogridApiClient,
+    EvCharger,
+    GridConnectionPoint,
+    Inverter,
+    Meter,
+    MismatchedCategoryComponent,
+    SolarInverter,
+    UnrecognizedComponent,
+    UnspecifiedComponent,
 )
 from typing_extensions import override
 
@@ -56,18 +66,18 @@ class ComponentGraph(ABC):
     @abstractmethod
     def components(
         self,
-        component_ids: set[ComponentId] | None = None,
-        component_categories: set[ComponentCategory] | None = None,
+        matching_ids: set[ComponentId] | None = None,
+        matching_types: set[type[Component]] | None = None,
     ) -> set[Component]:
         """Fetch the components of the microgrid.
 
         Args:
-            component_ids: The component IDs that the components must match.
-            component_categories: The component categories that the components must match.
+            matching_ids: The component IDs that the components must match.
+            matching_types: The component types that the components must match.
 
         Returns:
             The set of components currently connected to the microgrid, filtered by
-                the provided `component_ids` and `component_categories` values.
+                the provided `matching_ids` and `matching_types` values.
         """
 
     @abstractmethod
@@ -313,7 +323,7 @@ class ComponentGraph(ABC):
     def find_first_descendant_component(
         self,
         *,
-        descendant_categories: Iterable[ComponentCategory],
+        descendants: Iterable[type[Component]],
     ) -> Component:
         """Find the first descendant component given root and descendant categories.
 
@@ -325,7 +335,7 @@ class ComponentGraph(ABC):
         highest priority.
 
         Args:
-            descendant_categories: The descendant classes to search for the first
+            descendants: The descendant classes to search for the first
                 descendant component in.
 
         Returns:
@@ -376,30 +386,31 @@ class _MicrogridComponentGraph(
     @override
     def components(
         self,
-        component_ids: set[ComponentId] | None = None,
-        component_categories: set[ComponentCategory] | None = None,
+        matching_ids: set[ComponentId] | None = None,
+        matching_types: set[type[Component]] | None = None,
     ) -> set[Component]:
         """Fetch the components of the microgrid.
 
         Args:
-            component_ids: The component IDs that the components must match.
-            component_categories: The component categories that the components must match.
+            matching_ids: The component IDs that the components must match.
+            matching_types: The component types that the components must match.
 
         Returns:
             The set of components currently connected to the microgrid, filtered by
-                the provided `component_ids` and `component_categories` values.
+                the provided `matching_ids` and `matching_types` values.
         """
+        selection: Iterable[Component]
         selection_ids = (
             self._graph.nodes
-            if component_ids is None
-            else component_ids & self._graph.nodes
+            if matching_ids is None
+            else matching_ids & self._graph.nodes
         )
-        selection: Iterable[Component] = (
-            self._graph.nodes[i][_DATA_KEY] for i in selection_ids
-        )
+        selection = (self._graph.nodes[i][_DATA_KEY] for i in selection_ids)
 
-        if component_categories is not None:
-            selection = filter(lambda c: c.category in component_categories, selection)
+        if matching_types is not None:
+            selection = filter(
+                lambda c: isinstance(c, tuple(matching_types)), selection
+            )
 
         return set(selection)
 
@@ -451,7 +462,7 @@ class _MicrogridComponentGraph(
         """
         if component_id not in self._graph:
             raise KeyError(
-                f"Component with {component_id} not in graph, cannot get predecessors!"
+                f"Component {component_id} not in graph, cannot get predecessors!"
             )
 
         predecessors_ids = self._graph.predecessors(component_id)
@@ -475,7 +486,7 @@ class _MicrogridComponentGraph(
         """
         if component_id not in self._graph:
             raise KeyError(
-                f"Component with {component_id} not in graph, cannot get successors!"
+                f"Component {component_id} not in graph, cannot get successors!"
             )
 
         successors_ids = self._graph.successors(component_id)
@@ -494,7 +505,8 @@ class _MicrogridComponentGraph(
         components and connections.
 
         Args:
-            components: The components to include in the graph.
+            components: The components to initialize the graph with. If set, must
+                provide `connections` as well.
             connections: The connections to include in the graph.
             correct_errors: The callback that, if set, will be invoked if the
                 provided graph data is in any way invalid (it will attempt to
@@ -505,14 +517,20 @@ class _MicrogridComponentGraph(
                 do not form a valid component graph and `correct_errors` does
                 not fix it.
         """
-        if not all(component.is_valid() for component in components):
-            raise InvalidGraphError(f"Invalid components in input: {components}")
+        issues: list[str] = []
         if not all(connection.is_valid() for connection in connections):
             raise InvalidGraphError(f"Invalid connections in input: {connections}")
 
-        new_graph = nx.DiGraph()
         for component in components:
-            new_graph.add_node(component.id, **{_DATA_KEY: component})
+            issues.extend((self._validate_component(component)))
+
+        if issues:
+            raise InvalidGraphError(f"Invalid component data: {', '.join(issues)}")
+
+        new_graph = nx.DiGraph()
+        new_graph.add_nodes_from(
+            (component.id, {_DATA_KEY: component}) for component in components
+        )
 
         # Store the original connection object in the edge data (third item in the
         # tuple) so that we can retrieve it later.
@@ -543,6 +561,25 @@ class _MicrogridComponentGraph(
         old_graph = self._graph
         self._graph = new_graph
         old_graph.clear()  # just in case any references remain, but should not
+
+    def _validate_component(self, component: Component) -> list[str]:
+        """Check that the component is valid.
+
+        Args:
+            component: component to validate.
+
+        Returns:
+            List of issues found with the component.
+        """
+        issues: list[str] = []
+        if isinstance(component, UnspecifiedComponent):
+            _logger.warning("Component %r has an unspecified category!", component)
+        if isinstance(component, UnrecognizedComponent):
+            issues.append(f"Component {component!r} has an unrecognized category!")
+        if isinstance(component, MismatchedCategoryComponent):
+            _logger.warning("Component %r has a mismatched category!", component)
+
+        return issues
 
     async def refresh_from_client(
         self,
@@ -609,10 +646,7 @@ class _MicrogridComponentGraph(
         Returns:
             Whether the specified component is a PV inverter.
         """
-        return (
-            component.category == ComponentCategory.INVERTER
-            and component.type == InverterType.SOLAR
-        )
+        return isinstance(component, SolarInverter)
 
     @override
     def is_pv_meter(self, component: Component) -> bool:
@@ -629,7 +663,7 @@ class _MicrogridComponentGraph(
         """
         successors = self.successors(component.id)
         return (
-            component.category == ComponentCategory.METER
+            isinstance(component, Meter)
             and not self.is_grid_meter(component)
             and len(successors) > 0
             and all(
@@ -663,7 +697,7 @@ class _MicrogridComponentGraph(
         Returns:
             Whether the specified component is an EV charger.
         """
-        return component.category == ComponentCategory.EV_CHARGER
+        return isinstance(component, EvCharger)
 
     @override
     def is_ev_charger_meter(self, component: Component) -> bool:
@@ -680,7 +714,7 @@ class _MicrogridComponentGraph(
         """
         successors = self.successors(component.id)
         return (
-            component.category == ComponentCategory.METER
+            isinstance(component, Meter)
             and not self.is_grid_meter(component)
             and len(successors) > 0
             and all(self.is_ev_charger(successor) for successor in successors)
@@ -711,10 +745,7 @@ class _MicrogridComponentGraph(
         Returns:
             Whether the specified component is a battery inverter.
         """
-        return (
-            component.category == ComponentCategory.INVERTER
-            and component.type == InverterType.BATTERY
-        )
+        return isinstance(component, BatteryInverter)
 
     @override
     def is_battery_meter(self, component: Component) -> bool:
@@ -731,7 +762,7 @@ class _MicrogridComponentGraph(
         """
         successors = self.successors(component.id)
         return (
-            component.category == ComponentCategory.METER
+            isinstance(component, Meter)
             and not self.is_grid_meter(component)
             and len(successors) > 0
             and all(self.is_battery_inverter(successor) for successor in successors)
@@ -762,7 +793,7 @@ class _MicrogridComponentGraph(
         Returns:
             Whether the specified component is a CHP.
         """
-        return component.category == ComponentCategory.CHP
+        return isinstance(component, Chp)
 
     @override
     def is_chp_meter(self, component: Component) -> bool:
@@ -779,7 +810,7 @@ class _MicrogridComponentGraph(
         """
         successors = self.successors(component.id)
         return (
-            component.category == ComponentCategory.METER
+            isinstance(component, Meter)
             and not self.is_grid_meter(component)
             and len(successors) > 0
             and all(self.is_chp(successor) for successor in successors)
@@ -839,7 +870,7 @@ class _MicrogridComponentGraph(
     def find_first_descendant_component(
         self,
         *,
-        descendant_categories: Iterable[ComponentCategory],
+        descendants: Iterable[type[Component]],
     ) -> Component:
         """Find the first descendant component given root and descendant categories.
 
@@ -851,7 +882,7 @@ class _MicrogridComponentGraph(
         highest priority.
 
         Args:
-            descendant_categories: The descendant classes to search for the first
+            descendants: The descendant classes to search for the first
                 descendant component in.
 
         Returns:
@@ -862,33 +893,31 @@ class _MicrogridComponentGraph(
             InvalidGraphError: When no GRID component is found in the graph.
             ValueError: When no component is found in the given categories.
         """
+        # We always sort by component ID to ensure consistent results
+
+        def sorted_by_id(components: Iterable[Component]) -> Iterable[Component]:
+            return sorted(components, key=lambda c: c.id)
+
         root_component = next(
-            (
-                comp
-                for comp in self.components(
-                    component_categories={ComponentCategory.GRID}
-                )
-            ),
+            iter(sorted_by_id(self.components(matching_types={GridConnectionPoint}))),
             None,
         )
         if root_component is None:
-            raise InvalidGraphError("No GRID component found in the component graph!")
+            raise InvalidGraphError(
+                "No GridConnectionPoint component found in the component graph!"
+            )
 
-        # Sort by component ID to ensure consistent results.
-        successors = sorted(
-            self.successors(root_component.id),
-            key=lambda comp: comp.id,
-        )
+        successors = sorted_by_id(self.successors(root_component.id))
 
-        def find_component(component_category: ComponentCategory) -> Component | None:
+        def find_component(component_class: type[Component]) -> Component | None:
             return next(
-                (comp for comp in successors if comp.category == component_category),
+                (comp for comp in successors if isinstance(comp, component_class)),
                 None,
             )
 
         # Find the first component that matches the given descendant categories
         # in the order of the categories list.
-        component = next(filter(None, map(find_component, descendant_categories)), None)
+        component = next(filter(None, map(find_component, descendants)), None)
 
         if component is None:
             raise ValueError("Component not found in any of the descendant categories.")
@@ -920,9 +949,10 @@ class _MicrogridComponentGraph(
         if undefined := [
             node[0] for node in self._graph.nodes(data=True) if len(node[1]) == 0
         ]:
-            undefined_str = ", ".join(map(str, sorted(undefined)))
+            undefined_str = ", ".join(map(str, map(int, sorted(undefined))))
             raise InvalidGraphError(
-                f"Missing definition for graph components: {undefined_str}"
+                "Some component IDs found in connections are missing a "
+                f"component definition: {undefined_str}"
             )
 
         # should be true as a consequence of checks above
@@ -951,20 +981,19 @@ class _MicrogridComponentGraph(
             self.components(),
         )
 
-        valid_root_types = {
-            ComponentCategory.NONE,
-            ComponentCategory.GRID,
-        }
-
         valid_roots = list(
-            filter(lambda c: c.category in valid_root_types, no_predecessors)
+            filter(
+                lambda c: isinstance(c, (GridConnectionPoint, UnspecifiedComponent)),
+                no_predecessors,
+            )
         )
 
         if len(valid_roots) == 0:
             raise InvalidGraphError("No valid root nodes of component graph!")
 
         if len(valid_roots) > 1:
-            raise InvalidGraphError(f"Multiple potential root nodes: {valid_roots}")
+            root_nodes = ", ".join(map(str, sorted(valid_roots, key=lambda c: c.id)))
+            raise InvalidGraphError(f"Multiple potential root nodes: {root_nodes}")
 
         root = valid_roots[0]
         if self._graph.out_degree(root.id) == 0:
@@ -980,7 +1009,7 @@ class _MicrogridComponentGraph(
                 it has no successors in the graph (i.e. it is not connected to
                 anything).
         """
-        grid = list(self.components(component_categories={ComponentCategory.GRID}))
+        grid = list(self.components(matching_types={GridConnectionPoint}))
 
         if len(grid) == 0:
             # it's OK to not have a grid endpoint as long as other properties
@@ -994,15 +1023,13 @@ class _MicrogridComponentGraph(
 
         grid_id = grid[0].id
         if self._graph.in_degree(grid_id) > 0:
-            grid_predecessors = list(self.predecessors(grid_id))
-            raise InvalidGraphError(
-                f"Grid endpoint with {grid_id} has graph predecessors: {grid_predecessors}"
+            pred = ", ".join(
+                map(str, sorted(self.predecessors(grid_id), key=lambda c: c.id))
             )
+            raise InvalidGraphError(f"Grid endpoint {grid_id} has predecessors: {pred}")
 
         if self._graph.out_degree(grid_id) == 0:
-            raise InvalidGraphError(
-                f"Grid endpoint with {grid_id} has no graph successors!"
-            )
+            raise InvalidGraphError(f"Grid endpoint {grid_id} has no graph successors!")
 
     def _validate_intermediary_components(self) -> None:
         """Check that intermediary components (e.g. meters) are configured correctly.
@@ -1014,9 +1041,7 @@ class _MicrogridComponentGraph(
             InvalidGraphError: If any intermediary component has zero predecessors
                 or zero successors.
         """
-        intermediary_components = list(
-            self.components(component_categories={ComponentCategory.INVERTER})
-        )
+        intermediary_components = list(self.components(matching_types={Inverter}))
 
         missing_predecessors = list(
             filter(
@@ -1027,7 +1052,7 @@ class _MicrogridComponentGraph(
         if len(missing_predecessors) > 0:
             raise InvalidGraphError(
                 "Intermediary components without graph predecessors: "
-                f"{missing_predecessors}"
+                f"{list(map(str, missing_predecessors))}"
             )
 
     def _validate_leaf_components(self) -> None:
@@ -1043,9 +1068,9 @@ class _MicrogridComponentGraph(
         """
         leaf_components = list(
             self.components(
-                component_categories={
-                    ComponentCategory.BATTERY,
-                    ComponentCategory.EV_CHARGER,
+                matching_types={
+                    Battery,
+                    EvCharger,
                 }
             )
         )

--- a/src/frequenz/sdk/microgrid/component_graph.py
+++ b/src/frequenz/sdk/microgrid/component_graph.py
@@ -35,7 +35,7 @@ from frequenz.client.microgrid.component import (
     Chp,
     Component,
     ComponentCategory,
-    Connection,
+    ComponentConnection,
     EvCharger,
     GridConnectionPoint,
     Inverter,
@@ -83,18 +83,18 @@ class ComponentGraph(ABC):
     @abstractmethod
     def connections(
         self,
-        start: set[ComponentId] | None = None,
-        end: set[ComponentId] | None = None,
-    ) -> set[Connection]:
+        matching_sources: set[ComponentId] | None = None,
+        matching_destinations: set[ComponentId] | None = None,
+    ) -> set[ComponentConnection]:
         """Fetch the connections between microgrid components.
 
         Args:
-            start: The component IDs that the connections' start must match.
-            end: The component IDs that the connections' end must match.
+            matching_sources: The component IDs the connections' source must match.
+            matching_destinations: The component IDs the connections' destination must match.
 
         Returns:
             The set of connections between components in the microgrid, filtered by
-                the provided `start`/`end` choices.
+                the provided `matching_sources` and `matching_destinations` choices.
         """
 
     @abstractmethod
@@ -355,7 +355,7 @@ class _MicrogridComponentGraph(
     def __init__(
         self,
         components: set[Component] | None = None,
-        connections: set[Connection] | None = None,
+        connections: set[ComponentConnection] | None = None,
     ) -> None:
         """Initialize the component graph.
 
@@ -433,32 +433,33 @@ class _MicrogridComponentGraph(
     @override
     def connections(
         self,
-        start: set[ComponentId] | None = None,
-        end: set[ComponentId] | None = None,
-    ) -> set[Connection]:
+        matching_sources: set[ComponentId] | None = None,
+        matching_destinations: set[ComponentId] | None = None,
+    ) -> set[ComponentConnection]:
         """Fetch the connections between microgrid components.
 
         Args:
-            start: The component IDs that the connections' start must match.
-            end: The component IDs that the connections' end must match.
+            matching_sources: The component IDs that the connections' source must match.
+            matching_destinations: The component IDs that the connections' destination
+                must match.
 
         Returns:
             The set of connections between components in the microgrid, filtered by
-                the provided `start`/`end` choices.
+                the provided `matching_sources` and `matching_destinations` choices.
         """
-        match (start, end):
+        match (matching_sources, matching_destinations):
             case (None, None):
-                selection_ids = self._graph.edges
+                selection = self._graph.edges
             case (None, _):
-                selection_ids = self._graph.in_edges(end)
+                selection = self._graph.in_edges(matching_destinations)
             case (_, None):
-                selection_ids = self._graph.out_edges(start)
+                selection = self._graph.out_edges(matching_sources)
             case (_, _):
-                start_edges = self._graph.out_edges(start)
-                end_edges = self._graph.in_edges(end)
-                selection_ids = set(start_edges).intersection(end_edges)
+                source_edges = self._graph.out_edges(matching_sources)
+                destination_edges = self._graph.in_edges(matching_destinations)
+                selection = set(source_edges).intersection(destination_edges)
 
-        return set(self._graph.edges[i][_DATA_KEY] for i in selection_ids)
+        return set(self._graph.edges[i][_DATA_KEY] for i in selection)
 
     @override
     def predecessors(self, component_id: ComponentId) -> set[Component]:
@@ -512,7 +513,7 @@ class _MicrogridComponentGraph(
     def refresh_from(
         self,
         components: set[Component],
-        connections: set[Connection],
+        connections: set[ComponentConnection],
         correct_errors: Callable[["_MicrogridComponentGraph"], None] | None = None,
     ) -> None:
         """Refresh the graph from the provided list of components and connections.
@@ -523,7 +524,8 @@ class _MicrogridComponentGraph(
         Args:
             components: The components to initialize the graph with. If set, must
                 provide `connections` as well.
-            connections: The connections to include in the graph.
+            connections: The connections to initialize the graph with. If set, must
+                provide `components` as well.
             correct_errors: The callback that, if set, will be invoked if the
                 provided graph data is in any way invalid (it will attempt to
                 correct the errors by inferring what the correct data should be).
@@ -534,9 +536,9 @@ class _MicrogridComponentGraph(
                 not fix it.
         """
         issues: list[str] = []
-        if not all(connection.is_valid() for connection in connections):
-            raise InvalidGraphError(f"Invalid connections in input: {connections}")
 
+        for connection in connections:
+            issues.extend((self._validate_connection(connection)))
         for component in components:
             issues.extend((self._validate_component(component)))
 
@@ -550,10 +552,10 @@ class _MicrogridComponentGraph(
 
         # Store the original connection object in the edge data (third item in the
         # tuple) so that we can retrieve it later.
-        for connection in connections:
-            new_graph.add_edge(
-                connection.start, connection.end, **{_DATA_KEY: connection}
-            )
+        new_graph.add_edges_from(
+            (connection.source, connection.destination, {_DATA_KEY: connection})
+            for connection in connections
+        )
 
         # check if we can construct a valid ComponentGraph
         # from the new NetworkX graph data
@@ -577,6 +579,20 @@ class _MicrogridComponentGraph(
         old_graph = self._graph
         self._graph = new_graph
         old_graph.clear()  # just in case any references remain, but should not
+
+    def _validate_connection(self, connection: ComponentConnection) -> list[str]:
+        """Check that the connection is valid.
+
+        Args:
+            connection: connection to validate.
+
+        Returns:
+            List of issues found with the connection.
+        """
+        issues: list[str] = []
+        if connection.source == connection.destination:
+            issues.append(f"Connection {connection} has same source and destination!")
+        return issues
 
     def _validate_component(self, component: Component) -> list[str]:
         """Check that the component is valid.

--- a/src/frequenz/sdk/microgrid/component_graph.py
+++ b/src/frequenz/sdk/microgrid/component_graph.py
@@ -558,8 +558,8 @@ class _MicrogridComponentGraph(
                 correct the errors by inferring what the correct data should be).
         """
         components, connections = await asyncio.gather(
-            api.components(),
-            api.connections(),
+            api.list_components(),
+            api.list_connections(),
         )
 
         self.refresh_from(set(components), set(connections), correct_errors)

--- a/src/frequenz/sdk/microgrid/component_graph.py
+++ b/src/frequenz/sdk/microgrid/component_graph.py
@@ -544,22 +544,22 @@ class _MicrogridComponentGraph(
         self._graph = new_graph
         old_graph.clear()  # just in case any references remain, but should not
 
-    async def refresh_from_api(
+    async def refresh_from_client(
         self,
-        api: MicrogridApiClient,
+        client: MicrogridApiClient,
         correct_errors: Callable[["_MicrogridComponentGraph"], None] | None = None,
     ) -> None:
         """Refresh the contents of a component graph from the remote API.
 
         Args:
-            api: The API client from which to fetch graph data.
+            client: The API client from which to fetch graph data
             correct_errors: The callback that, if set, will be invoked if the
                 provided graph data is in any way invalid (it will attempt to
                 correct the errors by inferring what the correct data should be).
         """
         components, connections = await asyncio.gather(
-            api.list_components(),
-            api.list_connections(),
+            client.list_components(),
+            client.list_connections(),
         )
 
         self.refresh_from(set(components), set(connections), correct_errors)

--- a/src/frequenz/sdk/microgrid/component_graph.py
+++ b/src/frequenz/sdk/microgrid/component_graph.py
@@ -24,7 +24,7 @@ flow of power.
 import asyncio
 import logging
 from abc import ABC, abstractmethod
-from collections.abc import Callable, Iterable
+from collections.abc import Callable, Iterable, Set
 
 import networkx as nx
 from frequenz.client.common.microgrid.components import ComponentId
@@ -66,8 +66,8 @@ class ComponentGraph(ABC):
     @abstractmethod
     def components(
         self,
-        matching_ids: set[ComponentId] | None = None,
-        matching_types: set[type[Component]] | None = None,
+        matching_ids: Iterable[ComponentId] | ComponentId | None = None,
+        matching_types: Iterable[type[Component]] | type[Component] | None = None,
     ) -> set[Component]:
         """Fetch the components of the microgrid.
 
@@ -386,8 +386,8 @@ class _MicrogridComponentGraph(
     @override
     def components(
         self,
-        matching_ids: set[ComponentId] | None = None,
-        matching_types: set[type[Component]] | None = None,
+        matching_ids: Iterable[ComponentId] | ComponentId | None = None,
+        matching_types: Iterable[type[Component]] | type[Component] | None = None,
     ) -> set[Component]:
         """Fetch the components of the microgrid.
 
@@ -399,6 +399,22 @@ class _MicrogridComponentGraph(
             The set of components currently connected to the microgrid, filtered by
                 the provided `matching_ids` and `matching_types` values.
         """
+        match matching_ids:
+            case ComponentId():
+                matching_ids = {matching_ids}
+            case Set():
+                pass
+            case Iterable():
+                matching_ids = set(matching_ids)
+
+        match matching_types:
+            case type():
+                matching_types = {matching_types}
+            case Set():
+                pass
+            case Iterable():
+                matching_types = set(matching_types)
+
         selection: Iterable[Component]
         selection_ids = (
             self._graph.nodes

--- a/src/frequenz/sdk/microgrid/component_graph.py
+++ b/src/frequenz/sdk/microgrid/component_graph.py
@@ -512,7 +512,7 @@ class _MicrogridComponentGraph(
 
         new_graph = nx.DiGraph()
         for component in components:
-            new_graph.add_node(component.component_id, **{_DATA_KEY: component})
+            new_graph.add_node(component.id, **{_DATA_KEY: component})
 
         # Store the original connection object in the edge data (third item in the
         # tuple) so that we can retrieve it later.
@@ -588,7 +588,7 @@ class _MicrogridComponentGraph(
         if component.category != ComponentCategory.METER:
             return False
 
-        predecessors = self.predecessors(component.component_id)
+        predecessors = self.predecessors(component.id)
         if len(predecessors) != 1:
             return False
 
@@ -596,7 +596,7 @@ class _MicrogridComponentGraph(
         if predecessor.category != ComponentCategory.GRID:
             return False
 
-        grid_successors = self.successors(predecessor.component_id)
+        grid_successors = self.successors(predecessor.id)
         return len(grid_successors) == 1
 
     @override
@@ -627,14 +627,14 @@ class _MicrogridComponentGraph(
         Returns:
             Whether the specified component is a PV meter.
         """
-        successors = self.successors(component.component_id)
+        successors = self.successors(component.id)
         return (
             component.category == ComponentCategory.METER
             and not self.is_grid_meter(component)
             and len(successors) > 0
             and all(
                 self.is_pv_inverter(successor)
-                for successor in self.successors(component.component_id)
+                for successor in self.successors(component.id)
             )
         )
 
@@ -678,7 +678,7 @@ class _MicrogridComponentGraph(
         Returns:
             Whether the specified component is an EV charger meter.
         """
-        successors = self.successors(component.component_id)
+        successors = self.successors(component.id)
         return (
             component.category == ComponentCategory.METER
             and not self.is_grid_meter(component)
@@ -729,7 +729,7 @@ class _MicrogridComponentGraph(
         Returns:
             Whether the specified component is a battery meter.
         """
-        successors = self.successors(component.component_id)
+        successors = self.successors(component.id)
         return (
             component.category == ComponentCategory.METER
             and not self.is_grid_meter(component)
@@ -777,7 +777,7 @@ class _MicrogridComponentGraph(
         Returns:
             Whether the specified component is a CHP meter.
         """
-        successors = self.successors(component.component_id)
+        successors = self.successors(component.id)
         return (
             component.category == ComponentCategory.METER
             and not self.is_grid_meter(component)
@@ -830,7 +830,7 @@ class _MicrogridComponentGraph(
 
         component: set[Component] = set()
 
-        for successor in self.successors(current_node.component_id):
+        for successor in self.successors(current_node.id):
             component.update(self.dfs(successor, visited, condition))
 
         return component
@@ -876,8 +876,8 @@ class _MicrogridComponentGraph(
 
         # Sort by component ID to ensure consistent results.
         successors = sorted(
-            self.successors(root_component.component_id),
-            key=lambda comp: comp.component_id,
+            self.successors(root_component.id),
+            key=lambda comp: comp.id,
         )
 
         def find_component(component_category: ComponentCategory) -> Component | None:
@@ -933,9 +933,7 @@ class _MicrogridComponentGraph(
 
         # should be true as a consequence of the tree property:
         # there should be no unconnected components
-        unconnected = filter(
-            lambda c: self._graph.degree(c.component_id) == 0, self.components()
-        )
+        unconnected = filter(lambda c: self._graph.degree(c.id) == 0, self.components())
         if sum(1 for _ in unconnected) != 0:
             raise InvalidGraphError(
                 "Every component must have at least one connection!"
@@ -949,7 +947,7 @@ class _MicrogridComponentGraph(
                 or if there is a single such node that is not one of NONE or GRID.
         """
         no_predecessors = filter(
-            lambda c: self._graph.in_degree(c.component_id) == 0,
+            lambda c: self._graph.in_degree(c.id) == 0,
             self.components(),
         )
 
@@ -969,7 +967,7 @@ class _MicrogridComponentGraph(
             raise InvalidGraphError(f"Multiple potential root nodes: {valid_roots}")
 
         root = valid_roots[0]
-        if self._graph.out_degree(root.component_id) == 0:
+        if self._graph.out_degree(root.id) == 0:
             raise InvalidGraphError(f"Graph root {root} has no successors!")
 
     def _validate_grid_endpoint(self) -> None:
@@ -994,7 +992,7 @@ class _MicrogridComponentGraph(
                 f"Multiple grid endpoints in component graph: {grid}"
             )
 
-        grid_id = grid[0].component_id
+        grid_id = grid[0].id
         if self._graph.in_degree(grid_id) > 0:
             grid_predecessors = list(self.predecessors(grid_id))
             raise InvalidGraphError(
@@ -1022,7 +1020,7 @@ class _MicrogridComponentGraph(
 
         missing_predecessors = list(
             filter(
-                lambda c: sum(1 for _ in self.predecessors(c.component_id)) == 0,
+                lambda c: sum(1 for _ in self.predecessors(c.id)) == 0,
                 intermediary_components,
             )
         )
@@ -1054,7 +1052,7 @@ class _MicrogridComponentGraph(
 
         missing_predecessors = list(
             filter(
-                lambda c: sum(1 for _ in self.predecessors(c.component_id)) == 0,
+                lambda c: sum(1 for _ in self.predecessors(c.id)) == 0,
                 leaf_components,
             )
         )
@@ -1065,7 +1063,7 @@ class _MicrogridComponentGraph(
 
         with_successors = list(
             filter(
-                lambda c: sum(1 for _ in self.successors(c.component_id)) > 0,
+                lambda c: sum(1 for _ in self.successors(c.id)) > 0,
                 leaf_components,
             )
         )

--- a/src/frequenz/sdk/microgrid/connection_manager.py
+++ b/src/frequenz/sdk/microgrid/connection_manager.py
@@ -76,7 +76,7 @@ class ConnectionManager(ABC):
             the location of the microgrid if available, None otherwise.
         """
 
-    async def _update_api(self, server_url: str) -> None:
+    async def _update_client(self, server_url: str) -> None:
         self._server_url = server_url
 
     @abstractmethod
@@ -98,8 +98,8 @@ class _InsecureConnectionManager(ConnectionManager):
                 `grpc://localhost:1090?ssl=true`.
         """
         super().__init__(server_url)
-        self._api = MicrogridApiClient(server_url)
-        # To create graph from the api we need await.
+        self._client = MicrogridApiClient(server_url)
+        # To create graph from the API client we need await.
         # So create empty graph here, and update it in `run` method.
         self._graph = _MicrogridComponentGraph()
 
@@ -108,12 +108,8 @@ class _InsecureConnectionManager(ConnectionManager):
 
     @property
     def api_client(self) -> MicrogridApiClient:
-        """Get the MicrogridApiClient.
-
-        Returns:
-            api client
-        """
-        return self._api
+        """The microgrid API client used by this connection manager."""
+        return self._client
 
     @property
     def microgrid_id(self) -> MicrogridId | None:
@@ -142,8 +138,8 @@ class _InsecureConnectionManager(ConnectionManager):
         """
         return self._graph
 
-    async def _update_api(self, server_url: str) -> None:
-        """Update api with new host and port.
+    async def _update_client(self, server_url: str) -> None:
+        """Update the API client with a new server URL.
 
         Args:
             server_url: The new location of the microgrid API server in the form of a
@@ -153,14 +149,14 @@ class _InsecureConnectionManager(ConnectionManager):
                 a boolean (defaulting to false). For example:
                 `grpc://localhost:1090?ssl=true`.
         """
-        await super()._update_api(server_url)  # pylint: disable=protected-access
+        await super()._update_client(server_url)  # pylint: disable=protected-access
 
-        self._api = MicrogridApiClient(server_url)
+        self._client = MicrogridApiClient(server_url)
         await self._initialize()
 
     async def _initialize(self) -> None:
-        self._metadata = await self._api.get_microgrid_info()
-        await self._graph.refresh_from_api(self._api)
+        self._metadata = await self._client.get_microgrid_info()
+        await self._graph.refresh_from_client(self._client)
 
 
 _CONNECTION_MANAGER: ConnectionManager | None = None

--- a/src/frequenz/sdk/microgrid/connection_manager.py
+++ b/src/frequenz/sdk/microgrid/connection_manager.py
@@ -159,7 +159,7 @@ class _InsecureConnectionManager(ConnectionManager):
         await self._initialize()
 
     async def _initialize(self) -> None:
-        self._metadata = await self._api.metadata()
+        self._metadata = await self._api.get_microgrid_info()
         await self._graph.refresh_from_api(self._api)
 
 

--- a/src/frequenz/sdk/microgrid/connection_manager.py
+++ b/src/frequenz/sdk/microgrid/connection_manager.py
@@ -12,7 +12,7 @@ import logging
 from abc import ABC, abstractmethod
 
 from frequenz.client.common.microgrid import MicrogridId
-from frequenz.client.microgrid import Location, Metadata, MicrogridApiClient
+from frequenz.client.microgrid import Location, MicrogridApiClient, MicrogridInfo
 
 from .component_graph import ComponentGraph, _MicrogridComponentGraph
 
@@ -103,8 +103,8 @@ class _InsecureConnectionManager(ConnectionManager):
         # So create empty graph here, and update it in `run` method.
         self._graph = _MicrogridComponentGraph()
 
-        self._metadata: Metadata
-        """The metadata of the microgrid."""
+        self._microgrid: MicrogridInfo
+        """The microgrid information."""
 
     @property
     def api_client(self) -> MicrogridApiClient:
@@ -118,7 +118,7 @@ class _InsecureConnectionManager(ConnectionManager):
         Returns:
             the ID of the microgrid if available, None otherwise.
         """
-        return self._metadata.microgrid_id
+        return self._microgrid.id
 
     @property
     def location(self) -> Location | None:
@@ -127,7 +127,7 @@ class _InsecureConnectionManager(ConnectionManager):
         Returns:
             the location of the microgrid if available, None otherwise.
         """
-        return self._metadata.location
+        return self._microgrid.location
 
     @property
     def component_graph(self) -> ComponentGraph:
@@ -155,7 +155,7 @@ class _InsecureConnectionManager(ConnectionManager):
         await self._initialize()
 
     async def _initialize(self) -> None:
-        self._metadata = await self._client.get_microgrid_info()
+        self._microgrid = await self._client.get_microgrid_info()
         await self._graph.refresh_from_client(self._client)
 
 

--- a/src/frequenz/sdk/timeseries/_grid_frequency.py
+++ b/src/frequenz/sdk/timeseries/_grid_frequency.py
@@ -68,7 +68,7 @@ class GridFrequency:
         self._channel_registry: ChannelRegistry = channel_registry
         self._source_component: Component = source
         self._component_metric_request: ComponentMetricRequest = create_request(
-            self._source_component.component_id
+            self._source_component.id
         )
 
         self._task: None | asyncio.Task[None] = None

--- a/src/frequenz/sdk/timeseries/_grid_frequency.py
+++ b/src/frequenz/sdk/timeseries/_grid_frequency.py
@@ -10,7 +10,7 @@ import logging
 
 from frequenz.channels import Receiver, Sender
 from frequenz.client.common.microgrid.components import ComponentId
-from frequenz.client.microgrid import Component, ComponentCategory
+from frequenz.client.microgrid.component import Component, EvCharger, Inverter, Meter
 from frequenz.client.microgrid.metrics import Metric
 from frequenz.quantities import Frequency, Quantity
 
@@ -55,11 +55,7 @@ class GridFrequency:
         if not source:
             component_graph = connection_manager.get().component_graph
             source = component_graph.find_first_descendant_component(
-                descendant_categories=(
-                    ComponentCategory.METER,
-                    ComponentCategory.INVERTER,
-                    ComponentCategory.EV_CHARGER,
-                ),
+                descendants=[Meter, Inverter, EvCharger],
             )
 
         self._request_sender: Sender[ComponentMetricRequest] = (

--- a/src/frequenz/sdk/timeseries/_grid_frequency.py
+++ b/src/frequenz/sdk/timeseries/_grid_frequency.py
@@ -10,7 +10,8 @@ import logging
 
 from frequenz.channels import Receiver, Sender
 from frequenz.client.common.microgrid.components import ComponentId
-from frequenz.client.microgrid import Component, ComponentCategory, ComponentMetricId
+from frequenz.client.microgrid import Component, ComponentCategory
+from frequenz.client.microgrid.metrics import Metric
 from frequenz.quantities import Frequency, Quantity
 
 from .._internal._channels import ChannelRegistry
@@ -31,7 +32,7 @@ def create_request(component_id: ComponentId) -> ComponentMetricRequest:
         A component metric request for grid frequency.
     """
     return ComponentMetricRequest(
-        "grid-frequency", component_id, ComponentMetricId.FREQUENCY, None
+        "grid-frequency", component_id, Metric.AC_FREQUENCY, None
     )
 
 

--- a/src/frequenz/sdk/timeseries/_voltage_streamer.py
+++ b/src/frequenz/sdk/timeseries/_voltage_streamer.py
@@ -146,7 +146,7 @@ class VoltageStreamer:
         phases_rx: list[Receiver[Sample[Quantity]]] = []
         for metric in metrics:
             req = ComponentMetricRequest(
-                self._namespace, self._source_component.component_id, metric, None
+                self._namespace, self._source_component.id, metric, None
             )
 
             await self._resampler_subscription_sender.send(req)

--- a/src/frequenz/sdk/timeseries/_voltage_streamer.py
+++ b/src/frequenz/sdk/timeseries/_voltage_streamer.py
@@ -14,7 +14,7 @@ import logging
 from typing import TYPE_CHECKING
 
 from frequenz.channels import Receiver, Sender
-from frequenz.client.microgrid import Component, ComponentCategory
+from frequenz.client.microgrid.component import Component, EvCharger, Inverter, Meter
 from frequenz.client.microgrid.metrics import Metric
 from frequenz.quantities import Quantity, Voltage
 
@@ -82,11 +82,7 @@ class VoltageStreamer:
         if not source_component:
             component_graph = connection_manager.get().component_graph
             source_component = component_graph.find_first_descendant_component(
-                descendant_categories=[
-                    ComponentCategory.METER,
-                    ComponentCategory.INVERTER,
-                    ComponentCategory.EV_CHARGER,
-                ],
+                descendants=[Meter, Inverter, EvCharger],
             )
 
         self._source_component = source_component

--- a/src/frequenz/sdk/timeseries/_voltage_streamer.py
+++ b/src/frequenz/sdk/timeseries/_voltage_streamer.py
@@ -14,7 +14,8 @@ import logging
 from typing import TYPE_CHECKING
 
 from frequenz.channels import Receiver, Sender
-from frequenz.client.microgrid import Component, ComponentCategory, ComponentMetricId
+from frequenz.client.microgrid import Component, ComponentCategory
+from frequenz.client.microgrid.metrics import Metric
 from frequenz.quantities import Quantity, Voltage
 
 from .._internal._channels import ChannelRegistry
@@ -137,15 +138,15 @@ class VoltageStreamer:
             ComponentMetricRequest,
         )
 
-        metric_ids = (
-            ComponentMetricId.VOLTAGE_PHASE_1,
-            ComponentMetricId.VOLTAGE_PHASE_2,
-            ComponentMetricId.VOLTAGE_PHASE_3,
+        metrics = (
+            Metric.AC_VOLTAGE_PHASE_1_N,
+            Metric.AC_VOLTAGE_PHASE_2_N,
+            Metric.AC_VOLTAGE_PHASE_3_N,
         )
         phases_rx: list[Receiver[Sample[Quantity]]] = []
-        for metric_id in metric_ids:
+        for metric in metrics:
             req = ComponentMetricRequest(
-                self._namespace, self._source_component.component_id, metric_id, None
+                self._namespace, self._source_component.component_id, metric, None
             )
 
             await self._resampler_subscription_sender.send(req)

--- a/src/frequenz/sdk/timeseries/battery_pool/_battery_pool_reference_store.py
+++ b/src/frequenz/sdk/timeseries/battery_pool/_battery_pool_reference_store.py
@@ -142,7 +142,7 @@ class BatteryPoolReferenceStore:  # pylint: disable=too-many-instance-attributes
         """
         graph = connection_manager.get().component_graph
         return frozenset(
-            battery.id for battery in graph.components(matching_types={Battery})
+            battery.id for battery in graph.components(matching_types=Battery)
         )
 
     async def _update_battery_status(

--- a/src/frequenz/sdk/timeseries/battery_pool/_battery_pool_reference_store.py
+++ b/src/frequenz/sdk/timeseries/battery_pool/_battery_pool_reference_store.py
@@ -142,12 +142,10 @@ class BatteryPoolReferenceStore:  # pylint: disable=too-many-instance-attributes
         """
         graph = connection_manager.get().component_graph
         return frozenset(
-            {
-                battery.component_id
-                for battery in graph.components(
-                    component_categories={ComponentCategory.BATTERY}
-                )
-            }
+            battery.id
+            for battery in graph.components(
+                component_categories={ComponentCategory.BATTERY}
+            )
         )
 
     async def _update_battery_status(

--- a/src/frequenz/sdk/timeseries/battery_pool/_battery_pool_reference_store.py
+++ b/src/frequenz/sdk/timeseries/battery_pool/_battery_pool_reference_store.py
@@ -12,7 +12,7 @@ from typing import Any
 
 from frequenz.channels import Receiver, Sender
 from frequenz.client.common.microgrid.components import ComponentId
-from frequenz.client.microgrid import ComponentCategory
+from frequenz.client.microgrid.component import Battery
 
 from ..._internal._asyncio import cancel_and_await
 from ..._internal._channels import ChannelRegistry, ReceiverFetcher
@@ -142,10 +142,7 @@ class BatteryPoolReferenceStore:  # pylint: disable=too-many-instance-attributes
         """
         graph = connection_manager.get().component_graph
         return frozenset(
-            battery.id
-            for battery in graph.components(
-                component_categories={ComponentCategory.BATTERY}
-            )
+            battery.id for battery in graph.components(matching_types={Battery})
         )
 
     async def _update_battery_status(

--- a/src/frequenz/sdk/timeseries/battery_pool/_component_metric_fetcher.py
+++ b/src/frequenz/sdk/timeseries/battery_pool/_component_metric_fetcher.py
@@ -16,10 +16,7 @@ from typing import Any, Generic, Self, TypeVar
 from frequenz.channels import ChannelClosedError, Receiver
 from frequenz.client.common.microgrid.components import ComponentId
 from frequenz.client.microgrid import (
-    BatteryData,
     ComponentCategory,
-    ComponentData,
-    InverterData,
 )
 from frequenz.client.microgrid.metrics import Metric
 from typing_extensions import override
@@ -32,6 +29,9 @@ from ...microgrid._data_sourcing.microgrid_api_source import (
     _InverterDataMethods,
 )
 from ...microgrid._old_component_data import (
+    BatteryData,
+    ComponentData,
+    InverterData,
     TransitionalMetric,
 )
 from ._component_metrics import ComponentMetricsData
@@ -114,7 +114,7 @@ class LatestMetricsFetcher(ComponentMetricFetcher, Generic[T], ABC):
                 category = self._component_category()
                 raise ValueError(f"Metric {metric} not supported for {category}")
 
-        self._receiver = await self._subscribe()
+        self._receiver = self._subscribe()
         self._max_waiting_time = MAX_BATTERY_DATA_AGE_SEC
         # pylint: enable=protected-access
         return self
@@ -171,7 +171,7 @@ class LatestMetricsFetcher(ComponentMetricFetcher, Generic[T], ABC):
     def _component_category(self) -> ComponentCategory: ...
 
     @abstractmethod
-    async def _subscribe(self) -> Receiver[Any]:
+    def _subscribe(self) -> Receiver[Any]:
         """Subscribe for this component data.
 
         Size of the receiver buffer should should be 1 to make sure we receive only
@@ -223,7 +223,7 @@ class LatestBatteryMetricsFetcher(LatestMetricsFetcher[BatteryData]):
         return _BatteryDataMethods[metric](data)
 
     @override
-    async def _subscribe(self) -> Receiver[BatteryData]:
+    def _subscribe(self) -> Receiver[BatteryData]:
         """Subscribe for this component data.
 
         Size of the receiver buffer should should be 1 to make sure we receive only
@@ -233,7 +233,7 @@ class LatestBatteryMetricsFetcher(LatestMetricsFetcher[BatteryData]):
             Receiver for this component metrics.
         """
         api = connection_manager.get().api_client
-        return await api.battery_data(self._component_id, maxsize=1)
+        return BatteryData.subscribe(api, self._component_id, buffer_size=1)
 
     @override
     def _component_category(self) -> ComponentCategory:
@@ -281,7 +281,7 @@ class LatestInverterMetricsFetcher(LatestMetricsFetcher[InverterData]):
         return _InverterDataMethods[metric](data)
 
     @override
-    async def _subscribe(self) -> Receiver[InverterData]:
+    def _subscribe(self) -> Receiver[InverterData]:
         """Subscribe for this component data.
 
         Size of the receiver buffer should should be 1 to make sure we receive only
@@ -291,7 +291,7 @@ class LatestInverterMetricsFetcher(LatestMetricsFetcher[InverterData]):
             Receiver for this component metrics.
         """
         api = connection_manager.get().api_client
-        return await api.inverter_data(self._component_id, maxsize=1)
+        return InverterData.subscribe(api, self._component_id, buffer_size=1)
 
     @override
     def _component_category(self) -> ComponentCategory:

--- a/src/frequenz/sdk/timeseries/battery_pool/_component_metric_fetcher.py
+++ b/src/frequenz/sdk/timeseries/battery_pool/_component_metric_fetcher.py
@@ -15,9 +15,7 @@ from typing import Any, Generic, Self, TypeVar
 
 from frequenz.channels import ChannelClosedError, Receiver
 from frequenz.client.common.microgrid.components import ComponentId
-from frequenz.client.microgrid import (
-    ComponentCategory,
-)
+from frequenz.client.microgrid.component import ComponentCategory
 from frequenz.client.microgrid.metrics import Metric
 from typing_extensions import override
 

--- a/src/frequenz/sdk/timeseries/battery_pool/_component_metric_fetcher.py
+++ b/src/frequenz/sdk/timeseries/battery_pool/_component_metric_fetcher.py
@@ -19,9 +19,9 @@ from frequenz.client.microgrid import (
     BatteryData,
     ComponentCategory,
     ComponentData,
-    ComponentMetricId,
     InverterData,
 )
+from frequenz.client.microgrid.metrics import Metric
 from typing_extensions import override
 
 from ..._internal._asyncio import AsyncConstructible
@@ -30,6 +30,9 @@ from ...microgrid import connection_manager
 from ...microgrid._data_sourcing.microgrid_api_source import (
     _BatteryDataMethods,
     _InverterDataMethods,
+)
+from ...microgrid._old_component_data import (
+    TransitionalMetric,
 )
 from ._component_metrics import ComponentMetricsData
 
@@ -43,11 +46,11 @@ class ComponentMetricFetcher(AsyncConstructible, ABC):
     """Define how to subscribe for and fetch the component metrics data."""
 
     _component_id: ComponentId
-    _metrics: Iterable[ComponentMetricId]
+    _metrics: Iterable[Metric | TransitionalMetric]
 
     @classmethod
     async def async_new(
-        cls, component_id: ComponentId, metrics: Iterable[ComponentMetricId]
+        cls, component_id: ComponentId, metrics: Iterable[Metric | TransitionalMetric]
     ) -> Self:
         """Create an instance of this class.
 
@@ -86,7 +89,7 @@ class LatestMetricsFetcher(ComponentMetricFetcher, Generic[T], ABC):
     async def async_new(
         cls,
         component_id: ComponentId,
-        metrics: Iterable[ComponentMetricId],
+        metrics: Iterable[Metric | TransitionalMetric],
     ) -> Self:
         """Create instance of this class.
 
@@ -142,12 +145,12 @@ class LatestMetricsFetcher(ComponentMetricFetcher, Generic[T], ABC):
             )
 
         self._max_waiting_time = MAX_BATTERY_DATA_AGE_SEC
-        metrics = {}
-        for mid in self._metrics:
-            value = self._extract_metric(data, mid)
+        metrics: dict[Metric | TransitionalMetric, float] = {}
+        for metric in self._metrics:
+            value = self._extract_metric(data, metric)
             # There is no guarantee that all fields in component message are populated
             if not math.isnan(value):
-                metrics[mid] = value
+                metrics[metric] = value
 
         return ComponentMetricsData(self._component_id, data.timestamp, metrics)
 
@@ -157,10 +160,12 @@ class LatestMetricsFetcher(ComponentMetricFetcher, Generic[T], ABC):
         self._receiver.close()
 
     @abstractmethod
-    def _extract_metric(self, data: T, mid: ComponentMetricId) -> float: ...
+    def _extract_metric(
+        self, data: T, metric: Metric | TransitionalMetric
+    ) -> float: ...
 
     @abstractmethod
-    def _supported_metrics(self) -> set[ComponentMetricId]: ...
+    def _supported_metrics(self) -> set[Metric | TransitionalMetric]: ...
 
     @abstractmethod
     def _component_category(self) -> ComponentCategory: ...
@@ -185,7 +190,7 @@ class LatestBatteryMetricsFetcher(LatestMetricsFetcher[BatteryData]):
     async def async_new(  # noqa: DOC502 (ValueError is raised indirectly super.async_new)
         cls,
         component_id: ComponentId,
-        metrics: Iterable[ComponentMetricId],
+        metrics: Iterable[Metric | TransitionalMetric],
     ) -> LatestBatteryMetricsFetcher:
         """Create instance of this class.
 
@@ -208,12 +213,14 @@ class LatestBatteryMetricsFetcher(LatestMetricsFetcher[BatteryData]):
         return self
 
     @override
-    def _supported_metrics(self) -> set[ComponentMetricId]:
+    def _supported_metrics(self) -> set[Metric | TransitionalMetric]:
         return set(_BatteryDataMethods.keys())
 
     @override
-    def _extract_metric(self, data: BatteryData, mid: ComponentMetricId) -> float:
-        return _BatteryDataMethods[mid](data)
+    def _extract_metric(
+        self, data: BatteryData, metric: Metric | TransitionalMetric
+    ) -> float:
+        return _BatteryDataMethods[metric](data)
 
     @override
     async def _subscribe(self) -> Receiver[BatteryData]:
@@ -241,7 +248,7 @@ class LatestInverterMetricsFetcher(LatestMetricsFetcher[InverterData]):
     async def async_new(  # noqa: DOC502 (ValueError is raised indirectly by super.async_new)
         cls,
         component_id: ComponentId,
-        metrics: Iterable[ComponentMetricId],
+        metrics: Iterable[Metric | TransitionalMetric],
     ) -> LatestInverterMetricsFetcher:
         """Create instance of this class.
 
@@ -264,12 +271,14 @@ class LatestInverterMetricsFetcher(LatestMetricsFetcher[InverterData]):
         return self
 
     @override
-    def _supported_metrics(self) -> set[ComponentMetricId]:
+    def _supported_metrics(self) -> set[Metric | TransitionalMetric]:
         return set(_InverterDataMethods.keys())
 
     @override
-    def _extract_metric(self, data: InverterData, mid: ComponentMetricId) -> float:
-        return _InverterDataMethods[mid](data)
+    def _extract_metric(
+        self, data: InverterData, metric: Metric | TransitionalMetric
+    ) -> float:
+        return _InverterDataMethods[metric](data)
 
     @override
     async def _subscribe(self) -> Receiver[InverterData]:

--- a/src/frequenz/sdk/timeseries/battery_pool/_component_metric_fetcher.py
+++ b/src/frequenz/sdk/timeseries/battery_pool/_component_metric_fetcher.py
@@ -82,6 +82,7 @@ class LatestMetricsFetcher(ComponentMetricFetcher, Generic[T], ABC):
     _max_waiting_time: float
 
     @classmethod
+    @override
     async def async_new(
         cls,
         component_id: ComponentId,
@@ -115,6 +116,7 @@ class LatestMetricsFetcher(ComponentMetricFetcher, Generic[T], ABC):
         # pylint: enable=protected-access
         return self
 
+    @override
     async def fetch_next(self) -> ComponentMetricsData | None:
         """Fetch the latest component metrics.
 
@@ -179,6 +181,7 @@ class LatestBatteryMetricsFetcher(LatestMetricsFetcher[BatteryData]):
     """Subscribe for the latest battery data using MicrogridApiClient."""
 
     @classmethod
+    @override
     async def async_new(  # noqa: DOC502 (ValueError is raised indirectly super.async_new)
         cls,
         component_id: ComponentId,
@@ -204,12 +207,15 @@ class LatestBatteryMetricsFetcher(LatestMetricsFetcher[BatteryData]):
         )
         return self
 
+    @override
     def _supported_metrics(self) -> set[ComponentMetricId]:
         return set(_BatteryDataMethods.keys())
 
+    @override
     def _extract_metric(self, data: BatteryData, mid: ComponentMetricId) -> float:
         return _BatteryDataMethods[mid](data)
 
+    @override
     async def _subscribe(self) -> Receiver[BatteryData]:
         """Subscribe for this component data.
 
@@ -222,6 +228,7 @@ class LatestBatteryMetricsFetcher(LatestMetricsFetcher[BatteryData]):
         api = connection_manager.get().api_client
         return await api.battery_data(self._component_id, maxsize=1)
 
+    @override
     def _component_category(self) -> ComponentCategory:
         return ComponentCategory.BATTERY
 
@@ -230,6 +237,7 @@ class LatestInverterMetricsFetcher(LatestMetricsFetcher[InverterData]):
     """Subscribe for the latest inverter data using MicrogridApiClient."""
 
     @classmethod
+    @override
     async def async_new(  # noqa: DOC502 (ValueError is raised indirectly by super.async_new)
         cls,
         component_id: ComponentId,
@@ -255,12 +263,15 @@ class LatestInverterMetricsFetcher(LatestMetricsFetcher[InverterData]):
         )
         return self
 
+    @override
     def _supported_metrics(self) -> set[ComponentMetricId]:
         return set(_InverterDataMethods.keys())
 
+    @override
     def _extract_metric(self, data: InverterData, mid: ComponentMetricId) -> float:
         return _InverterDataMethods[mid](data)
 
+    @override
     async def _subscribe(self) -> Receiver[InverterData]:
         """Subscribe for this component data.
 
@@ -273,5 +284,6 @@ class LatestInverterMetricsFetcher(LatestMetricsFetcher[InverterData]):
         api = connection_manager.get().api_client
         return await api.inverter_data(self._component_id, maxsize=1)
 
+    @override
     def _component_category(self) -> ComponentCategory:
         return ComponentCategory.INVERTER

--- a/src/frequenz/sdk/timeseries/battery_pool/_component_metrics.py
+++ b/src/frequenz/sdk/timeseries/battery_pool/_component_metrics.py
@@ -9,7 +9,9 @@ from dataclasses import dataclass
 from datetime import datetime
 
 from frequenz.client.common.microgrid.components import ComponentId
-from frequenz.client.microgrid import ComponentMetricId
+from frequenz.client.microgrid.metrics import Metric
+
+from ...microgrid._old_component_data import TransitionalMetric
 
 
 @dataclass(frozen=True, eq=False)
@@ -22,10 +24,10 @@ class ComponentMetricsData:
     timestamp: datetime
     """The timestamp for all the metrics."""
 
-    metrics: Mapping[ComponentMetricId, float]
+    metrics: Mapping[Metric | TransitionalMetric, float]
     """The values for each metric."""
 
-    def get(self, metric: ComponentMetricId) -> float | None:
+    def get(self, metric: Metric | TransitionalMetric) -> float | None:
         """Get metric value.
 
         Args:

--- a/src/frequenz/sdk/timeseries/battery_pool/_metric_calculator.py
+++ b/src/frequenz/sdk/timeseries/battery_pool/_metric_calculator.py
@@ -14,6 +14,7 @@ from typing import Generic, TypeVar
 from frequenz.client.common.microgrid.components import ComponentId
 from frequenz.client.microgrid import ComponentMetricId
 from frequenz.quantities import Energy, Percentage, Power, Temperature
+from typing_extensions import override
 
 from ... import timeseries
 from ..._internal import _math
@@ -137,6 +138,7 @@ class CapacityCalculator(MetricCalculator[Sample[Energy]]):
         ]
 
     @classmethod
+    @override
     def name(cls) -> str:
         """Return name of the calculator.
 
@@ -146,6 +148,7 @@ class CapacityCalculator(MetricCalculator[Sample[Energy]]):
         return "Capacity"
 
     @property
+    @override
     def battery_metrics(self) -> Mapping[ComponentId, list[ComponentMetricId]]:
         """Return what metrics are needed for each battery.
 
@@ -155,6 +158,7 @@ class CapacityCalculator(MetricCalculator[Sample[Energy]]):
         return {bid: self._metrics for bid in self._batteries}
 
     @property
+    @override
     def inverter_metrics(self) -> Mapping[ComponentId, list[ComponentMetricId]]:
         """Return what metrics are needed for each inverter.
 
@@ -163,6 +167,7 @@ class CapacityCalculator(MetricCalculator[Sample[Energy]]):
         """
         return {}
 
+    @override
     def calculate(
         self,
         metrics_data: dict[ComponentId, ComponentMetricsData],
@@ -227,6 +232,7 @@ class TemperatureCalculator(MetricCalculator[Sample[Temperature]]):
         ]
 
     @classmethod
+    @override
     def name(cls) -> str:
         """Return name of the calculator.
 
@@ -236,6 +242,7 @@ class TemperatureCalculator(MetricCalculator[Sample[Temperature]]):
         return "temperature"
 
     @property
+    @override
     def battery_metrics(self) -> Mapping[ComponentId, list[ComponentMetricId]]:
         """Return what metrics are needed for each battery.
 
@@ -245,6 +252,7 @@ class TemperatureCalculator(MetricCalculator[Sample[Temperature]]):
         return {bid: self._metrics for bid in self._batteries}
 
     @property
+    @override
     def inverter_metrics(self) -> Mapping[ComponentId, list[ComponentMetricId]]:
         """Return what metrics are needed for each inverter.
 
@@ -253,6 +261,7 @@ class TemperatureCalculator(MetricCalculator[Sample[Temperature]]):
         """
         return {}
 
+    @override
     def calculate(
         self,
         metrics_data: dict[ComponentId, ComponentMetricsData],
@@ -317,6 +326,7 @@ class SoCCalculator(MetricCalculator[Sample[Percentage]]):
         ]
 
     @classmethod
+    @override
     def name(cls) -> str:
         """Return name of the calculator.
 
@@ -326,6 +336,7 @@ class SoCCalculator(MetricCalculator[Sample[Percentage]]):
         return "SoC"
 
     @property
+    @override
     def battery_metrics(self) -> Mapping[ComponentId, list[ComponentMetricId]]:
         """Return what metrics are needed for each battery.
 
@@ -335,6 +346,7 @@ class SoCCalculator(MetricCalculator[Sample[Percentage]]):
         return {bid: self._metrics for bid in self._batteries}
 
     @property
+    @override
     def inverter_metrics(self) -> Mapping[ComponentId, list[ComponentMetricId]]:
         """Return what metrics are needed for each inverter.
 
@@ -343,6 +355,7 @@ class SoCCalculator(MetricCalculator[Sample[Percentage]]):
         """
         return {}
 
+    @override
     def calculate(
         self,
         metrics_data: dict[ComponentId, ComponentMetricsData],
@@ -485,6 +498,7 @@ class PowerBoundsCalculator(MetricCalculator[SystemBounds]):
         ]
 
     @classmethod
+    @override
     def name(cls) -> str:
         """Return name of the calculator.
 
@@ -494,6 +508,7 @@ class PowerBoundsCalculator(MetricCalculator[SystemBounds]):
         return "PowerBounds"
 
     @property
+    @override
     def battery_metrics(self) -> Mapping[ComponentId, list[ComponentMetricId]]:
         """Return what metrics are needed for each battery.
 
@@ -503,6 +518,7 @@ class PowerBoundsCalculator(MetricCalculator[SystemBounds]):
         return {bid: self._battery_metrics for bid in set(self._bat_inv_map.keys())}
 
     @property
+    @override
     def inverter_metrics(self) -> Mapping[ComponentId, list[ComponentMetricId]]:
         """Return what metrics are needed for each inverter.
 
@@ -516,6 +532,7 @@ class PowerBoundsCalculator(MetricCalculator[SystemBounds]):
         }
 
     # pylint: disable=too-many-locals
+    @override
     def calculate(
         self,
         metrics_data: dict[ComponentId, ComponentMetricsData],

--- a/src/frequenz/sdk/timeseries/battery_pool/_metric_calculator.py
+++ b/src/frequenz/sdk/timeseries/battery_pool/_metric_calculator.py
@@ -12,9 +12,11 @@ from datetime import datetime, timezone
 from typing import Generic, TypeVar
 
 from frequenz.client.common.microgrid.components import ComponentId
-from frequenz.client.microgrid import ComponentMetricId
+from frequenz.client.microgrid.metrics import Metric
 from frequenz.quantities import Energy, Percentage, Power, Temperature
 from typing_extensions import override
+
+from frequenz.sdk.microgrid._old_component_data import TransitionalMetric
 
 from ... import timeseries
 from ..._internal import _math
@@ -80,7 +82,9 @@ class MetricCalculator(ABC, Generic[T]):
 
     @property
     @abstractmethod
-    def battery_metrics(self) -> Mapping[ComponentId, list[ComponentMetricId]]:
+    def battery_metrics(
+        self,
+    ) -> Mapping[ComponentId, list[Metric | TransitionalMetric]]:
         """Return what metrics are needed for each battery.
 
         Returns:
@@ -89,7 +93,9 @@ class MetricCalculator(ABC, Generic[T]):
 
     @property
     @abstractmethod
-    def inverter_metrics(self) -> Mapping[ComponentId, list[ComponentMetricId]]:
+    def inverter_metrics(
+        self,
+    ) -> Mapping[ComponentId, list[Metric | TransitionalMetric]]:
         """Return what metrics are needed for each inverter.
 
         Returns:
@@ -131,10 +137,10 @@ class CapacityCalculator(MetricCalculator[Sample[Energy]]):
         """
         super().__init__(batteries)
 
-        self._metrics = [
-            ComponentMetricId.CAPACITY,
-            ComponentMetricId.SOC_LOWER_BOUND,
-            ComponentMetricId.SOC_UPPER_BOUND,
+        self._metrics: list[Metric | TransitionalMetric] = [
+            Metric.BATTERY_CAPACITY,
+            TransitionalMetric.SOC_LOWER_BOUND,
+            TransitionalMetric.SOC_UPPER_BOUND,
         ]
 
     @classmethod
@@ -149,7 +155,9 @@ class CapacityCalculator(MetricCalculator[Sample[Energy]]):
 
     @property
     @override
-    def battery_metrics(self) -> Mapping[ComponentId, list[ComponentMetricId]]:
+    def battery_metrics(
+        self,
+    ) -> Mapping[ComponentId, list[Metric | TransitionalMetric]]:
         """Return what metrics are needed for each battery.
 
         Returns:
@@ -159,7 +167,9 @@ class CapacityCalculator(MetricCalculator[Sample[Energy]]):
 
     @property
     @override
-    def inverter_metrics(self) -> Mapping[ComponentId, list[ComponentMetricId]]:
+    def inverter_metrics(
+        self,
+    ) -> Mapping[ComponentId, list[Metric | TransitionalMetric]]:
         """Return what metrics are needed for each inverter.
 
         Returns:
@@ -198,9 +208,9 @@ class CapacityCalculator(MetricCalculator[Sample[Energy]]):
 
             metrics = metrics_data[battery_id]
 
-            capacity = metrics.get(ComponentMetricId.CAPACITY)
-            soc_upper_bound = metrics.get(ComponentMetricId.SOC_UPPER_BOUND)
-            soc_lower_bound = metrics.get(ComponentMetricId.SOC_LOWER_BOUND)
+            capacity = metrics.get(Metric.BATTERY_CAPACITY)
+            soc_upper_bound = metrics.get(TransitionalMetric.SOC_UPPER_BOUND)
+            soc_lower_bound = metrics.get(TransitionalMetric.SOC_LOWER_BOUND)
 
             # All metrics are related so if any is missing then we skip the component.
             if capacity is None or soc_lower_bound is None or soc_upper_bound is None:
@@ -227,8 +237,8 @@ class TemperatureCalculator(MetricCalculator[Sample[Temperature]]):
         """
         super().__init__(batteries)
 
-        self._metrics = [
-            ComponentMetricId.TEMPERATURE,
+        self._metrics: list[Metric | TransitionalMetric] = [
+            Metric.BATTERY_TEMPERATURE,
         ]
 
     @classmethod
@@ -243,7 +253,9 @@ class TemperatureCalculator(MetricCalculator[Sample[Temperature]]):
 
     @property
     @override
-    def battery_metrics(self) -> Mapping[ComponentId, list[ComponentMetricId]]:
+    def battery_metrics(
+        self,
+    ) -> Mapping[ComponentId, list[Metric | TransitionalMetric]]:
         """Return what metrics are needed for each battery.
 
         Returns:
@@ -253,7 +265,9 @@ class TemperatureCalculator(MetricCalculator[Sample[Temperature]]):
 
     @property
     @override
-    def inverter_metrics(self) -> Mapping[ComponentId, list[ComponentMetricId]]:
+    def inverter_metrics(
+        self,
+    ) -> Mapping[ComponentId, list[Metric | TransitionalMetric]]:
         """Return what metrics are needed for each inverter.
 
         Returns:
@@ -290,7 +304,7 @@ class TemperatureCalculator(MetricCalculator[Sample[Temperature]]):
             if battery_id not in metrics_data:
                 continue
             metrics = metrics_data[battery_id]
-            temperature = metrics.get(ComponentMetricId.TEMPERATURE)
+            temperature = metrics.get(Metric.BATTERY_TEMPERATURE)
             if temperature is None:
                 continue
             timestamp = max(timestamp, metrics.timestamp)
@@ -318,11 +332,11 @@ class SoCCalculator(MetricCalculator[Sample[Percentage]]):
         """
         super().__init__(batteries)
 
-        self._metrics = [
-            ComponentMetricId.CAPACITY,
-            ComponentMetricId.SOC_LOWER_BOUND,
-            ComponentMetricId.SOC_UPPER_BOUND,
-            ComponentMetricId.SOC,
+        self._metrics: list[Metric | TransitionalMetric] = [
+            Metric.BATTERY_CAPACITY,
+            TransitionalMetric.SOC_LOWER_BOUND,
+            TransitionalMetric.SOC_UPPER_BOUND,
+            Metric.BATTERY_SOC_PCT,
         ]
 
     @classmethod
@@ -337,7 +351,9 @@ class SoCCalculator(MetricCalculator[Sample[Percentage]]):
 
     @property
     @override
-    def battery_metrics(self) -> Mapping[ComponentId, list[ComponentMetricId]]:
+    def battery_metrics(
+        self,
+    ) -> Mapping[ComponentId, list[Metric | TransitionalMetric]]:
         """Return what metrics are needed for each battery.
 
         Returns:
@@ -347,7 +363,9 @@ class SoCCalculator(MetricCalculator[Sample[Percentage]]):
 
     @property
     @override
-    def inverter_metrics(self) -> Mapping[ComponentId, list[ComponentMetricId]]:
+    def inverter_metrics(
+        self,
+    ) -> Mapping[ComponentId, list[Metric | TransitionalMetric]]:
         """Return what metrics are needed for each inverter.
 
         Returns:
@@ -388,10 +406,10 @@ class SoCCalculator(MetricCalculator[Sample[Percentage]]):
 
             metrics = metrics_data[battery_id]
 
-            capacity = metrics.get(ComponentMetricId.CAPACITY)
-            soc_upper_bound = metrics.get(ComponentMetricId.SOC_UPPER_BOUND)
-            soc_lower_bound = metrics.get(ComponentMetricId.SOC_LOWER_BOUND)
-            soc = metrics.get(ComponentMetricId.SOC)
+            capacity = metrics.get(Metric.BATTERY_CAPACITY)
+            soc_upper_bound = metrics.get(TransitionalMetric.SOC_UPPER_BOUND)
+            soc_lower_bound = metrics.get(TransitionalMetric.SOC_LOWER_BOUND)
+            soc = metrics.get(Metric.BATTERY_SOC_PCT)
 
             # All metrics are related so if any is missing then we skip the component.
             if (
@@ -483,18 +501,18 @@ class PowerBoundsCalculator(MetricCalculator[SystemBounds]):
             )
 
         super().__init__(used_batteries)
-        self._battery_metrics = [
-            ComponentMetricId.POWER_INCLUSION_LOWER_BOUND,
-            ComponentMetricId.POWER_EXCLUSION_LOWER_BOUND,
-            ComponentMetricId.POWER_EXCLUSION_UPPER_BOUND,
-            ComponentMetricId.POWER_INCLUSION_UPPER_BOUND,
+        self._battery_metrics: list[Metric | TransitionalMetric] = [
+            TransitionalMetric.POWER_INCLUSION_LOWER_BOUND,
+            TransitionalMetric.POWER_EXCLUSION_LOWER_BOUND,
+            TransitionalMetric.POWER_EXCLUSION_UPPER_BOUND,
+            TransitionalMetric.POWER_INCLUSION_UPPER_BOUND,
         ]
 
-        self._inverter_metrics = [
-            ComponentMetricId.ACTIVE_POWER_INCLUSION_LOWER_BOUND,
-            ComponentMetricId.ACTIVE_POWER_EXCLUSION_LOWER_BOUND,
-            ComponentMetricId.ACTIVE_POWER_EXCLUSION_UPPER_BOUND,
-            ComponentMetricId.ACTIVE_POWER_INCLUSION_UPPER_BOUND,
+        self._inverter_metrics: list[Metric | TransitionalMetric] = [
+            TransitionalMetric.ACTIVE_POWER_INCLUSION_LOWER_BOUND,
+            TransitionalMetric.ACTIVE_POWER_EXCLUSION_LOWER_BOUND,
+            TransitionalMetric.ACTIVE_POWER_EXCLUSION_UPPER_BOUND,
+            TransitionalMetric.ACTIVE_POWER_INCLUSION_UPPER_BOUND,
         ]
 
     @classmethod
@@ -509,7 +527,9 @@ class PowerBoundsCalculator(MetricCalculator[SystemBounds]):
 
     @property
     @override
-    def battery_metrics(self) -> Mapping[ComponentId, list[ComponentMetricId]]:
+    def battery_metrics(
+        self,
+    ) -> Mapping[ComponentId, list[Metric | TransitionalMetric]]:
         """Return what metrics are needed for each battery.
 
         Returns:
@@ -519,7 +539,9 @@ class PowerBoundsCalculator(MetricCalculator[SystemBounds]):
 
     @property
     @override
-    def inverter_metrics(self) -> Mapping[ComponentId, list[ComponentMetricId]]:
+    def inverter_metrics(
+        self,
+    ) -> Mapping[ComponentId, list[Metric | TransitionalMetric]]:
         """Return what metrics are needed for each inverter.
 
         Returns:
@@ -564,7 +586,7 @@ class PowerBoundsCalculator(MetricCalculator[SystemBounds]):
         }
 
         def get_validated_bounds(
-            comp_id: ComponentId, comp_metric_ids: list[ComponentMetricId]
+            comp_id: ComponentId, comp_metric_ids: list[Metric | TransitionalMetric]
         ) -> PowerBounds | None:
             results: list[float] = []
             # Make timestamp accessible
@@ -590,7 +612,8 @@ class PowerBoundsCalculator(MetricCalculator[SystemBounds]):
             )
 
         def get_bounds_list(
-            comp_ids: frozenset[ComponentId], comp_metric_ids: list[ComponentMetricId]
+            comp_ids: frozenset[ComponentId],
+            comp_metric_ids: list[Metric | TransitionalMetric],
         ) -> list[PowerBounds]:
             return list(
                 x

--- a/src/frequenz/sdk/timeseries/ev_charger_pool/_ev_charger_pool_reference_store.py
+++ b/src/frequenz/sdk/timeseries/ev_charger_pool/_ev_charger_pool_reference_store.py
@@ -9,7 +9,7 @@ from collections import abc
 
 from frequenz.channels import Broadcast, Receiver, Sender
 from frequenz.client.common.microgrid.components import ComponentId
-from frequenz.client.microgrid import ComponentCategory
+from frequenz.client.microgrid.component import EvCharger
 
 from ..._internal._channels import ChannelRegistry, ReceiverFetcher
 from ...microgrid import connection_manager
@@ -76,12 +76,7 @@ class EVChargerPoolReferenceStore:
         else:
             graph = connection_manager.get().component_graph
             self.component_ids = frozenset(
-                {
-                    evc.id
-                    for evc in graph.components(
-                        component_categories={ComponentCategory.EV_CHARGER}
-                    )
-                }
+                {evc.id for evc in graph.components(matching_types={EvCharger})}
             )
 
         self.power_bounds_subs: dict[str, asyncio.Task[None]] = {}

--- a/src/frequenz/sdk/timeseries/ev_charger_pool/_ev_charger_pool_reference_store.py
+++ b/src/frequenz/sdk/timeseries/ev_charger_pool/_ev_charger_pool_reference_store.py
@@ -77,7 +77,7 @@ class EVChargerPoolReferenceStore:
             graph = connection_manager.get().component_graph
             self.component_ids = frozenset(
                 {
-                    evc.component_id
+                    evc.id
                     for evc in graph.components(
                         component_categories={ComponentCategory.EV_CHARGER}
                     )

--- a/src/frequenz/sdk/timeseries/ev_charger_pool/_ev_charger_pool_reference_store.py
+++ b/src/frequenz/sdk/timeseries/ev_charger_pool/_ev_charger_pool_reference_store.py
@@ -76,7 +76,7 @@ class EVChargerPoolReferenceStore:
         else:
             graph = connection_manager.get().component_graph
             self.component_ids = frozenset(
-                {evc.id for evc in graph.components(matching_types={EvCharger})}
+                {evc.id for evc in graph.components(matching_types=EvCharger)}
             )
 
         self.power_bounds_subs: dict[str, asyncio.Task[None]] = {}

--- a/src/frequenz/sdk/timeseries/ev_charger_pool/_system_bounds_tracker.py
+++ b/src/frequenz/sdk/timeseries/ev_charger_pool/_system_bounds_tracker.py
@@ -9,12 +9,12 @@ from collections import abc
 
 from frequenz.channels import Receiver, Sender, merge, select, selected_from
 from frequenz.client.common.microgrid.components import ComponentId
-from frequenz.client.microgrid import EVChargerData
 from frequenz.quantities import Power
 
 from ..._internal._asyncio import run_forever
 from ...actor import BackgroundService
 from ...microgrid import connection_manager
+from ...microgrid._old_component_data import EVChargerData
 from ...microgrid._power_distributing._component_status import ComponentPoolStatus
 from .._base_types import Bounds, SystemBounds
 
@@ -108,11 +108,7 @@ class EVCSystemBoundsTracker(BackgroundService):
         api_client = connection_manager.get().api_client
         status_rx = self._status_receiver
         ev_data_rx = merge(
-            *(
-                await asyncio.gather(
-                    *[api_client.ev_charger_data(cid) for cid in self._component_ids]
-                )
-            )
+            *(EVChargerData.subscribe(api_client, cid) for cid in self._component_ids)
         )
 
         async for selected in select(status_rx, ev_data_rx):

--- a/src/frequenz/sdk/timeseries/formula_engine/_formula_engine_pool.py
+++ b/src/frequenz/sdk/timeseries/formula_engine/_formula_engine_pool.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from frequenz.channels import Sender
-from frequenz.client.microgrid import ComponentMetricId
+from frequenz.client.microgrid.metrics import Metric
 from frequenz.quantities import Current, Power, Quantity, ReactivePower
 
 from ..._internal._channels import ChannelRegistry
@@ -59,7 +59,7 @@ class FormulaEnginePool:
     def from_string(
         self,
         formula: str,
-        component_metric_id: ComponentMetricId,
+        metric: Metric,
         *,
         nones_are_zeros: bool = False,
     ) -> FormulaEngine[Quantity]:
@@ -67,15 +67,15 @@ class FormulaEnginePool:
 
         Args:
             formula: formula to execute.
-            component_metric_id: The metric ID to use when fetching receivers from the
-                resampling actor.
+            metric: The metric to use when fetching receivers from the resampling
+                actor.
             nones_are_zeros: Whether to treat None values from the stream as 0s.  If
                 False, the returned value will be a None.
 
         Returns:
             A FormulaReceiver that streams values with the formulas applied.
         """
-        channel_key = formula + component_metric_id.value
+        channel_key = formula + str(metric.value)
         if channel_key in self._string_engines:
             return self._string_engines[channel_key]
 
@@ -84,7 +84,7 @@ class FormulaEnginePool:
             formula_name=formula,
             channel_registry=self._channel_registry,
             resampler_subscription_sender=self._resampler_subscription_sender,
-            metric_id=component_metric_id,
+            metric=metric,
             create_method=Quantity,
         )
         formula_engine = builder.from_string(formula, nones_are_zeros=nones_are_zeros)

--- a/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_battery_power_formula.py
+++ b/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_battery_power_formula.py
@@ -6,7 +6,7 @@
 import itertools
 import logging
 
-from frequenz.client.microgrid import Component, ComponentCategory
+from frequenz.client.microgrid.component import Component, Meter
 from frequenz.client.microgrid.metrics import Metric
 from frequenz.quantities import Power
 
@@ -107,9 +107,7 @@ class BatteryPowerFormula(FormulaGenerator[Power]):
 
                 builder.push_component_metric(
                     primary_component.id,
-                    nones_are_zeros=(
-                        primary_component.category != ComponentCategory.METER
-                    ),
+                    nones_are_zeros=not isinstance(primary_component, Meter),
                     fallback=fallback_formula,
                 )
         else:

--- a/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_battery_power_formula.py
+++ b/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_battery_power_formula.py
@@ -84,15 +84,13 @@ class BatteryPowerFormula(FormulaGenerator[Power]):
                 )
 
             for inverter in inverters:
-                all_connected_batteries = component_graph.successors(
-                    inverter.component_id
-                )
+                all_connected_batteries = component_graph.successors(inverter.id)
                 battery_ids = set(
-                    map(lambda battery: battery.component_id, all_connected_batteries)
+                    map(lambda battery: battery.id, all_connected_batteries)
                 )
                 if not battery_ids.issubset(component_ids):
                     raise FormulaGenerationError(
-                        f"Not all batteries behind inverter {inverter.component_id} "
+                        f"Not all batteries behind {inverter} "
                         f"are requested. Missing: {battery_ids - component_ids}"
                     )
 
@@ -108,7 +106,7 @@ class BatteryPowerFormula(FormulaGenerator[Power]):
                     builder.push_oper("+")
 
                 builder.push_component_metric(
-                    primary_component.component_id,
+                    primary_component.id,
                     nones_are_zeros=(
                         primary_component.category != ComponentCategory.METER
                     ),
@@ -118,7 +116,7 @@ class BatteryPowerFormula(FormulaGenerator[Power]):
             for idx, comp in enumerate(inv_bat_mapping.keys()):
                 if idx > 0:
                     builder.push_oper("+")
-                builder.push_component_metric(comp.component_id, nones_are_zeros=True)
+                builder.push_component_metric(comp.id, nones_are_zeros=True)
 
         return builder.build()
 
@@ -150,7 +148,7 @@ class BatteryPowerFormula(FormulaGenerator[Power]):
 
             battery_ids = set(
                 map(
-                    lambda battery: battery.component_id,
+                    lambda battery: battery.id,
                     itertools.chain.from_iterable(
                         inv_bat_mapping[inv] for inv in fallback_components
                     ),

--- a/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_battery_power_formula.py
+++ b/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_battery_power_formula.py
@@ -6,7 +6,8 @@
 import itertools
 import logging
 
-from frequenz.client.microgrid import Component, ComponentCategory, ComponentMetricId
+from frequenz.client.microgrid import Component, ComponentCategory
+from frequenz.client.microgrid.metrics import Metric
 from frequenz.quantities import Power
 
 from ....microgrid import connection_manager
@@ -48,7 +49,7 @@ class BatteryPowerFormula(FormulaGenerator[Power]):
                 inverters have been requested.
         """
         builder = self._get_builder(
-            "battery-power", ComponentMetricId.ACTIVE_POWER, Power.from_watts
+            "battery-power", Metric.AC_ACTIVE_POWER, Power.from_watts
         )
 
         if not self._config.component_ids:

--- a/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_chp_power_formula.py
+++ b/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_chp_power_formula.py
@@ -8,7 +8,8 @@ import logging
 from collections import abc
 
 from frequenz.client.common.microgrid.components import ComponentId
-from frequenz.client.microgrid import ComponentCategory, ComponentMetricId
+from frequenz.client.microgrid import ComponentCategory
+from frequenz.client.microgrid.metrics import Metric
 from frequenz.quantities import Power
 
 from ....microgrid import connection_manager
@@ -41,7 +42,7 @@ class CHPPowerFormula(FormulaGenerator[Power]):
 
         """
         builder = self._get_builder(
-            "chp-power", ComponentMetricId.ACTIVE_POWER, Power.from_watts
+            "chp-power", Metric.AC_ACTIVE_POWER, Power.from_watts
         )
 
         chp_meter_ids = self._get_chp_meters()

--- a/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_chp_power_formula.py
+++ b/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_chp_power_formula.py
@@ -79,23 +79,23 @@ class CHPPowerFormula(FormulaGenerator[Power]):
 
         chp_meters: set[ComponentId] = set()
         for chp in chps:
-            predecessors = component_graph.predecessors(chp.component_id)
+            predecessors = component_graph.predecessors(chp.id)
             if len(predecessors) != 1:
                 raise FormulaGenerationError(
-                    f"CHP {chp.component_id} has {len(predecessors)} predecessors. "
+                    f"CHP {chp.id} has {len(predecessors)} predecessors. "
                     " Expected exactly one."
                 )
             meter = next(iter(predecessors))
             if meter.category != ComponentCategory.METER:
                 raise FormulaGenerationError(
-                    f"CHP {chp.component_id} has a predecessor of category "
+                    f"CHP {chp.id} has a predecessor of category "
                     f"{meter.category}. Expected ComponentCategory.METER."
                 )
-            meter_successors = component_graph.successors(meter.component_id)
+            meter_successors = component_graph.successors(meter.id)
             if not all(successor in chps for successor in meter_successors):
                 raise FormulaGenerationError(
-                    f"Meter {meter.component_id} connected to CHP {chp.component_id}"
+                    f"Meter {meter.id} connected to CHP {chp.id}"
                     "has non-chp successors."
                 )
-            chp_meters.add(meter.component_id)
+            chp_meters.add(meter.id)
         return chp_meters

--- a/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_chp_power_formula.py
+++ b/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_chp_power_formula.py
@@ -8,7 +8,7 @@ import logging
 from collections import abc
 
 from frequenz.client.common.microgrid.components import ComponentId
-from frequenz.client.microgrid import ComponentCategory
+from frequenz.client.microgrid.component import Chp, Meter
 from frequenz.client.microgrid.metrics import Metric
 from frequenz.quantities import Power
 
@@ -71,11 +71,7 @@ class CHPPowerFormula(FormulaGenerator[Power]):
             FormulaGenerationError: If there's no dedicated meter attached to every CHP.
         """
         component_graph = connection_manager.get().component_graph
-        chps = list(
-            comp
-            for comp in component_graph.components()
-            if comp.category == ComponentCategory.CHP
-        )
+        chps = component_graph.components(matching_types={Chp})
 
         chp_meters: set[ComponentId] = set()
         for chp in chps:
@@ -86,7 +82,7 @@ class CHPPowerFormula(FormulaGenerator[Power]):
                     " Expected exactly one."
                 )
             meter = next(iter(predecessors))
-            if meter.category != ComponentCategory.METER:
+            if not isinstance(meter, Meter):
                 raise FormulaGenerationError(
                     f"CHP {chp.id} has a predecessor of category "
                     f"{meter.category}. Expected ComponentCategory.METER."

--- a/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_chp_power_formula.py
+++ b/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_chp_power_formula.py
@@ -71,7 +71,7 @@ class CHPPowerFormula(FormulaGenerator[Power]):
             FormulaGenerationError: If there's no dedicated meter attached to every CHP.
         """
         component_graph = connection_manager.get().component_graph
-        chps = component_graph.components(matching_types={Chp})
+        chps = component_graph.components(matching_types=Chp)
 
         chp_meters: set[ComponentId] = set()
         for chp in chps:

--- a/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_consumer_power_formula.py
+++ b/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_consumer_power_formula.py
@@ -124,9 +124,7 @@ class ConsumerPowerFormula(FormulaGenerator[Power]):
         for idx, grid_meter in enumerate(grid_meters):
             if idx > 0:
                 builder.push_oper("+")
-            builder.push_component_metric(
-                grid_meter.component_id, nones_are_zeros=False
-            )
+            builder.push_component_metric(grid_meter.id, nones_are_zeros=False)
 
         if self._config.allow_fallback:
             fallbacks = self._get_fallback_formulas(non_consumer_components)
@@ -138,7 +136,7 @@ class ConsumerPowerFormula(FormulaGenerator[Power]):
 
                 # should only be the case if the component is not a meter
                 builder.push_component_metric(
-                    primary_component.component_id,
+                    primary_component.id,
                     nones_are_zeros=(
                         primary_component.category != ComponentCategory.METER
                     ),
@@ -149,7 +147,7 @@ class ConsumerPowerFormula(FormulaGenerator[Power]):
             for component in non_consumer_components:
                 builder.push_oper("-")
                 builder.push_component_metric(
-                    component.component_id,
+                    component.id,
                     nones_are_zeros=component.category != ComponentCategory.METER,
                 )
 
@@ -219,7 +217,7 @@ class ConsumerPowerFormula(FormulaGenerator[Power]):
 
                 # should only be the case if the component is not a meter
                 builder.push_component_metric(
-                    primary_component.component_id,
+                    primary_component.id,
                     nones_are_zeros=(
                         primary_component.category != ComponentCategory.METER
                     ),
@@ -231,7 +229,7 @@ class ConsumerPowerFormula(FormulaGenerator[Power]):
                     builder.push_oper("+")
 
                 builder.push_component_metric(
-                    component.component_id,
+                    component.id,
                     nones_are_zeros=component.category != ComponentCategory.METER,
                 )
 
@@ -265,7 +263,7 @@ class ConsumerPowerFormula(FormulaGenerator[Power]):
                 fallback_formulas[primary_component] = None
                 continue
 
-            fallback_ids = [c.component_id for c in fallback_components]
+            fallback_ids = [c.id for c in fallback_components]
             generator = SimplePowerFormula(
                 f"{self._namespace}_fallback_{fallback_ids}",
                 self._channel_registry,

--- a/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_consumer_power_formula.py
+++ b/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_consumer_power_formula.py
@@ -5,7 +5,8 @@
 
 import logging
 
-from frequenz.client.microgrid import Component, ComponentCategory, ComponentMetricId
+from frequenz.client.microgrid import Component, ComponentCategory
+from frequenz.client.microgrid.metrics import Metric
 from frequenz.quantities import Power
 
 from ....microgrid import connection_manager
@@ -63,7 +64,7 @@ class ConsumerPowerFormula(FormulaGenerator[Power]):
                 meter.
         """
         builder = self._get_builder(
-            "consumer-power", ComponentMetricId.ACTIVE_POWER, Power.from_watts
+            "consumer-power", Metric.AC_ACTIVE_POWER, Power.from_watts
         )
 
         grid_successors = self._get_grid_component_successors()

--- a/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_consumer_power_formula.py
+++ b/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_consumer_power_formula.py
@@ -5,7 +5,7 @@
 
 import logging
 
-from frequenz.client.microgrid import Component, ComponentCategory
+from frequenz.client.microgrid.component import Component, Inverter, Meter
 from frequenz.client.microgrid.metrics import Metric
 from frequenz.quantities import Power
 
@@ -42,7 +42,7 @@ class ConsumerPowerFormula(FormulaGenerator[Power]):
         """
         component_graph = connection_manager.get().component_graph
         return all(
-            successor.category == ComponentCategory.METER
+            isinstance(successor, Meter)
             and not component_graph.is_battery_chain(successor)
             and not component_graph.is_chp_chain(successor)
             and not component_graph.is_pv_chain(successor)
@@ -137,9 +137,7 @@ class ConsumerPowerFormula(FormulaGenerator[Power]):
                 # should only be the case if the component is not a meter
                 builder.push_component_metric(
                     primary_component.id,
-                    nones_are_zeros=(
-                        primary_component.category != ComponentCategory.METER
-                    ),
+                    nones_are_zeros=not isinstance(primary_component, Meter),
                     fallback=fallback_formula,
                 )
         else:
@@ -148,7 +146,7 @@ class ConsumerPowerFormula(FormulaGenerator[Power]):
                 builder.push_oper("-")
                 builder.push_component_metric(
                     component.id,
-                    nones_are_zeros=component.category != ComponentCategory.METER,
+                    nones_are_zeros=not isinstance(component, Meter),
                 )
 
         return builder.build()
@@ -181,8 +179,7 @@ class ConsumerPowerFormula(FormulaGenerator[Power]):
             # If the component graph supports additional types of grid successors in the
             # future, additional checks need to be added here.
             return (
-                component.category
-                in {ComponentCategory.METER, ComponentCategory.INVERTER}
+                isinstance(component, (Meter, Inverter))
                 and not component_graph.is_battery_chain(component)
                 and not component_graph.is_chp_chain(component)
                 and not component_graph.is_pv_chain(component)
@@ -218,9 +215,7 @@ class ConsumerPowerFormula(FormulaGenerator[Power]):
                 # should only be the case if the component is not a meter
                 builder.push_component_metric(
                     primary_component.id,
-                    nones_are_zeros=(
-                        primary_component.category != ComponentCategory.METER
-                    ),
+                    nones_are_zeros=not isinstance(primary_component, Meter),
                     fallback=fallback_formula,
                 )
         else:
@@ -230,7 +225,7 @@ class ConsumerPowerFormula(FormulaGenerator[Power]):
 
                 builder.push_component_metric(
                     component.id,
-                    nones_are_zeros=component.category != ComponentCategory.METER,
+                    nones_are_zeros=not isinstance(component, Meter),
                 )
 
         return builder.build()

--- a/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_ev_charger_current_formula.py
+++ b/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_ev_charger_current_formula.py
@@ -8,7 +8,7 @@ import logging
 from collections import abc
 
 from frequenz.client.common.microgrid.components import ComponentId
-from frequenz.client.microgrid import ComponentMetricId
+from frequenz.client.microgrid.metrics import Metric
 from frequenz.quantities import Current
 
 from .._formula_engine import FormulaEngine, FormulaEngine3Phase
@@ -38,7 +38,7 @@ class EVChargerCurrentFormula(FormulaGenerator[Current]):
             # frequency as the other streams.  So we subscribe with a non-existing
             # component id, just to get a `None` message at the resampling interval.
             builder = self._get_builder(
-                "ev-current", ComponentMetricId.ACTIVE_POWER, Current.from_amperes
+                "ev-current", Metric.AC_ACTIVE_POWER, Current.from_amperes
             )
             builder.push_component_metric(
                 NON_EXISTING_COMPONENT_ID, nones_are_zeros=True
@@ -54,30 +54,18 @@ class EVChargerCurrentFormula(FormulaGenerator[Current]):
             "ev-current",
             Current.from_amperes,
             (
-                (
-                    self._gen_phase_formula(
-                        component_ids, ComponentMetricId.CURRENT_PHASE_1
-                    )
-                ),
-                (
-                    self._gen_phase_formula(
-                        component_ids, ComponentMetricId.CURRENT_PHASE_2
-                    )
-                ),
-                (
-                    self._gen_phase_formula(
-                        component_ids, ComponentMetricId.CURRENT_PHASE_3
-                    )
-                ),
+                (self._gen_phase_formula(component_ids, Metric.AC_CURRENT_PHASE_1)),
+                (self._gen_phase_formula(component_ids, Metric.AC_CURRENT_PHASE_2)),
+                (self._gen_phase_formula(component_ids, Metric.AC_CURRENT_PHASE_3)),
             ),
         )
 
     def _gen_phase_formula(
         self,
         component_ids: abc.Set[ComponentId],
-        metric_id: ComponentMetricId,
+        metric: Metric,
     ) -> FormulaEngine[Current]:
-        builder = self._get_builder("ev-current", metric_id, Current.from_amperes)
+        builder = self._get_builder("ev-current", metric, Current.from_amperes)
 
         # generate a formula that just adds values from all EV Chargers.
         for idx, component_id in enumerate(component_ids):

--- a/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_ev_charger_power_formula.py
+++ b/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_ev_charger_power_formula.py
@@ -5,7 +5,7 @@
 
 import logging
 
-from frequenz.client.microgrid import ComponentMetricId
+from frequenz.client.microgrid.metrics import Metric
 from frequenz.quantities import Power
 
 from .._formula_engine import FormulaEngine
@@ -24,7 +24,7 @@ class EVChargerPowerFormula(FormulaGenerator[Power]):
             A formula engine that calculates total EV Charger power values.
         """
         builder = self._get_builder(
-            "ev-power", ComponentMetricId.ACTIVE_POWER, Power.from_watts
+            "ev-power", Metric.AC_ACTIVE_POWER, Power.from_watts
         )
 
         component_ids = self._config.component_ids

--- a/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_formula_generator.py
+++ b/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_formula_generator.py
@@ -114,7 +114,7 @@ class FormulaGenerator(ABC, Generic[QuantityT]):
         """
         component_graph = connection_manager.get().component_graph
         grid_component = next(
-            iter(component_graph.components(matching_types={GridConnectionPoint})),
+            iter(component_graph.components(matching_types=GridConnectionPoint)),
             None,
         )
         if grid_component is None:

--- a/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_formula_generator.py
+++ b/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_formula_generator.py
@@ -14,7 +14,7 @@ from typing import Generic
 
 from frequenz.channels import Sender
 from frequenz.client.common.microgrid.components import ComponentId
-from frequenz.client.microgrid import Component, ComponentCategory
+from frequenz.client.microgrid.component import Component, GridConnectionPoint, Meter
 from frequenz.client.microgrid.metrics import Metric
 
 from ...._internal._channels import ChannelRegistry
@@ -114,11 +114,7 @@ class FormulaGenerator(ABC, Generic[QuantityT]):
         """
         component_graph = connection_manager.get().component_graph
         grid_component = next(
-            iter(
-                component_graph.components(
-                    component_categories={ComponentCategory.GRID}
-                )
-            ),
+            iter(component_graph.components(matching_types={GridConnectionPoint})),
             None,
         )
         if grid_component is None:
@@ -184,7 +180,7 @@ class FormulaGenerator(ABC, Generic[QuantityT]):
         fallbacks: dict[Component, set[Component]] = {}
 
         for component in components:
-            if component.category == ComponentCategory.METER:
+            if isinstance(component, Meter):
                 fallbacks[component] = self._get_meter_fallback_components(component)
             else:
                 predecessors = graph.predecessors(component.id)
@@ -210,7 +206,7 @@ class FormulaGenerator(ABC, Generic[QuantityT]):
             A set of fallback components for the given meter.
             An empty set is returned if the meter has no fallbacks.
         """
-        assert meter.category == ComponentCategory.METER
+        assert isinstance(meter, Meter)
 
         graph = connection_manager.get().component_graph
         successors = graph.successors(meter.id)

--- a/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_formula_generator.py
+++ b/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_formula_generator.py
@@ -14,7 +14,8 @@ from typing import Generic
 
 from frequenz.channels import Sender
 from frequenz.client.common.microgrid.components import ComponentId
-from frequenz.client.microgrid import Component, ComponentCategory, ComponentMetricId
+from frequenz.client.microgrid import Component, ComponentCategory
+from frequenz.client.microgrid.metrics import Metric
 
 from ...._internal._channels import ChannelRegistry
 from ....microgrid import connection_manager
@@ -88,7 +89,7 @@ class FormulaGenerator(ABC, Generic[QuantityT]):
     def _get_builder(
         self,
         name: str,
-        component_metric_id: ComponentMetricId,
+        metric: Metric,
         create_method: Callable[[float], QuantityT],
     ) -> ResampledFormulaBuilder[QuantityT]:
         builder = ResampledFormulaBuilder(
@@ -96,7 +97,7 @@ class FormulaGenerator(ABC, Generic[QuantityT]):
             formula_name=name,
             channel_registry=self._channel_registry,
             resampler_subscription_sender=self._resampler_subscription_sender,
-            metric_id=component_metric_id,
+            metric=metric,
             create_method=create_method,
         )
         return builder

--- a/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_formula_generator.py
+++ b/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_formula_generator.py
@@ -137,7 +137,7 @@ class FormulaGenerator(ABC, Generic[QuantityT]):
         """
         grid_component = self._get_grid_component()
         component_graph = connection_manager.get().component_graph
-        grid_successors = component_graph.successors(grid_component.component_id)
+        grid_successors = component_graph.successors(grid_component.id)
 
         if not grid_successors:
             raise ComponentNotFound("No components found in the component graph.")
@@ -187,7 +187,7 @@ class FormulaGenerator(ABC, Generic[QuantityT]):
             if component.category == ComponentCategory.METER:
                 fallbacks[component] = self._get_meter_fallback_components(component)
             else:
-                predecessors = graph.predecessors(component.component_id)
+                predecessors = graph.predecessors(component.id)
                 if len(predecessors) == 1:
                     predecessor = predecessors.pop()
                     if self._is_primary_fallback_pair(predecessor, component):
@@ -213,7 +213,7 @@ class FormulaGenerator(ABC, Generic[QuantityT]):
         assert meter.category == ComponentCategory.METER
 
         graph = connection_manager.get().component_graph
-        successors = graph.successors(meter.component_id)
+        successors = graph.successors(meter.id)
 
         # All fallbacks has to be of the same type and category.
         if (

--- a/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_grid_current_formula.py
+++ b/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_grid_current_formula.py
@@ -67,8 +67,6 @@ class GridCurrentFormula(FormulaGenerator[Current]):
             if idx > 0:
                 builder.push_oper("+")
 
-            builder.push_component_metric(
-                comp.component_id, nones_are_zeros=nones_are_zeros
-            )
+            builder.push_component_metric(comp.id, nones_are_zeros=nones_are_zeros)
 
         return builder.build()

--- a/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_grid_current_formula.py
+++ b/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_grid_current_formula.py
@@ -3,7 +3,7 @@
 
 """Formula generator from component graph for 3-phase Grid Current."""
 
-from frequenz.client.microgrid import Component, ComponentCategory
+from frequenz.client.microgrid.component import Component, EvCharger, Inverter, Meter
 from frequenz.client.microgrid.metrics import Metric
 from frequenz.quantities import Current
 
@@ -54,15 +54,13 @@ class GridCurrentFormula(FormulaGenerator[Current]):
             #
             # This is not possible for Meters, so when they produce `None`
             # values, those values get propagated as the output.
-            if comp.category in (
-                ComponentCategory.INVERTER,
-                ComponentCategory.EV_CHARGER,
-            ):
-                nones_are_zeros = True
-            elif comp.category == ComponentCategory.METER:
-                nones_are_zeros = False
-            else:
-                continue
+            match comp:
+                case Inverter() | EvCharger():
+                    nones_are_zeros = True
+                case Meter():
+                    nones_are_zeros = False
+                case _:
+                    continue
 
             if idx > 0:
                 builder.push_oper("+")

--- a/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_grid_current_formula.py
+++ b/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_grid_current_formula.py
@@ -3,7 +3,8 @@
 
 """Formula generator from component graph for 3-phase Grid Current."""
 
-from frequenz.client.microgrid import Component, ComponentCategory, ComponentMetricId
+from frequenz.client.microgrid import Component, ComponentCategory
+from frequenz.client.microgrid.metrics import Metric
 from frequenz.quantities import Current
 
 from .._formula_engine import FormulaEngine, FormulaEngine3Phase
@@ -31,24 +32,18 @@ class GridCurrentFormula(FormulaGenerator[Current]):
             "grid-current",
             Current.from_amperes,
             (
-                self._gen_phase_formula(
-                    grid_successors, ComponentMetricId.CURRENT_PHASE_1
-                ),
-                self._gen_phase_formula(
-                    grid_successors, ComponentMetricId.CURRENT_PHASE_2
-                ),
-                self._gen_phase_formula(
-                    grid_successors, ComponentMetricId.CURRENT_PHASE_3
-                ),
+                self._gen_phase_formula(grid_successors, Metric.AC_CURRENT_PHASE_1),
+                self._gen_phase_formula(grid_successors, Metric.AC_CURRENT_PHASE_2),
+                self._gen_phase_formula(grid_successors, Metric.AC_CURRENT_PHASE_3),
             ),
         )
 
     def _gen_phase_formula(
         self,
         grid_successors: set[Component],
-        metric_id: ComponentMetricId,
+        metric: Metric,
     ) -> FormulaEngine[Current]:
-        builder = self._get_builder("grid-current", metric_id, Current.from_amperes)
+        builder = self._get_builder("grid-current", metric, Current.from_amperes)
 
         # generate a formula that just adds values from all components that are
         # directly connected to the grid.

--- a/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_grid_power_3_phase_formula.py
+++ b/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_grid_power_3_phase_formula.py
@@ -86,7 +86,7 @@ class GridPower3PhaseFormula(FormulaGenerator[Power]):
                 formula_builder.push_oper("+")
 
             formula_builder.push_component_metric(
-                comp.component_id, nones_are_zeros=nones_are_zeros
+                comp.id, nones_are_zeros=nones_are_zeros
             )
 
         return formula_builder.build()

--- a/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_grid_power_3_phase_formula.py
+++ b/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_grid_power_3_phase_formula.py
@@ -3,7 +3,7 @@
 
 """Formula generator from component graph for 3-phase Grid Power."""
 
-from frequenz.client.microgrid import Component, ComponentCategory
+from frequenz.client.microgrid.component import Component, EvCharger, Inverter, Meter
 from frequenz.client.microgrid.metrics import Metric
 from frequenz.quantities import Power
 
@@ -72,15 +72,13 @@ class GridPower3PhaseFormula(FormulaGenerator[Power]):
             #
             # This is not possible for Meters, so when they produce `None`
             # values, those values get propagated as the output.
-            if comp.category in (
-                ComponentCategory.INVERTER,
-                ComponentCategory.EV_CHARGER,
-            ):
-                nones_are_zeros = True
-            elif comp.category == ComponentCategory.METER:
-                nones_are_zeros = False
-            else:
-                continue
+            match comp:
+                case Inverter() | EvCharger():
+                    nones_are_zeros = True
+                case Meter():
+                    nones_are_zeros = False
+                case _:
+                    continue
 
             if idx > 0:
                 formula_builder.push_oper("+")

--- a/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_grid_power_3_phase_formula.py
+++ b/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_grid_power_3_phase_formula.py
@@ -3,7 +3,8 @@
 
 """Formula generator from component graph for 3-phase Grid Power."""
 
-from frequenz.client.microgrid import Component, ComponentCategory, ComponentMetricId
+from frequenz.client.microgrid import Component, ComponentCategory
+from frequenz.client.microgrid.metrics import Metric
 from frequenz.quantities import Power
 
 from .._formula_engine import FormulaEngine, FormulaEngine3Phase
@@ -32,13 +33,13 @@ class GridPower3PhaseFormula(FormulaGenerator[Power]):
             Power.from_watts,
             (
                 self._gen_phase_formula(
-                    grid_successors, ComponentMetricId.ACTIVE_POWER_PHASE_1
+                    grid_successors, Metric.AC_ACTIVE_POWER_PHASE_1
                 ),
                 self._gen_phase_formula(
-                    grid_successors, ComponentMetricId.ACTIVE_POWER_PHASE_2
+                    grid_successors, Metric.AC_ACTIVE_POWER_PHASE_2
                 ),
                 self._gen_phase_formula(
-                    grid_successors, ComponentMetricId.ACTIVE_POWER_PHASE_3
+                    grid_successors, Metric.AC_ACTIVE_POWER_PHASE_3
                 ),
             ),
         )
@@ -46,7 +47,7 @@ class GridPower3PhaseFormula(FormulaGenerator[Power]):
     def _gen_phase_formula(
         self,
         grid_successors: set[Component],
-        metric_id: ComponentMetricId,
+        metric: Metric,
     ) -> FormulaEngine[Power]:
         """Generate a formula for calculating grid 3-phase power from the component graph.
 
@@ -55,13 +56,13 @@ class GridPower3PhaseFormula(FormulaGenerator[Power]):
 
         Args:
             grid_successors: The set of components that are directly connected to the grid.
-            metric_id: The metric to use for the formula.
+            metric: The metric to use for the formula.
 
         Returns:
             A formula engine that will calculate grid 3-phase power values.
         """
         formula_builder = self._get_builder(
-            "grid-power-3-phase", metric_id, Power.from_watts
+            "grid-power-3-phase", metric, Power.from_watts
         )
 
         for idx, comp in enumerate(grid_successors):

--- a/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_grid_power_formula.py
+++ b/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_grid_power_formula.py
@@ -4,7 +4,7 @@
 """Formula generator from component graph for Grid Power."""
 
 
-from frequenz.client.microgrid import Component
+from frequenz.client.microgrid.component import Component
 from frequenz.client.microgrid.metrics import Metric
 from frequenz.quantities import Power
 

--- a/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_grid_power_formula.py
+++ b/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_grid_power_formula.py
@@ -64,7 +64,7 @@ class GridPowerFormula(GridPowerFormulaBase[Power]):
                 fallback_formulas[primary_component] = None
                 continue
 
-            fallback_ids = [c.component_id for c in fallback_components]
+            fallback_ids = [c.id for c in fallback_components]
             generator = SimplePowerFormula(
                 f"{self._namespace}_fallback_{fallback_ids}",
                 self._channel_registry,

--- a/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_grid_power_formula.py
+++ b/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_grid_power_formula.py
@@ -4,7 +4,8 @@
 """Formula generator from component graph for Grid Power."""
 
 
-from frequenz.client.microgrid import Component, ComponentMetricId
+from frequenz.client.microgrid import Component
+from frequenz.client.microgrid.metrics import Metric
 from frequenz.quantities import Power
 
 from .._formula_engine import FormulaEngine
@@ -31,7 +32,7 @@ class GridPowerFormula(GridPowerFormulaBase[Power]):
         """
         builder = self._get_builder(
             "grid-power",
-            ComponentMetricId.ACTIVE_POWER,
+            Metric.AC_ACTIVE_POWER,
             Power.from_watts,
         )
         return self._generate(builder)

--- a/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_grid_power_formula_base.py
+++ b/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_grid_power_formula_base.py
@@ -69,7 +69,7 @@ class GridPowerFormulaBase(FormulaGenerator[QuantityT], ABC):
 
                 # should only be the case if the component is not a meter
                 builder.push_component_metric(
-                    primary_component.component_id,
+                    primary_component.id,
                     nones_are_zeros=(
                         primary_component.category != ComponentCategory.METER
                     ),
@@ -81,7 +81,7 @@ class GridPowerFormulaBase(FormulaGenerator[QuantityT], ABC):
                     builder.push_oper("+")
 
                 builder.push_component_metric(
-                    comp.component_id,
+                    comp.id,
                     nones_are_zeros=(comp.category != ComponentCategory.METER),
                 )
 

--- a/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_grid_power_formula_base.py
+++ b/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_grid_power_formula_base.py
@@ -5,7 +5,7 @@
 
 from abc import ABC, abstractmethod
 
-from frequenz.client.microgrid import Component, ComponentCategory
+from frequenz.client.microgrid.component import Component, EvCharger, Inverter, Meter
 
 from ..._base_types import QuantityT
 from .._formula_engine import FormulaEngine
@@ -33,15 +33,8 @@ class GridPowerFormulaBase(FormulaGenerator[QuantityT], ABC):
         """
         grid_successors = self._get_grid_component_successors()
 
-        components = {
-            c
-            for c in grid_successors
-            if c.category
-            in {
-                ComponentCategory.INVERTER,
-                ComponentCategory.EV_CHARGER,
-                ComponentCategory.METER,
-            }
+        components: set[Component] = {
+            c for c in grid_successors if isinstance(c, (Inverter, EvCharger, Meter))
         }
 
         if not components:
@@ -70,9 +63,7 @@ class GridPowerFormulaBase(FormulaGenerator[QuantityT], ABC):
                 # should only be the case if the component is not a meter
                 builder.push_component_metric(
                     primary_component.id,
-                    nones_are_zeros=(
-                        primary_component.category != ComponentCategory.METER
-                    ),
+                    nones_are_zeros=not isinstance(primary_component, Meter),
                     fallback=fallback_formula,
                 )
         else:
@@ -82,7 +73,7 @@ class GridPowerFormulaBase(FormulaGenerator[QuantityT], ABC):
 
                 builder.push_component_metric(
                     comp.id,
-                    nones_are_zeros=(comp.category != ComponentCategory.METER),
+                    nones_are_zeros=not isinstance(comp, Meter),
                 )
 
         return builder.build()

--- a/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_grid_reactive_power_formula.py
+++ b/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_grid_reactive_power_formula.py
@@ -4,7 +4,8 @@
 """Formula generator from component graph for Grid Reactive Power."""
 
 
-from frequenz.client.microgrid import Component, ComponentMetricId
+from frequenz.client.microgrid import Component
+from frequenz.client.microgrid.metrics import Metric
 from frequenz.quantities import ReactivePower
 
 from .._formula_engine import FormulaEngine
@@ -31,7 +32,7 @@ class GridReactivePowerFormula(GridPowerFormulaBase[ReactivePower]):
         """
         builder = self._get_builder(
             "grid_reactive_power_formula",
-            ComponentMetricId.REACTIVE_POWER,
+            Metric.AC_REACTIVE_POWER,
             ReactivePower.from_volt_amperes_reactive,
         )
         return self._generate(builder)

--- a/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_grid_reactive_power_formula.py
+++ b/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_grid_reactive_power_formula.py
@@ -4,7 +4,7 @@
 """Formula generator from component graph for Grid Reactive Power."""
 
 
-from frequenz.client.microgrid import Component
+from frequenz.client.microgrid.component import Component
 from frequenz.client.microgrid.metrics import Metric
 from frequenz.quantities import ReactivePower
 

--- a/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_grid_reactive_power_formula.py
+++ b/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_grid_reactive_power_formula.py
@@ -64,7 +64,7 @@ class GridReactivePowerFormula(GridPowerFormulaBase[ReactivePower]):
                 fallback_formulas[primary_component] = None
                 continue
 
-            fallback_ids = [c.component_id for c in fallback_components]
+            fallback_ids = [c.id for c in fallback_components]
             generator = SimpleReactivePowerFormula(
                 f"{self._namespace}_fallback_{fallback_ids}",
                 self._channel_registry,

--- a/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_producer_power_formula.py
+++ b/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_producer_power_formula.py
@@ -88,7 +88,7 @@ class ProducerPowerFormula(FormulaGenerator[Power]):
 
                 # should only be the case if the component is not a meter
                 builder.push_component_metric(
-                    primary_component.component_id,
+                    primary_component.id,
                     nones_are_zeros=is_not_meter(primary_component),
                     fallback=fallback_formula,
                 )
@@ -98,7 +98,7 @@ class ProducerPowerFormula(FormulaGenerator[Power]):
                     builder.push_oper("+")
 
                 builder.push_component_metric(
-                    component.component_id,
+                    component.id,
                     nones_are_zeros=is_not_meter(component),
                 )
 
@@ -131,7 +131,7 @@ class ProducerPowerFormula(FormulaGenerator[Power]):
                 fallback_formulas[primary_component] = None
                 continue
 
-            fallback_ids = [c.component_id for c in fallback_components]
+            fallback_ids = [c.id for c in fallback_components]
             generator = SimplePowerFormula(
                 f"{self._namespace}_fallback_{fallback_ids}",
                 self._channel_registry,

--- a/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_producer_power_formula.py
+++ b/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_producer_power_formula.py
@@ -6,7 +6,7 @@
 import logging
 from typing import Callable
 
-from frequenz.client.microgrid import Component, ComponentCategory
+from frequenz.client.microgrid.component import Component, Meter
 from frequenz.client.microgrid.metrics import Metric
 from frequenz.quantities import Power
 
@@ -73,8 +73,8 @@ class ProducerPowerFormula(FormulaGenerator[Power]):
             )
             return builder.build()
 
-        is_not_meter: Callable[[Component], bool] = (
-            lambda component: component.category != ComponentCategory.METER
+        is_not_meter: Callable[[Component], bool] = lambda component: not isinstance(
+            component, Meter
         )
 
         if self._config.allow_fallback:

--- a/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_producer_power_formula.py
+++ b/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_producer_power_formula.py
@@ -6,7 +6,8 @@
 import logging
 from typing import Callable
 
-from frequenz.client.microgrid import Component, ComponentCategory, ComponentMetricId
+from frequenz.client.microgrid import Component, ComponentCategory
+from frequenz.client.microgrid.metrics import Metric
 from frequenz.quantities import Power
 
 from ....microgrid import connection_manager
@@ -46,7 +47,7 @@ class ProducerPowerFormula(FormulaGenerator[Power]):
                 meter.
         """
         builder = self._get_builder(
-            "producer_power", ComponentMetricId.ACTIVE_POWER, Power.from_watts
+            "producer_power", Metric.AC_ACTIVE_POWER, Power.from_watts
         )
 
         component_graph = connection_manager.get().component_graph

--- a/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_pv_power_formula.py
+++ b/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_pv_power_formula.py
@@ -5,7 +5,7 @@
 
 import logging
 
-from frequenz.client.microgrid import Component, ComponentCategory
+from frequenz.client.microgrid.component import Component, Meter
 from frequenz.client.microgrid.metrics import Metric
 from frequenz.quantities import Power
 
@@ -80,9 +80,7 @@ class PVPowerFormula(FormulaGenerator[Power]):
 
                 builder.push_component_metric(
                     primary_component.id,
-                    nones_are_zeros=(
-                        primary_component.category != ComponentCategory.METER
-                    ),
+                    nones_are_zeros=not isinstance(primary_component, Meter),
                     fallback=fallback_formula,
                 )
         else:
@@ -92,7 +90,7 @@ class PVPowerFormula(FormulaGenerator[Power]):
 
                 builder.push_component_metric(
                     component.id,
-                    nones_are_zeros=component.category != ComponentCategory.METER,
+                    nones_are_zeros=not isinstance(component, Meter),
                 )
 
         return builder.build()

--- a/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_pv_power_formula.py
+++ b/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_pv_power_formula.py
@@ -5,7 +5,8 @@
 
 import logging
 
-from frequenz.client.microgrid import Component, ComponentCategory, ComponentMetricId
+from frequenz.client.microgrid import Component, ComponentCategory
+from frequenz.client.microgrid.metrics import Metric
 from frequenz.quantities import Power
 
 from ....microgrid import connection_manager
@@ -39,7 +40,7 @@ class PVPowerFormula(FormulaGenerator[Power]):
                 successors.
         """
         builder = self._get_builder(
-            "pv-power", ComponentMetricId.ACTIVE_POWER, Power.from_watts
+            "pv-power", Metric.AC_ACTIVE_POWER, Power.from_watts
         )
 
         component_graph = connection_manager.get().component_graph

--- a/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_pv_power_formula.py
+++ b/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_pv_power_formula.py
@@ -79,7 +79,7 @@ class PVPowerFormula(FormulaGenerator[Power]):
                     builder.push_oper("+")
 
                 builder.push_component_metric(
-                    primary_component.component_id,
+                    primary_component.id,
                     nones_are_zeros=(
                         primary_component.category != ComponentCategory.METER
                     ),
@@ -91,7 +91,7 @@ class PVPowerFormula(FormulaGenerator[Power]):
                     builder.push_oper("+")
 
                 builder.push_component_metric(
-                    component.component_id,
+                    component.id,
                     nones_are_zeros=component.category != ComponentCategory.METER,
                 )
 
@@ -123,7 +123,7 @@ class PVPowerFormula(FormulaGenerator[Power]):
             if len(fallback_components) == 0:
                 fallback_formulas[primary_component] = None
                 continue
-            fallback_ids = [c.component_id for c in fallback_components]
+            fallback_ids = [c.id for c in fallback_components]
 
             generator = PVPowerFormula(
                 f"{self._namespace}_fallback_{fallback_ids}",

--- a/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_simple_formula.py
+++ b/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_simple_formula.py
@@ -40,9 +40,7 @@ class SimpleFormulaBase(FormulaGenerator[QuantityT]):
             component_ids=set(self._config.component_ids)
         )
 
-        not_found_components = self._config.component_ids - {
-            c.component_id for c in components
-        }
+        not_found_components = self._config.component_ids - {c.id for c in components}
         if not_found_components:
             raise RuntimeError(
                 f"Unable to find {not_found_components} components in the component graph. ",
@@ -53,7 +51,7 @@ class SimpleFormulaBase(FormulaGenerator[QuantityT]):
                 builder.push_oper("+")
 
             builder.push_component_metric(
-                component.component_id,
+                component.id,
                 nones_are_zeros=component.category != ComponentCategory.METER,
             )
 

--- a/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_simple_formula.py
+++ b/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_simple_formula.py
@@ -3,7 +3,7 @@
 
 """Formula generator from component graph."""
 
-from frequenz.client.microgrid import ComponentCategory
+from frequenz.client.microgrid.component import Meter
 from frequenz.client.microgrid.metrics import Metric
 from frequenz.quantities import Power, ReactivePower
 
@@ -37,7 +37,7 @@ class SimpleFormulaBase(FormulaGenerator[QuantityT]):
             raise RuntimeError("Power formula without component ids is not supported.")
 
         components = component_graph.components(
-            component_ids=set(self._config.component_ids)
+            matching_ids=set(self._config.component_ids)
         )
 
         not_found_components = self._config.component_ids - {c.id for c in components}
@@ -52,7 +52,7 @@ class SimpleFormulaBase(FormulaGenerator[QuantityT]):
 
             builder.push_component_metric(
                 component.id,
-                nones_are_zeros=component.category != ComponentCategory.METER,
+                nones_are_zeros=not isinstance(component, Meter),
             )
 
         return builder.build()

--- a/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_simple_formula.py
+++ b/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_simple_formula.py
@@ -36,9 +36,7 @@ class SimpleFormulaBase(FormulaGenerator[QuantityT]):
         if self._config.component_ids is None:
             raise RuntimeError("Power formula without component ids is not supported.")
 
-        components = component_graph.components(
-            matching_ids=set(self._config.component_ids)
-        )
+        components = component_graph.components(matching_ids=self._config.component_ids)
 
         not_found_components = self._config.component_ids - {c.id for c in components}
         if not_found_components:

--- a/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_simple_formula.py
+++ b/src/frequenz/sdk/timeseries/formula_engine/_formula_generators/_simple_formula.py
@@ -3,7 +3,8 @@
 
 """Formula generator from component graph."""
 
-from frequenz.client.microgrid import ComponentCategory, ComponentMetricId
+from frequenz.client.microgrid import ComponentCategory
+from frequenz.client.microgrid.metrics import Metric
 from frequenz.quantities import Power, ReactivePower
 
 from ....microgrid import connection_manager
@@ -78,7 +79,7 @@ class SimplePowerFormula(SimpleFormulaBase[Power]):
         """
         builder = self._get_builder(
             "simple_power_formula",
-            ComponentMetricId.ACTIVE_POWER,
+            Metric.AC_ACTIVE_POWER,
             Power.from_watts,
         )
         return self._generate(builder)
@@ -103,7 +104,7 @@ class SimpleReactivePowerFormula(SimpleFormulaBase[ReactivePower]):
         """
         builder = self._get_builder(
             "simple_reactive_power_formula",
-            ComponentMetricId.REACTIVE_POWER,
+            Metric.AC_REACTIVE_POWER,
             ReactivePower.from_volt_amperes_reactive,
         )
         return self._generate(builder)

--- a/src/frequenz/sdk/timeseries/formula_engine/_resampled_formula_builder.py
+++ b/src/frequenz/sdk/timeseries/formula_engine/_resampled_formula_builder.py
@@ -9,8 +9,10 @@ from collections.abc import Callable
 
 from frequenz.channels import Receiver, Sender
 from frequenz.client.common.microgrid.components import ComponentId
-from frequenz.client.microgrid import ComponentMetricId
+from frequenz.client.microgrid.metrics import Metric
 from frequenz.quantities import Quantity
+
+from frequenz.sdk.microgrid._old_component_data import TransitionalMetric
 
 from ..._internal._channels import ChannelRegistry
 from ...microgrid._data_sourcing import ComponentMetricRequest
@@ -30,7 +32,7 @@ class ResampledFormulaBuilder(FormulaBuilder[QuantityT]):
         formula_name: str,
         channel_registry: ChannelRegistry,
         resampler_subscription_sender: Sender[ComponentMetricRequest],
-        metric_id: ComponentMetricId,
+        metric: Metric | TransitionalMetric,
         create_method: Callable[[float], QuantityT],
     ) -> None:
         """Create a `ResampledFormulaBuilder` instance.
@@ -43,7 +45,7 @@ class ResampledFormulaBuilder(FormulaBuilder[QuantityT]):
                 and the data sourcing actors.
             resampler_subscription_sender: A sender to send metric requests to the
                 resampling actor.
-            metric_id: A metric ID to fetch for all components in this formula.
+            metric: The metric to fetch for all components in this formula.
             create_method: A method to generate the output `Sample` value with.  If the
                 formula is for generating power values, this would be
                 `Power.from_watts`, for example.
@@ -53,23 +55,25 @@ class ResampledFormulaBuilder(FormulaBuilder[QuantityT]):
             resampler_subscription_sender
         )
         self._namespace: str = namespace
-        self._metric_id: ComponentMetricId = metric_id
+        self._metric: Metric | TransitionalMetric = metric
         self._resampler_requests: list[ComponentMetricRequest] = []
         super().__init__(formula_name, create_method)
 
     def _get_resampled_receiver(
-        self, component_id: ComponentId, metric_id: ComponentMetricId
+        self,
+        component_id: ComponentId,
+        metric: Metric | TransitionalMetric,
     ) -> Receiver[Sample[QuantityT]]:
         """Get a receiver with the resampled data for the given component id.
 
         Args:
             component_id: The component id for which to get a resampled data receiver.
-            metric_id: A metric ID to fetch for all components in this formula.
+            metric: The metric to fetch for all components in this formula.
 
         Returns:
             A receiver to stream resampled data for the given component id.
         """
-        request = ComponentMetricRequest(self._namespace, component_id, metric_id, None)
+        request = ComponentMetricRequest(self._namespace, component_id, metric, None)
         self._resampler_requests.append(request)
         resampled_channel = self._channel_registry.get_or_create(
             Sample[Quantity], request.get_channel_name()
@@ -108,7 +112,7 @@ class ResampledFormulaBuilder(FormulaBuilder[QuantityT]):
                 invalid data (e.g. due to a component stop). If None the data from
                 primary metric fetcher will be returned.
         """
-        receiver = self._get_resampled_receiver(component_id, self._metric_id)
+        receiver = self._get_resampled_receiver(component_id, self._metric)
         self.push_metric(
             f"#{int(component_id)}",
             receiver,

--- a/src/frequenz/sdk/timeseries/grid.py
+++ b/src/frequenz/sdk/timeseries/grid.py
@@ -13,7 +13,8 @@ import uuid
 from dataclasses import dataclass
 
 from frequenz.channels import Sender
-from frequenz.client.microgrid._component import ComponentCategory, ComponentMetricId
+from frequenz.client.microgrid._component import ComponentCategory
+from frequenz.client.microgrid.metrics import Metric
 from frequenz.quantities import Current, Power, ReactivePower
 
 from .._internal._channels import ChannelRegistry
@@ -112,7 +113,7 @@ class Grid:
             A FormulaEngine that will calculate and stream grid reactive power.
         """
         engine = self._formula_pool.from_reactive_power_formula_generator(
-            f"grid-{ComponentMetricId.REACTIVE_POWER.value}",
+            f"grid-{Metric.AC_REACTIVE_POWER.value}",
             GridReactivePowerFormula,
         )
         assert isinstance(engine, FormulaEngine)

--- a/src/frequenz/sdk/timeseries/grid.py
+++ b/src/frequenz/sdk/timeseries/grid.py
@@ -13,7 +13,7 @@ import uuid
 from dataclasses import dataclass
 
 from frequenz.channels import Sender
-from frequenz.client.microgrid._component import ComponentCategory
+from frequenz.client.microgrid.component import GridConnectionPoint
 from frequenz.client.microgrid.metrics import Metric
 from frequenz.quantities import Current, Power, ReactivePower
 
@@ -187,33 +187,29 @@ def initialize(
 
     grid_connections = list(
         connection_manager.get().component_graph.components(
-            component_categories={ComponentCategory.GRID},
+            matching_types={GridConnectionPoint}
         )
     )
 
-    grid_connections_count = len(grid_connections)
-
     fuse: Fuse | None = None
-
-    match grid_connections_count:
+    match len(grid_connections):
         case 0:
             fuse = Fuse(max_current=Current.zero())
             _logger.info(
                 "No grid connection found for this microgrid. "
-                "This is normal for an islanded microgrid."
+                "This is normal for an islanded microgrid. Setting the grid connection "
+                "fuse to zero as no electricity can flow from/to the grid."
             )
         case 1:
-            metadata = grid_connections[0].metadata
-            if metadata is None:
-                _logger.warning(
-                    "Unable to get grid metadata, the grid connection point is "
-                    "considered to have no fuse"
-                )
-            elif metadata.fuse is None:
+            grid_connection_point = grid_connections[0]
+            assert isinstance(grid_connection_point, GridConnectionPoint)
+            rated_fuse_current = grid_connection_point.rated_fuse_current
+            if rated_fuse_current is None:
                 _logger.warning("The grid connection point does not have a fuse")
             else:
-                fuse = Fuse(max_current=Current.from_amperes(metadata.fuse.max_current))
-        case _:
+                fuse = Fuse(max_current=Current.from_amperes(rated_fuse_current))
+                _logger.info("Grid connection fuse: %s", fuse)
+        case grid_connections_count:
             raise RuntimeError(
                 f"Expected at most one grid connection, got {grid_connections_count}"
             )

--- a/src/frequenz/sdk/timeseries/grid.py
+++ b/src/frequenz/sdk/timeseries/grid.py
@@ -187,7 +187,7 @@ def initialize(
 
     grid_connections = list(
         connection_manager.get().component_graph.components(
-            matching_types={GridConnectionPoint}
+            matching_types=GridConnectionPoint
         )
     )
 

--- a/src/frequenz/sdk/timeseries/logical_meter/_logical_meter.py
+++ b/src/frequenz/sdk/timeseries/logical_meter/_logical_meter.py
@@ -7,10 +7,11 @@
 import uuid
 
 from frequenz.channels import Sender
+from frequenz.client.microgrid.metrics import Metric
 from frequenz.quantities import Power, Quantity
 
 from ..._internal._channels import ChannelRegistry
-from ...microgrid._data_sourcing import ComponentMetricId, ComponentMetricRequest
+from ...microgrid._data_sourcing import ComponentMetricRequest
 from ..formula_engine import FormulaEngine
 from ..formula_engine._formula_engine_pool import FormulaEnginePool
 from ..formula_engine._formula_generators import CHPPowerFormula
@@ -34,7 +35,7 @@ class LogicalMeter:
 
         from frequenz.sdk import microgrid
         from frequenz.sdk.timeseries import ResamplerConfig2
-        from frequenz.client.microgrid import ComponentMetricId
+        from frequenz.client.microgrid.metrics import Metric
 
 
         await microgrid.initialize(
@@ -44,7 +45,7 @@ class LogicalMeter:
 
         logical_meter = (
             microgrid.logical_meter()
-            .start_formula("#1001 + #1002", ComponentMetricId.ACTIVE_POWER)
+            .start_formula("#1001 + #1002", Metric.AC_ACTIVE_POWER)
             .new_receiver()
         )
 
@@ -88,7 +89,7 @@ class LogicalMeter:
     def start_formula(
         self,
         formula: str,
-        component_metric_id: ComponentMetricId,
+        metric: Metric,
         *,
         nones_are_zeros: bool = False,
     ) -> FormulaEngine[Quantity]:
@@ -102,8 +103,7 @@ class LogicalMeter:
 
         Args:
             formula: formula to execute.
-            component_metric_id: The metric ID to use when fetching receivers from the
-                resampling actor.
+            metric: The metric to use when fetching receivers from the resampling actor.
             nones_are_zeros: Whether to treat None values from the stream as 0s.  If
                 False, the returned value will be a None.
 
@@ -111,7 +111,7 @@ class LogicalMeter:
             A FormulaEngine that applies the formula and streams values.
         """
         return self._formula_pool.from_string(
-            formula, component_metric_id, nones_are_zeros=nones_are_zeros
+            formula, metric, nones_are_zeros=nones_are_zeros
         )
 
     @property

--- a/src/frequenz/sdk/timeseries/pv_pool/_pv_pool_reference_store.py
+++ b/src/frequenz/sdk/timeseries/pv_pool/_pv_pool_reference_store.py
@@ -77,7 +77,7 @@ class PVPoolReferenceStore:
         else:
             graph = connection_manager.get().component_graph
             self.component_ids = frozenset(
-                {inv.id for inv in graph.components(matching_types={SolarInverter})}
+                {inv.id for inv in graph.components(matching_types=SolarInverter)}
             )
 
         self.power_bounds_subs: dict[str, asyncio.Task[None]] = {}

--- a/src/frequenz/sdk/timeseries/pv_pool/_pv_pool_reference_store.py
+++ b/src/frequenz/sdk/timeseries/pv_pool/_pv_pool_reference_store.py
@@ -78,7 +78,7 @@ class PVPoolReferenceStore:
             graph = connection_manager.get().component_graph
             self.component_ids = frozenset(
                 {
-                    inv.component_id
+                    inv.id
                     for inv in graph.components(
                         component_categories={ComponentCategory.INVERTER}
                     )

--- a/src/frequenz/sdk/timeseries/pv_pool/_pv_pool_reference_store.py
+++ b/src/frequenz/sdk/timeseries/pv_pool/_pv_pool_reference_store.py
@@ -10,7 +10,7 @@ from collections import abc
 
 from frequenz.channels import Broadcast, Receiver, Sender
 from frequenz.client.common.microgrid.components import ComponentId
-from frequenz.client.microgrid import ComponentCategory, InverterType
+from frequenz.client.microgrid.component import SolarInverter
 
 from ..._internal._channels import ChannelRegistry, ReceiverFetcher
 from ...microgrid import connection_manager
@@ -77,13 +77,7 @@ class PVPoolReferenceStore:
         else:
             graph = connection_manager.get().component_graph
             self.component_ids = frozenset(
-                {
-                    inv.id
-                    for inv in graph.components(
-                        component_categories={ComponentCategory.INVERTER}
-                    )
-                    if inv.type == InverterType.SOLAR
-                }
+                {inv.id for inv in graph.components(matching_types={SolarInverter})}
             )
 
         self.power_bounds_subs: dict[str, asyncio.Task[None]] = {}

--- a/src/frequenz/sdk/timeseries/pv_pool/_system_bounds_tracker.py
+++ b/src/frequenz/sdk/timeseries/pv_pool/_system_bounds_tracker.py
@@ -8,12 +8,12 @@ from collections import abc
 
 from frequenz.channels import Receiver, Sender, merge, select, selected_from
 from frequenz.client.common.microgrid.components import ComponentId
-from frequenz.client.microgrid import InverterData
 from frequenz.quantities import Power
 
 from ..._internal._asyncio import run_forever
 from ...actor import BackgroundService
 from ...microgrid import connection_manager
+from ...microgrid._old_component_data import InverterData
 from ...microgrid._power_distributing._component_status import ComponentPoolStatus
 from .._base_types import Bounds, SystemBounds
 
@@ -108,12 +108,8 @@ class PVSystemBoundsTracker(BackgroundService):
         status_rx = self._status_receiver
         pv_data_rx = merge(
             *(
-                await asyncio.gather(
-                    *(
-                        api_client.inverter_data(component_id)
-                        for component_id in self._component_ids
-                    )
-                )
+                InverterData.subscribe(api_client, component_id)
+                for component_id in self._component_ids
             )
         )
 

--- a/tests/actor/test_resampling.py
+++ b/tests/actor/test_resampling.py
@@ -11,7 +11,7 @@ import pytest
 import time_machine
 from frequenz.channels import Broadcast
 from frequenz.client.common.microgrid.components import ComponentId
-from frequenz.client.microgrid import ComponentMetricId
+from frequenz.client.microgrid.metrics import Metric
 from frequenz.quantities import Quantity
 
 from frequenz.sdk._internal._channels import ChannelRegistry
@@ -121,7 +121,7 @@ async def test_single_request(
         subs_req = ComponentMetricRequest(
             namespace="Resampling",
             component_id=ComponentId(9),
-            metric_id=ComponentMetricId.SOC,
+            metric=Metric.BATTERY_SOC_PCT,
             start_time=None,
         )
 
@@ -164,7 +164,7 @@ async def test_duplicate_request(
         subs_req = ComponentMetricRequest(
             namespace="Resampling",
             component_id=ComponentId(9),
-            metric_id=ComponentMetricId.SOC,
+            metric=Metric.BATTERY_SOC_PCT,
             start_time=None,
         )
 

--- a/tests/microgrid/fixtures.py
+++ b/tests/microgrid/fixtures.py
@@ -12,7 +12,7 @@ from datetime import timedelta
 from typing import AsyncIterator
 
 from frequenz.channels import Sender
-from frequenz.client.microgrid import ComponentCategory
+from frequenz.client.microgrid.component import ComponentCategory
 from pytest_mock import MockerFixture
 
 from frequenz.sdk import microgrid

--- a/tests/microgrid/power_distributing/_component_status/test_battery_pool_status.py
+++ b/tests/microgrid/power_distributing/_component_status/test_battery_pool_status.py
@@ -68,7 +68,7 @@ class TestBatteryPoolStatus:
             batteries_list = list(batteries)
 
             await mock_microgrid.mock_client.send(
-                battery_data(component_id=batteries_list[0])
+                battery_data(component_id=batteries_list[0]).to_samples()
             )
             await asyncio.sleep(0.1)
             assert (
@@ -77,7 +77,9 @@ class TestBatteryPoolStatus:
 
             expected_working.add(batteries_list[0])
             await mock_microgrid.mock_client.send(
-                inverter_data(component_id=ComponentId(int(batteries_list[0]) - 1))
+                inverter_data(
+                    component_id=ComponentId(int(batteries_list[0]) - 1)
+                ).to_samples()
             )
             await asyncio.sleep(0.1)
             assert (
@@ -87,17 +89,21 @@ class TestBatteryPoolStatus:
             assert msg == batteries_status._current_status
 
             await mock_microgrid.mock_client.send(
-                inverter_data(component_id=ComponentId(int(batteries_list[1]) - 1))
+                inverter_data(
+                    component_id=ComponentId(int(batteries_list[1]) - 1)
+                ).to_samples()
             )
             await mock_microgrid.mock_client.send(
-                battery_data(component_id=batteries_list[1])
+                battery_data(component_id=batteries_list[1]).to_samples()
             )
 
             await mock_microgrid.mock_client.send(
-                inverter_data(component_id=ComponentId(int(batteries_list[2]) - 1))
+                inverter_data(
+                    component_id=ComponentId(int(batteries_list[2]) - 1)
+                ).to_samples()
             )
             await mock_microgrid.mock_client.send(
-                battery_data(component_id=batteries_list[2])
+                battery_data(component_id=batteries_list[2]).to_samples()
             )
 
             expected_working = set(batteries_list)

--- a/tests/microgrid/power_distributing/_component_status/test_battery_pool_status.py
+++ b/tests/microgrid/power_distributing/_component_status/test_battery_pool_status.py
@@ -41,7 +41,7 @@ class TestBatteryPoolStatus:
         async with AsyncExitStack() as stack:
             await stack.enter_async_context(mock_microgrid)
             batteries = {
-                battery.component_id
+                battery.id
                 for battery in mock_microgrid.mock_client.component_graph.components(
                     component_categories={ComponentCategory.BATTERY}
                 )

--- a/tests/microgrid/power_distributing/_component_status/test_battery_pool_status.py
+++ b/tests/microgrid/power_distributing/_component_status/test_battery_pool_status.py
@@ -8,7 +8,7 @@ from datetime import timedelta
 
 from frequenz.channels import Broadcast
 from frequenz.client.common.microgrid.components import ComponentId
-from frequenz.client.microgrid import ComponentCategory
+from frequenz.client.microgrid.component import Battery
 from pytest_mock import MockerFixture
 
 from frequenz.sdk.microgrid._power_distributing._component_pool_status_tracker import (
@@ -43,7 +43,7 @@ class TestBatteryPoolStatus:
             batteries = {
                 battery.id
                 for battery in mock_microgrid.mock_client.component_graph.components(
-                    component_categories={ComponentCategory.BATTERY}
+                    matching_types={Battery}
                 )
             }
             battery_status_channel = Broadcast[ComponentPoolStatus](

--- a/tests/microgrid/power_distributing/_component_status/test_battery_pool_status.py
+++ b/tests/microgrid/power_distributing/_component_status/test_battery_pool_status.py
@@ -43,7 +43,7 @@ class TestBatteryPoolStatus:
             batteries = {
                 battery.id
                 for battery in mock_microgrid.mock_client.component_graph.components(
-                    matching_types={Battery}
+                    matching_types=Battery
                 )
             }
             battery_status_channel = Broadcast[ComponentPoolStatus](

--- a/tests/microgrid/power_distributing/_component_status/test_battery_status.py
+++ b/tests/microgrid/power_distributing/_component_status/test_battery_status.py
@@ -7,7 +7,7 @@
 
 import asyncio
 import math
-from collections.abc import AsyncIterator, Iterable
+from collections.abc import AsyncIterator, Set
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from typing import Generic, TypeVar
@@ -16,16 +16,7 @@ import async_solipsism
 import pytest
 from frequenz.channels import Broadcast, Receiver
 from frequenz.client.common.microgrid.components import ComponentId
-from frequenz.client.microgrid import (
-    BatteryComponentState,
-    BatteryError,
-    BatteryErrorCode,
-    BatteryRelayState,
-    ErrorLevel,
-    InverterComponentState,
-    InverterError,
-    InverterErrorCode,
-)
+from frequenz.client.microgrid.component import ComponentErrorCode, ComponentStateCode
 from pytest_mock import MockerFixture
 from time_machine import TimeMachineFixture
 
@@ -51,9 +42,11 @@ def event_loop_policy() -> async_solipsism.EventLoopPolicy:
 def battery_data(  # pylint: disable=too-many-arguments,too-many-positional-arguments
     component_id: ComponentId,
     timestamp: datetime | None = None,
-    relay_state: BatteryRelayState = BatteryRelayState.CLOSED,
-    component_state: BatteryComponentState = BatteryComponentState.CHARGING,
-    errors: Iterable[BatteryError] | None = None,
+    states: Set[ComponentStateCode] = frozenset(
+        [ComponentStateCode.CHARGING, ComponentStateCode.RELAY_CLOSED]
+    ),
+    errors: Set[ComponentErrorCode] = frozenset(),
+    warnings: Set[ComponentErrorCode] = frozenset(),
     capacity: float = 0,
 ) -> BatteryData:
     """Create BatteryData with given arguments.
@@ -66,11 +59,10 @@ def battery_data(  # pylint: disable=too-many-arguments,too-many-positional-argu
         component_id: component id
         timestamp: Timestamp of the component message.
             Defaults to datetime.now(tz=timezone.utc).
-        relay_state: Battery relay state.
-            Defaults to BatteryRelayState.CLOSED.
-        component_state: Component state.
-            Defaults to BatteryComponentState.CHARGING.
+        states: Component states.
+            Defaults to {ComponentStateCode.CHARGING, ComponentStateCode.RELAY_CLOSED}.
         errors: List of the components error. By default empty list will be created.
+        warnings: List of the components warnings. By default empty list will be created.
         capacity: Battery capacity.
 
     Returns:
@@ -80,17 +72,18 @@ def battery_data(  # pylint: disable=too-many-arguments,too-many-positional-argu
         component_id=component_id,
         capacity=capacity,
         timestamp=datetime.now(tz=timezone.utc) if timestamp is None else timestamp,
-        relay_state=relay_state,
-        component_state=component_state,
-        errors=list(errors) if errors is not None else [],
+        states=states,
+        errors=errors,
+        warnings=warnings,
     )
 
 
 def inverter_data(
     component_id: ComponentId,
     timestamp: datetime | None = None,
-    component_state: InverterComponentState = InverterComponentState.CHARGING,
-    errors: list[InverterError] | None = None,
+    states: Set[ComponentStateCode] = frozenset([ComponentStateCode.CHARGING]),
+    errors: Set[ComponentErrorCode] = frozenset(),
+    warnings: Set[ComponentErrorCode] = frozenset(),
 ) -> InverterData:
     """Create InverterData with given arguments.
 
@@ -102,9 +95,10 @@ def inverter_data(
         component_id: component id
         timestamp: Timestamp of the component message.
             Defaults to datetime.now(tz=timezone.utc).
-        component_state: Component state.
-            Defaults to InverterComponentState.CHARGING.
+        states: Component states.
+            Defaults to {ComponentStateCode.CHARGING}.
         errors: List of the components error. By default empty list will be created.
+        warnings: List of the components warnings. By default empty list will be created.
 
     Returns:
         InverterData with given arguments.
@@ -112,8 +106,9 @@ def inverter_data(
     return InverterDataWrapper(
         component_id=component_id,
         timestamp=datetime.now(tz=timezone.utc) if timestamp is None else timestamp,
-        component_state=component_state,
+        states=states,
         errors=errors,
+        warnings=warnings,
     )
 
 
@@ -195,7 +190,7 @@ class TestBatteryStatus:
             tracker._handle_status_battery(
                 battery_data(
                     component_id=BATTERY_ID,
-                    relay_state=BatteryRelayState.OPENED,
+                    states={ComponentStateCode.RELAY_OPEN, ComponentStateCode.READY},
                 )
             )
             assert tracker._get_new_status_if_changed() is None
@@ -211,30 +206,22 @@ class TestBatteryStatus:
             tracker._handle_status_inverter(
                 inverter_data(
                     component_id=INVERTER_ID,
-                    component_state=InverterComponentState.SWITCHING_OFF,
+                    states={ComponentStateCode.SWITCHING_OFF},
                 )
             )
             assert (
                 tracker._get_new_status_if_changed() is ComponentStatusEnum.NOT_WORKING
             )
 
-            inverter_critical_error = InverterError(
-                code=InverterErrorCode.UNSPECIFIED,
-                level=ErrorLevel.CRITICAL,
-                message="",
-            )
-
-            inverter_warning_error = InverterError(
-                code=InverterErrorCode.UNSPECIFIED,
-                level=ErrorLevel.WARN,
-                message="",
-            )
+            inverter_errors = {ComponentErrorCode.UNSPECIFIED}
+            inverter_warnings = {ComponentErrorCode.UNSPECIFIED}
 
             tracker._handle_status_inverter(
                 inverter_data(
                     component_id=INVERTER_ID,
-                    component_state=InverterComponentState.SWITCHING_OFF,
-                    errors=[inverter_critical_error, inverter_warning_error],
+                    states={ComponentStateCode.SWITCHING_OFF},
+                    errors=inverter_errors,
+                    warnings=inverter_warnings,
                 )
             )
 
@@ -243,32 +230,24 @@ class TestBatteryStatus:
             tracker._handle_status_inverter(
                 inverter_data(
                     component_id=INVERTER_ID,
-                    errors=[inverter_critical_error, inverter_warning_error],
+                    errors=inverter_errors,
+                    warnings=inverter_warnings,
                 )
             )
 
             assert tracker._get_new_status_if_changed() is None
 
             tracker._handle_status_inverter(
-                inverter_data(component_id=INVERTER_ID, errors=[inverter_warning_error])
+                inverter_data(component_id=INVERTER_ID, warnings=inverter_warnings)
             )
 
             assert tracker._get_new_status_if_changed() is ComponentStatusEnum.WORKING
 
-            battery_critical_error = BatteryError(
-                code=BatteryErrorCode.UNSPECIFIED,
-                level=ErrorLevel.CRITICAL,
-                message="",
-            )
-
-            battery_warning_error = BatteryError(
-                code=BatteryErrorCode.UNSPECIFIED,
-                level=ErrorLevel.WARN,
-                message="",
-            )
+            battery_errors = {ComponentErrorCode.UNSPECIFIED}
+            battery_warnings = {ComponentErrorCode.UNSPECIFIED}
 
             tracker._handle_status_battery(
-                battery_data(component_id=BATTERY_ID, errors=[battery_warning_error])
+                battery_data(component_id=BATTERY_ID, warnings=battery_warnings)
             )
 
             assert tracker._get_new_status_if_changed() is None
@@ -276,7 +255,8 @@ class TestBatteryStatus:
             tracker._handle_status_battery(
                 battery_data(
                     component_id=BATTERY_ID,
-                    errors=[battery_warning_error, battery_critical_error],
+                    errors=battery_errors,
+                    warnings=battery_warnings,
                 )
             )
 
@@ -287,8 +267,9 @@ class TestBatteryStatus:
             tracker._handle_status_battery(
                 battery_data(
                     component_id=BATTERY_ID,
-                    component_state=BatteryComponentState.ERROR,
-                    errors=[battery_warning_error, battery_critical_error],
+                    states={ComponentStateCode.ERROR},
+                    errors=battery_errors,
+                    warnings=battery_warnings,
                 )
             )
 
@@ -344,7 +325,7 @@ class TestBatteryStatus:
                 tracker._handle_status_battery(
                     battery_data(
                         component_id=BATTERY_ID,
-                        component_state=BatteryComponentState.ERROR,
+                        states={ComponentStateCode.ERROR},
                     )
                 )
 
@@ -414,7 +395,7 @@ class TestBatteryStatus:
                 tracker._handle_status_battery(
                     battery_data(
                         component_id=BATTERY_ID,
-                        component_state=BatteryComponentState.ERROR,
+                        states={ComponentStateCode.ERROR},
                     )
                 )
 
@@ -441,7 +422,7 @@ class TestBatteryStatus:
 
                 # If battery succeed, then it should unblock.
                 tracker._handle_status_set_power_result(
-                    SetPowerResult(succeeded={BATTERY_ID}, failed={ComponentId(19)})
+                    SetPowerResult(succeeded={BATTERY_ID}, failed={ComponentId(1)})
                 )
                 assert (
                     tracker._get_new_status_if_changed() is ComponentStatusEnum.WORKING
@@ -542,7 +523,7 @@ class TestBatteryStatus:
             tracker._handle_status_inverter(
                 inverter_data(
                     component_id=INVERTER_ID,
-                    component_state=InverterComponentState.ERROR,
+                    states={ComponentStateCode.ERROR},
                 )
             )
             assert (
@@ -757,8 +738,7 @@ class TestBatteryStatusRecovery:
             battery_data(
                 timestamp=timestamp,
                 component_id=BATTERY_ID,
-                component_state=BatteryComponentState.IDLE,
-                relay_state=BatteryRelayState.CLOSED,
+                states={ComponentStateCode.READY, ComponentStateCode.RELAY_CLOSED},
             ).to_samples()
         )
 
@@ -768,8 +748,7 @@ class TestBatteryStatusRecovery:
         await mock_microgrid.mock_client.send(
             battery_data(
                 component_id=BATTERY_ID,
-                component_state=BatteryComponentState.IDLE,
-                relay_state=BatteryRelayState.CLOSED,
+                states={ComponentStateCode.READY, ComponentStateCode.RELAY_CLOSED},
                 capacity=math.nan,
             ).to_samples()
         )
@@ -781,7 +760,7 @@ class TestBatteryStatusRecovery:
             inverter_data(
                 timestamp=timestamp,
                 component_id=INVERTER_ID,
-                component_state=InverterComponentState.IDLE,
+                states={ComponentStateCode.READY},
             ).to_samples()
         )
 
@@ -789,8 +768,7 @@ class TestBatteryStatusRecovery:
         await mock_microgrid.mock_client.send(
             battery_data(
                 component_id=BATTERY_ID,
-                component_state=BatteryComponentState.ERROR,
-                relay_state=BatteryRelayState.CLOSED,
+                states={ComponentStateCode.ERROR, ComponentStateCode.RELAY_CLOSED},
             ).to_samples()
         )
 
@@ -798,67 +776,49 @@ class TestBatteryStatusRecovery:
         await mock_microgrid.mock_client.send(
             inverter_data(
                 component_id=INVERTER_ID,
-                component_state=InverterComponentState.ERROR,
+                states={ComponentStateCode.ERROR},
             ).to_samples()
         )
 
     async def _send_critical_error_battery(self, mock_microgrid: MockMicrogrid) -> None:
-        battery_critical_error = BatteryError(
-            code=BatteryErrorCode.BLOCK_ERROR,
-            level=ErrorLevel.CRITICAL,
-            message="",
-        )
+        battery_errors = {ComponentErrorCode.BATTERY_BLOCK_ERROR}
         await mock_microgrid.mock_client.send(
             battery_data(
                 component_id=BATTERY_ID,
-                component_state=BatteryComponentState.IDLE,
-                relay_state=BatteryRelayState.CLOSED,
-                errors=[battery_critical_error],
+                states={ComponentStateCode.READY, ComponentStateCode.RELAY_CLOSED},
+                errors=battery_errors,
             ).to_samples()
         )
 
     async def _send_warning_error_battery(self, mock_microgrid: MockMicrogrid) -> None:
-        battery_warning_error = BatteryError(
-            code=BatteryErrorCode.HIGH_HUMIDITY,
-            level=ErrorLevel.WARN,
-            message="",
-        )
+        battery_warnings = {ComponentErrorCode.HIGH_HUMIDITY}
         await mock_microgrid.mock_client.send(
             battery_data(
                 component_id=BATTERY_ID,
-                component_state=BatteryComponentState.IDLE,
-                relay_state=BatteryRelayState.CLOSED,
-                errors=[battery_warning_error],
+                states={ComponentStateCode.READY, ComponentStateCode.RELAY_CLOSED},
+                warnings=battery_warnings,
             ).to_samples()
         )
 
     async def _send_critical_error_inverter(
         self, mock_microgrid: MockMicrogrid
     ) -> None:
-        inverter_critical_error = InverterError(
-            code=InverterErrorCode.UNSPECIFIED,
-            level=ErrorLevel.CRITICAL,
-            message="",
-        )
+        inverter_errors = {ComponentErrorCode.UNSPECIFIED}
         await mock_microgrid.mock_client.send(
             inverter_data(
                 component_id=INVERTER_ID,
-                component_state=InverterComponentState.IDLE,
-                errors=[inverter_critical_error],
+                states={ComponentStateCode.READY},
+                errors=inverter_errors,
             ).to_samples()
         )
 
     async def _send_warning_error_inverter(self, mock_microgrid: MockMicrogrid) -> None:
-        inverter_warning_error = InverterError(
-            code=InverterErrorCode.UNSPECIFIED,
-            level=ErrorLevel.WARN,
-            message="",
-        )
+        inverter_warnings = {ComponentErrorCode.UNSPECIFIED}
         await mock_microgrid.mock_client.send(
             inverter_data(
                 component_id=INVERTER_ID,
-                component_state=InverterComponentState.IDLE,
-                errors=[inverter_warning_error],
+                states={ComponentStateCode.READY},
+                warnings=inverter_warnings,
             ).to_samples()
         )
 

--- a/tests/microgrid/power_distributing/_component_status/test_battery_status.py
+++ b/tests/microgrid/power_distributing/_component_status/test_battery_status.py
@@ -18,19 +18,18 @@ from frequenz.channels import Broadcast, Receiver
 from frequenz.client.common.microgrid.components import ComponentId
 from frequenz.client.microgrid import (
     BatteryComponentState,
-    BatteryData,
     BatteryError,
     BatteryErrorCode,
     BatteryRelayState,
     ErrorLevel,
     InverterComponentState,
-    InverterData,
     InverterError,
     InverterErrorCode,
 )
 from pytest_mock import MockerFixture
 from time_machine import TimeMachineFixture
 
+from frequenz.sdk.microgrid._old_component_data import BatteryData, InverterData
 from frequenz.sdk.microgrid._power_distributing._component_status import (
     BatteryStatusTracker,
     ComponentStatus,
@@ -666,10 +665,10 @@ class TestBatteryStatus:
 
             with time_machine.travel("2022-01-01 00:00 UTC", tick=False) as time:
                 await mock_microgrid.mock_client.send(
-                    inverter_data(component_id=INVERTER_ID)
+                    inverter_data(component_id=INVERTER_ID).to_samples()
                 )
                 await mock_microgrid.mock_client.send(
-                    battery_data(component_id=BATTERY_ID)
+                    battery_data(component_id=BATTERY_ID).to_samples()
                 )
                 status = await asyncio.wait_for(status_receiver.receive(), timeout=0.1)
                 assert status.value is ComponentStatusEnum.WORKING
@@ -683,7 +682,7 @@ class TestBatteryStatus:
                 time.shift(2)
 
                 await mock_microgrid.mock_client.send(
-                    battery_data(component_id=BATTERY_ID)
+                    battery_data(component_id=BATTERY_ID).to_samples()
                 )
                 status = await asyncio.wait_for(status_receiver.receive(), timeout=0.1)
                 assert status.value is ComponentStatusEnum.WORKING
@@ -692,7 +691,7 @@ class TestBatteryStatus:
                     inverter_data(
                         component_id=INVERTER_ID,
                         timestamp=datetime.now(tz=timezone.utc) - timedelta(seconds=7),
-                    )
+                    ).to_samples()
                 )
                 status = await asyncio.wait_for(status_receiver.receive(), timeout=0.1)
                 assert status.value is ComponentStatusEnum.NOT_WORKING
@@ -706,7 +705,7 @@ class TestBatteryStatus:
                     await asyncio.wait_for(status_receiver.receive(), timeout=0.1)
 
                 await mock_microgrid.mock_client.send(
-                    inverter_data(component_id=INVERTER_ID)
+                    inverter_data(component_id=INVERTER_ID).to_samples()
                 )
                 status = await asyncio.wait_for(status_receiver.receive(), timeout=0.1)
                 assert status.value is ComponentStatusEnum.WORKING
@@ -760,7 +759,7 @@ class TestBatteryStatusRecovery:
                 component_id=BATTERY_ID,
                 component_state=BatteryComponentState.IDLE,
                 relay_state=BatteryRelayState.CLOSED,
-            )
+            ).to_samples()
         )
 
     async def _send_battery_missing_capacity(
@@ -772,7 +771,7 @@ class TestBatteryStatusRecovery:
                 component_state=BatteryComponentState.IDLE,
                 relay_state=BatteryRelayState.CLOSED,
                 capacity=math.nan,
-            )
+            ).to_samples()
         )
 
     async def _send_healthy_inverter(
@@ -783,7 +782,7 @@ class TestBatteryStatusRecovery:
                 timestamp=timestamp,
                 component_id=INVERTER_ID,
                 component_state=InverterComponentState.IDLE,
-            )
+            ).to_samples()
         )
 
     async def _send_bad_state_battery(self, mock_microgrid: MockMicrogrid) -> None:
@@ -792,7 +791,7 @@ class TestBatteryStatusRecovery:
                 component_id=BATTERY_ID,
                 component_state=BatteryComponentState.ERROR,
                 relay_state=BatteryRelayState.CLOSED,
-            )
+            ).to_samples()
         )
 
     async def _send_bad_state_inverter(self, mock_microgrid: MockMicrogrid) -> None:
@@ -800,7 +799,7 @@ class TestBatteryStatusRecovery:
             inverter_data(
                 component_id=INVERTER_ID,
                 component_state=InverterComponentState.ERROR,
-            )
+            ).to_samples()
         )
 
     async def _send_critical_error_battery(self, mock_microgrid: MockMicrogrid) -> None:
@@ -815,7 +814,7 @@ class TestBatteryStatusRecovery:
                 component_state=BatteryComponentState.IDLE,
                 relay_state=BatteryRelayState.CLOSED,
                 errors=[battery_critical_error],
-            )
+            ).to_samples()
         )
 
     async def _send_warning_error_battery(self, mock_microgrid: MockMicrogrid) -> None:
@@ -830,7 +829,7 @@ class TestBatteryStatusRecovery:
                 component_state=BatteryComponentState.IDLE,
                 relay_state=BatteryRelayState.CLOSED,
                 errors=[battery_warning_error],
-            )
+            ).to_samples()
         )
 
     async def _send_critical_error_inverter(
@@ -846,7 +845,7 @@ class TestBatteryStatusRecovery:
                 component_id=INVERTER_ID,
                 component_state=InverterComponentState.IDLE,
                 errors=[inverter_critical_error],
-            )
+            ).to_samples()
         )
 
     async def _send_warning_error_inverter(self, mock_microgrid: MockMicrogrid) -> None:
@@ -860,7 +859,7 @@ class TestBatteryStatusRecovery:
                 component_id=INVERTER_ID,
                 component_state=InverterComponentState.IDLE,
                 errors=[inverter_warning_error],
-            )
+            ).to_samples()
         )
 
     async def test_missing_data(

--- a/tests/microgrid/power_distributing/_component_status/test_ev_charger_status.py
+++ b/tests/microgrid/power_distributing/_component_status/test_ev_charger_status.py
@@ -62,7 +62,7 @@ class TestEVChargerStatusTracker:
                     active_power=0.0,
                     component_state=EVChargerComponentState.READY,
                     cable_state=EVChargerCableState.EV_PLUGGED,
-                )
+                ).to_samples()
             )
             assert await receive_timeout(status_receiver) == ComponentStatus(
                 _EV_CHARGER_ID, ComponentStatusEnum.WORKING
@@ -76,7 +76,7 @@ class TestEVChargerStatusTracker:
                     active_power=0.0,
                     component_state=EVChargerComponentState.READY,
                     cable_state=EVChargerCableState.EV_LOCKED,
-                )
+                ).to_samples()
             )
             assert await receive_timeout(status_receiver) is Timeout
 
@@ -88,7 +88,7 @@ class TestEVChargerStatusTracker:
                     active_power=0.0,
                     component_state=EVChargerComponentState.READY,
                     cable_state=EVChargerCableState.UNPLUGGED,
-                )
+                ).to_samples()
             )
             assert await receive_timeout(status_receiver) == ComponentStatus(
                 _EV_CHARGER_ID, ComponentStatusEnum.NOT_WORKING
@@ -102,7 +102,7 @@ class TestEVChargerStatusTracker:
                     active_power=0.0,
                     component_state=EVChargerComponentState.READY,
                     cable_state=EVChargerCableState.EV_LOCKED,
-                )
+                ).to_samples()
             )
             assert await receive_timeout(status_receiver) == ComponentStatus(
                 _EV_CHARGER_ID, ComponentStatusEnum.WORKING
@@ -123,7 +123,7 @@ class TestEVChargerStatusTracker:
                     active_power=0.0,
                     component_state=EVChargerComponentState.READY,
                     cable_state=EVChargerCableState.EV_LOCKED,
-                )
+                ).to_samples()
             )
             assert await receive_timeout(status_receiver) == ComponentStatus(
                 _EV_CHARGER_ID, ComponentStatusEnum.WORKING
@@ -138,7 +138,7 @@ class TestEVChargerStatusTracker:
                             active_power=0.0,
                             component_state=EVChargerComponentState.READY,
                             cable_state=EVChargerCableState.EV_LOCKED,
-                        )
+                        ).to_samples()
                     )
                     await asyncio.sleep(0.1)
 

--- a/tests/microgrid/power_distributing/_component_status/test_ev_charger_status.py
+++ b/tests/microgrid/power_distributing/_component_status/test_ev_charger_status.py
@@ -8,7 +8,7 @@ from datetime import datetime, timedelta, timezone
 
 from frequenz.channels import Broadcast
 from frequenz.client.common.microgrid.components import ComponentId
-from frequenz.client.microgrid import EVChargerCableState, EVChargerComponentState
+from frequenz.client.microgrid.component import ComponentStateCode
 from pytest_mock import MockerFixture
 
 from frequenz.sdk._internal._asyncio import cancel_and_await
@@ -60,8 +60,11 @@ class TestEVChargerStatusTracker:
                     _EV_CHARGER_ID,
                     datetime.now(tz=timezone.utc),
                     active_power=0.0,
-                    component_state=EVChargerComponentState.READY,
-                    cable_state=EVChargerCableState.EV_PLUGGED,
+                    states={
+                        ComponentStateCode.READY,
+                        ComponentStateCode.EV_CHARGING_CABLE_PLUGGED_AT_EV,
+                        ComponentStateCode.EV_CHARGING_CABLE_PLUGGED_AT_STATION,
+                    },
                 ).to_samples()
             )
             assert await receive_timeout(status_receiver) == ComponentStatus(
@@ -74,8 +77,11 @@ class TestEVChargerStatusTracker:
                     _EV_CHARGER_ID,
                     datetime.now(tz=timezone.utc),
                     active_power=0.0,
-                    component_state=EVChargerComponentState.READY,
-                    cable_state=EVChargerCableState.EV_LOCKED,
+                    states={
+                        ComponentStateCode.READY,
+                        ComponentStateCode.EV_CHARGING_CABLE_LOCKED_AT_EV,
+                        ComponentStateCode.EV_CHARGING_CABLE_LOCKED_AT_STATION,
+                    },
                 ).to_samples()
             )
             assert await receive_timeout(status_receiver) is Timeout
@@ -86,8 +92,10 @@ class TestEVChargerStatusTracker:
                     _EV_CHARGER_ID,
                     datetime.now(tz=timezone.utc),
                     active_power=0.0,
-                    component_state=EVChargerComponentState.READY,
-                    cable_state=EVChargerCableState.UNPLUGGED,
+                    states={
+                        ComponentStateCode.READY,
+                        ComponentStateCode.EV_CHARGING_CABLE_UNPLUGGED,
+                    },
                 ).to_samples()
             )
             assert await receive_timeout(status_receiver) == ComponentStatus(
@@ -100,8 +108,11 @@ class TestEVChargerStatusTracker:
                     _EV_CHARGER_ID,
                     datetime.now(tz=timezone.utc),
                     active_power=0.0,
-                    component_state=EVChargerComponentState.READY,
-                    cable_state=EVChargerCableState.EV_LOCKED,
+                    states={
+                        ComponentStateCode.READY,
+                        ComponentStateCode.EV_CHARGING_CABLE_PLUGGED_AT_EV,
+                        ComponentStateCode.EV_CHARGING_CABLE_LOCKED_AT_STATION,
+                    },
                 ).to_samples()
             )
             assert await receive_timeout(status_receiver) == ComponentStatus(
@@ -121,8 +132,11 @@ class TestEVChargerStatusTracker:
                     _EV_CHARGER_ID,
                     datetime.now(tz=timezone.utc),
                     active_power=0.0,
-                    component_state=EVChargerComponentState.READY,
-                    cable_state=EVChargerCableState.EV_LOCKED,
+                    states={
+                        ComponentStateCode.READY,
+                        ComponentStateCode.EV_CHARGING_CABLE_PLUGGED_AT_EV,
+                        ComponentStateCode.EV_CHARGING_CABLE_PLUGGED_AT_STATION,
+                    },
                 ).to_samples()
             )
             assert await receive_timeout(status_receiver) == ComponentStatus(
@@ -136,8 +150,11 @@ class TestEVChargerStatusTracker:
                             _EV_CHARGER_ID,
                             datetime.now(tz=timezone.utc),
                             active_power=0.0,
-                            component_state=EVChargerComponentState.READY,
-                            cable_state=EVChargerCableState.EV_LOCKED,
+                            states={
+                                ComponentStateCode.READY,
+                                ComponentStateCode.EV_CHARGING_CABLE_LOCKED_AT_EV,
+                                ComponentStateCode.EV_CHARGING_CABLE_LOCKED_AT_STATION,
+                            },
                         ).to_samples()
                     )
                     await asyncio.sleep(0.1)

--- a/tests/microgrid/power_distributing/_component_status/test_pv_inverter_status.py
+++ b/tests/microgrid/power_distributing/_component_status/test_pv_inverter_status.py
@@ -62,7 +62,7 @@ class TestPVInverterStatusTracker:
                     datetime.now(tz=timezone.utc),
                     active_power=0.0,
                     component_state=InverterComponentState.IDLE,
-                )
+                ).to_samples()
             )
             assert await receive_timeout(status_receiver) == ComponentStatus(
                 _PV_INVERTER_ID, ComponentStatusEnum.WORKING
@@ -75,7 +75,7 @@ class TestPVInverterStatusTracker:
                     datetime.now(tz=timezone.utc),
                     active_power=0.0,
                     component_state=InverterComponentState.DISCHARGING,
-                )
+                ).to_samples()
             )
             assert await receive_timeout(status_receiver) is Timeout
 
@@ -86,7 +86,7 @@ class TestPVInverterStatusTracker:
                     datetime.now(tz=timezone.utc),
                     active_power=0.0,
                     component_state=InverterComponentState.ERROR,
-                )
+                ).to_samples()
             )
             assert await receive_timeout(status_receiver) == ComponentStatus(
                 _PV_INVERTER_ID, ComponentStatusEnum.NOT_WORKING
@@ -99,7 +99,7 @@ class TestPVInverterStatusTracker:
                     datetime.now(tz=timezone.utc),
                     active_power=0.0,
                     component_state=InverterComponentState.IDLE,
-                )
+                ).to_samples()
             )
             assert await receive_timeout(status_receiver) == ComponentStatus(
                 _PV_INVERTER_ID, ComponentStatusEnum.WORKING
@@ -118,7 +118,7 @@ class TestPVInverterStatusTracker:
                     datetime.now(tz=timezone.utc),
                     active_power=0.0,
                     component_state=InverterComponentState.IDLE,
-                )
+                ).to_samples()
             )
             assert await receive_timeout(status_receiver) == ComponentStatus(
                 _PV_INVERTER_ID, ComponentStatusEnum.WORKING
@@ -133,7 +133,7 @@ class TestPVInverterStatusTracker:
                             datetime.now(tz=timezone.utc),
                             active_power=0.0,
                             component_state=InverterComponentState.IDLE,
-                        )
+                        ).to_samples()
                     )
                     await asyncio.sleep(0.1)
 

--- a/tests/microgrid/power_distributing/_component_status/test_pv_inverter_status.py
+++ b/tests/microgrid/power_distributing/_component_status/test_pv_inverter_status.py
@@ -9,7 +9,7 @@ from datetime import datetime, timedelta, timezone
 
 from frequenz.channels import Broadcast
 from frequenz.client.common.microgrid.components import ComponentId
-from frequenz.client.microgrid import InverterComponentState
+from frequenz.client.microgrid.component import ComponentStateCode
 from pytest_mock import MockerFixture
 
 from frequenz.sdk._internal._asyncio import cancel_and_await
@@ -61,7 +61,7 @@ class TestPVInverterStatusTracker:
                     _PV_INVERTER_ID,
                     datetime.now(tz=timezone.utc),
                     active_power=0.0,
-                    component_state=InverterComponentState.IDLE,
+                    states={ComponentStateCode.READY},
                 ).to_samples()
             )
             assert await receive_timeout(status_receiver) == ComponentStatus(
@@ -74,7 +74,7 @@ class TestPVInverterStatusTracker:
                     _PV_INVERTER_ID,
                     datetime.now(tz=timezone.utc),
                     active_power=0.0,
-                    component_state=InverterComponentState.DISCHARGING,
+                    states={ComponentStateCode.DISCHARGING},
                 ).to_samples()
             )
             assert await receive_timeout(status_receiver) is Timeout
@@ -85,7 +85,7 @@ class TestPVInverterStatusTracker:
                     _PV_INVERTER_ID,
                     datetime.now(tz=timezone.utc),
                     active_power=0.0,
-                    component_state=InverterComponentState.ERROR,
+                    states={ComponentStateCode.ERROR},
                 ).to_samples()
             )
             assert await receive_timeout(status_receiver) == ComponentStatus(
@@ -98,7 +98,7 @@ class TestPVInverterStatusTracker:
                     _PV_INVERTER_ID,
                     datetime.now(tz=timezone.utc),
                     active_power=0.0,
-                    component_state=InverterComponentState.IDLE,
+                    states={ComponentStateCode.READY},
                 ).to_samples()
             )
             assert await receive_timeout(status_receiver) == ComponentStatus(
@@ -117,7 +117,7 @@ class TestPVInverterStatusTracker:
                     _PV_INVERTER_ID,
                     datetime.now(tz=timezone.utc),
                     active_power=0.0,
-                    component_state=InverterComponentState.IDLE,
+                    states={ComponentStateCode.READY},
                 ).to_samples()
             )
             assert await receive_timeout(status_receiver) == ComponentStatus(
@@ -132,7 +132,7 @@ class TestPVInverterStatusTracker:
                             _PV_INVERTER_ID,
                             datetime.now(tz=timezone.utc),
                             active_power=0.0,
-                            component_state=InverterComponentState.IDLE,
+                            states={ComponentStateCode.READY},
                         ).to_samples()
                     )
                     await asyncio.sleep(0.1)

--- a/tests/microgrid/power_distributing/test_battery_distribution_algorithm.py
+++ b/tests/microgrid/power_distributing/test_battery_distribution_algorithm.py
@@ -9,10 +9,10 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 
 from frequenz.client.common.microgrid.components import ComponentId
-from frequenz.client.microgrid import BatteryData, InverterData
 from frequenz.quantities import Power
 from pytest import approx, raises
 
+from frequenz.sdk.microgrid._old_component_data import BatteryData, InverterData
 from frequenz.sdk.microgrid._power_distributing._distribution_algorithm import (
     AggregatedBatteryData,
     BatteryDistributionAlgorithm,

--- a/tests/microgrid/power_distributing/test_power_distributing.py
+++ b/tests/microgrid/power_distributing/test_power_distributing.py
@@ -368,8 +368,8 @@ class TestPowerDistributingActor:
             request = Request(
                 power=Power.from_watts(1200.0),
                 component_ids={
-                    bat_component1.component_id,
-                    bat_component2.component_id,
+                    bat_component1.id,
+                    bat_component2.id,
                 },
             )
 
@@ -427,13 +427,11 @@ class TestPowerDistributingActor:
         )
 
         async with _mocks(mocker, ComponentCategory.BATTERY, graph=graph) as mocks:
-            await self.init_component_data(
-                mocks, skip_batteries={bat_components[0].component_id}
-            )
+            await self.init_component_data(mocks, skip_batteries={bat_components[0].id})
 
             mocks.streamer.start_streaming(
                 battery_msg(
-                    bat_components[0].component_id,
+                    bat_components[0].id,
                     soc=Metric(math.nan, Bound(20, 80)),
                     capacity=Metric(98000),
                     power=PowerBounds(
@@ -451,7 +449,7 @@ class TestPowerDistributingActor:
 
             request = Request(
                 power=Power.from_watts(1200.0),
-                component_ids=set(battery.component_id for battery in bat_components),
+                component_ids=set(battery.id for battery in bat_components),
             )
 
             await self._patch_battery_pool_status(mocks, mocker, request.component_ids)
@@ -499,7 +497,7 @@ class TestPowerDistributingActor:
 
             request = Request(
                 power=Power.from_watts(1200.0),
-                component_ids={bat_component.component_id},
+                component_ids={bat_component.id},
             )
 
             await self._patch_battery_pool_status(mocks, mocker, request.component_ids)
@@ -546,7 +544,7 @@ class TestPowerDistributingActor:
 
             request = Request(
                 power=Power.from_watts(1700.0),
-                component_ids={batteries[0].component_id, batteries[1].component_id},
+                component_ids={batteries[0].id, batteries[1].id},
             )
 
             await self._patch_battery_pool_status(mocks, mocker, request.component_ids)
@@ -598,7 +596,7 @@ class TestPowerDistributingActor:
         async with _mocks(mocker, ComponentCategory.BATTERY, graph=graph) as mocks:
             mocks.streamer.start_streaming(
                 inverter_msg(
-                    inverter.component_id,
+                    inverter.id,
                     power=PowerBounds(
                         Power.from_watts(-1000),
                         Power.from_watts(-500),
@@ -610,7 +608,7 @@ class TestPowerDistributingActor:
             )
             mocks.streamer.start_streaming(
                 battery_msg(
-                    batteries[0].component_id,
+                    batteries[0].id,
                     soc=Metric(40, Bound(20, 80)),
                     capacity=Metric(10_000),
                     power=PowerBounds(
@@ -624,7 +622,7 @@ class TestPowerDistributingActor:
             )
             mocks.streamer.start_streaming(
                 battery_msg(
-                    batteries[1].component_id,
+                    batteries[1].id,
                     soc=Metric(40, Bound(20, 80)),
                     capacity=Metric(10_000),
                     power=PowerBounds(
@@ -642,7 +640,7 @@ class TestPowerDistributingActor:
 
             request = Request(
                 power=Power.from_watts(300.0),
-                component_ids={batteries[0].component_id, batteries[1].component_id},
+                component_ids={batteries[0].id, batteries[1].id},
             )
 
             await self._patch_battery_pool_status(mocks, mocker, request.component_ids)
@@ -703,11 +701,11 @@ class TestPowerDistributingActor:
 
         async with _mocks(mocker, ComponentCategory.BATTERY, graph=graph) as mocks:
             await self.init_component_data(
-                mocks, skip_batteries={bat.component_id for bat in batteries}
+                mocks, skip_batteries={bat.id for bat in batteries}
             )
             mocks.streamer.start_streaming(
                 battery_msg(
-                    batteries[0].component_id,
+                    batteries[0].id,
                     soc=Metric(40, Bound(20, 80)),
                     capacity=Metric(10_000),
                     power=PowerBounds(
@@ -721,7 +719,7 @@ class TestPowerDistributingActor:
             )
             mocks.streamer.start_streaming(
                 battery_msg(
-                    batteries[1].component_id,
+                    batteries[1].id,
                     soc=Metric(40, Bound(20, 80)),
                     capacity=Metric(10_000),
                     power=PowerBounds(
@@ -739,7 +737,7 @@ class TestPowerDistributingActor:
 
             request = Request(
                 power=Power.from_watts(300.0),
-                component_ids={batteries[0].component_id, batteries[1].component_id},
+                component_ids={batteries[0].id, batteries[1].id},
             )
 
             await self._patch_battery_pool_status(mocks, mocker, request.component_ids)
@@ -805,7 +803,7 @@ class TestPowerDistributingActor:
 
             request = Request(
                 power=Power.from_watts(600.0),
-                component_ids={batteries[0].component_id},
+                component_ids={batteries[0].id},
             )
 
             await self._patch_battery_pool_status(mocks, mocker, request.component_ids)

--- a/tests/microgrid/power_distributing/test_power_distributing.py
+++ b/tests/microgrid/power_distributing/test_power_distributing.py
@@ -13,7 +13,7 @@ from unittest.mock import MagicMock
 
 from frequenz.channels import Broadcast
 from frequenz.client.common.microgrid.components import ComponentId
-from frequenz.client.microgrid import ComponentCategory
+from frequenz.client.microgrid.component import Battery, ComponentCategory
 from frequenz.quantities import Power
 from pytest_mock import MockerFixture
 
@@ -107,8 +107,7 @@ class TestPowerDistributingActor:
                 name="battery_status"
             )
             async with PowerDistributingActor(
-                component_category=ComponentCategory.BATTERY,
-                component_type=None,
+                component_type=Battery,
                 requests_receiver=requests_channel.new_receiver(),
                 results_sender=results_channel.new_sender(),
                 component_pool_status_sender=battery_status_channel.new_sender(),
@@ -139,8 +138,7 @@ class TestPowerDistributingActor:
                 name="battery_status"
             )
             async with PowerDistributingActor(
-                component_category=ComponentCategory.BATTERY,
-                component_type=None,
+                Battery,
                 requests_receiver=requests_channel.new_receiver(),
                 results_sender=results_channel.new_sender(),
                 component_pool_status_sender=battery_status_channel.new_sender(),
@@ -214,8 +212,7 @@ class TestPowerDistributingActor:
 
         battery_status_channel = Broadcast[ComponentPoolStatus](name="battery_status")
         async with PowerDistributingActor(
-            component_category=ComponentCategory.BATTERY,
-            component_type=None,
+            Battery,
             requests_receiver=requests_channel.new_receiver(),
             results_sender=results_channel.new_sender(),
             component_pool_status_sender=battery_status_channel.new_sender(),
@@ -285,8 +282,7 @@ class TestPowerDistributingActor:
                 name="battery_status"
             )
             async with PowerDistributingActor(
-                component_category=ComponentCategory.BATTERY,
-                component_type=None,
+                Battery,
                 requests_receiver=requests_channel.new_receiver(),
                 results_sender=results_channel.new_sender(),
                 component_pool_status_sender=battery_status_channel.new_sender(),
@@ -380,8 +376,7 @@ class TestPowerDistributingActor:
             )
 
             async with PowerDistributingActor(
-                component_category=ComponentCategory.BATTERY,
-                component_type=None,
+                Battery,
                 requests_receiver=requests_channel.new_receiver(),
                 component_pool_status_sender=battery_status_channel.new_sender(),
                 results_sender=results_channel.new_sender(),
@@ -458,8 +453,7 @@ class TestPowerDistributingActor:
             )
 
             async with PowerDistributingActor(
-                component_category=ComponentCategory.BATTERY,
-                component_type=None,
+                Battery,
                 requests_receiver=requests_channel.new_receiver(),
                 component_pool_status_sender=battery_status_channel.new_sender(),
                 results_sender=results_channel.new_sender(),
@@ -506,8 +500,7 @@ class TestPowerDistributingActor:
             )
 
             async with PowerDistributingActor(
-                component_category=ComponentCategory.BATTERY,
-                component_type=None,
+                Battery,
                 requests_receiver=requests_channel.new_receiver(),
                 component_pool_status_sender=battery_status_channel.new_sender(),
                 results_sender=results_channel.new_sender(),
@@ -553,8 +546,7 @@ class TestPowerDistributingActor:
             )
 
             async with PowerDistributingActor(
-                component_category=ComponentCategory.BATTERY,
-                component_type=None,
+                Battery,
                 requests_receiver=requests_channel.new_receiver(),
                 component_pool_status_sender=battery_status_channel.new_sender(),
                 results_sender=results_channel.new_sender(),
@@ -649,8 +641,7 @@ class TestPowerDistributingActor:
             )
 
             async with PowerDistributingActor(
-                component_category=ComponentCategory.BATTERY,
-                component_type=None,
+                Battery,
                 requests_receiver=requests_channel.new_receiver(),
                 component_pool_status_sender=battery_status_channel.new_sender(),
                 results_sender=results_channel.new_sender(),
@@ -746,8 +737,7 @@ class TestPowerDistributingActor:
             )
 
             async with PowerDistributingActor(
-                component_category=ComponentCategory.BATTERY,
-                component_type=None,
+                Battery,
                 requests_receiver=requests_channel.new_receiver(),
                 component_pool_status_sender=battery_status_channel.new_sender(),
                 results_sender=results_channel.new_sender(),
@@ -812,8 +802,7 @@ class TestPowerDistributingActor:
             )
 
             async with PowerDistributingActor(
-                component_category=ComponentCategory.BATTERY,
-                component_type=None,
+                Battery,
                 requests_receiver=requests_channel.new_receiver(),
                 component_pool_status_sender=battery_status_channel.new_sender(),
                 results_sender=results_channel.new_sender(),
@@ -866,8 +855,7 @@ class TestPowerDistributingActor:
                 name="battery_status"
             )
             async with PowerDistributingActor(
-                component_category=ComponentCategory.BATTERY,
-                component_type=None,
+                Battery,
                 requests_receiver=requests_channel.new_receiver(),
                 results_sender=results_channel.new_sender(),
                 component_pool_status_sender=battery_status_channel.new_sender(),
@@ -921,8 +909,7 @@ class TestPowerDistributingActor:
                 name="battery_status"
             )
             async with PowerDistributingActor(
-                component_category=ComponentCategory.BATTERY,
-                component_type=None,
+                Battery,
                 requests_receiver=requests_channel.new_receiver(),
                 results_sender=results_channel.new_sender(),
                 component_pool_status_sender=battery_status_channel.new_sender(),
@@ -1007,8 +994,7 @@ class TestPowerDistributingActor:
                 name="battery_status"
             )
             async with PowerDistributingActor(
-                component_category=ComponentCategory.BATTERY,
-                component_type=None,
+                Battery,
                 requests_receiver=requests_channel.new_receiver(),
                 results_sender=results_channel.new_sender(),
                 component_pool_status_sender=battery_status_channel.new_sender(),
@@ -1048,8 +1034,7 @@ class TestPowerDistributingActor:
                 name="battery_status"
             )
             async with PowerDistributingActor(
-                component_category=ComponentCategory.BATTERY,
-                component_type=None,
+                Battery,
                 requests_receiver=requests_channel.new_receiver(),
                 results_sender=results_channel.new_sender(),
                 component_pool_status_sender=battery_status_channel.new_sender(),
@@ -1090,8 +1075,7 @@ class TestPowerDistributingActor:
                 name="battery_status"
             )
             async with PowerDistributingActor(
-                component_category=ComponentCategory.BATTERY,
-                component_type=None,
+                Battery,
                 requests_receiver=requests_channel.new_receiver(),
                 results_sender=results_channel.new_sender(),
                 component_pool_status_sender=battery_status_channel.new_sender(),
@@ -1132,8 +1116,7 @@ class TestPowerDistributingActor:
                 name="battery_status"
             )
             async with PowerDistributingActor(
-                component_category=ComponentCategory.BATTERY,
-                component_type=None,
+                Battery,
                 requests_receiver=requests_channel.new_receiver(),
                 results_sender=results_channel.new_sender(),
                 component_pool_status_sender=battery_status_channel.new_sender(),
@@ -1174,8 +1157,7 @@ class TestPowerDistributingActor:
                 name="battery_status"
             )
             async with PowerDistributingActor(
-                component_category=ComponentCategory.BATTERY,
-                component_type=None,
+                Battery,
                 requests_receiver=requests_channel.new_receiver(),
                 results_sender=results_channel.new_sender(),
                 component_pool_status_sender=battery_status_channel.new_sender(),
@@ -1212,8 +1194,7 @@ class TestPowerDistributingActor:
                 name="battery_status"
             )
             async with PowerDistributingActor(
-                component_category=ComponentCategory.BATTERY,
-                component_type=None,
+                Battery,
                 requests_receiver=requests_channel.new_receiver(),
                 results_sender=results_channel.new_sender(),
                 component_pool_status_sender=battery_status_channel.new_sender(),
@@ -1262,8 +1243,7 @@ class TestPowerDistributingActor:
                 name="battery_status"
             )
             async with PowerDistributingActor(
-                component_category=ComponentCategory.BATTERY,
-                component_type=None,
+                Battery,
                 requests_receiver=requests_channel.new_receiver(),
                 results_sender=results_channel.new_sender(),
                 component_pool_status_sender=battery_status_channel.new_sender(),

--- a/tests/microgrid/test_data_sourcing.py
+++ b/tests/microgrid/test_data_sourcing.py
@@ -15,17 +15,12 @@ from frequenz.channels import Broadcast
 from frequenz.client.common.microgrid.components import ComponentId
 from frequenz.client.microgrid import (
     BatteryComponentState,
-    BatteryData,
     BatteryRelayState,
     Component,
     ComponentCategory,
-    ComponentData,
     EVChargerCableState,
     EVChargerComponentState,
-    EVChargerData,
     InverterComponentState,
-    InverterData,
-    MeterData,
 )
 from frequenz.client.microgrid.metrics import Metric
 from frequenz.quantities import Quantity
@@ -34,6 +29,13 @@ from frequenz.sdk._internal._channels import ChannelRegistry
 from frequenz.sdk.microgrid._data_sourcing import (
     ComponentMetricRequest,
     DataSourcingActor,
+)
+from frequenz.sdk.microgrid._old_component_data import (
+    BatteryData,
+    ComponentData,
+    EVChargerData,
+    InverterData,
+    MeterData,
 )
 from frequenz.sdk.timeseries import Sample
 
@@ -44,8 +46,8 @@ T = TypeVar("T", bound=ComponentData)
 def mock_connection_manager(mocker: pytest_mock.MockFixture) -> mock.Mock:
     """Fixture for getting a mock connection manager."""
     mock_client = mock.MagicMock(name="connection_manager.get().api_client")
-    mock_client.components = mock.AsyncMock(
-        name="components()",
+    mock_client.list_components = mock.AsyncMock(
+        name="list_components()",
         return_value=[
             Component(component_id=ComponentId(4), category=ComponentCategory.METER),
             Component(component_id=ComponentId(6), category=ComponentCategory.INVERTER),
@@ -55,16 +57,24 @@ def mock_connection_manager(mocker: pytest_mock.MockFixture) -> mock.Mock:
             ),
         ],
     )
-    mock_client.meter_data = _new_meter_data_mock(ComponentId(4), starting_value=100.0)
-    mock_client.inverter_data = _new_inverter_data_mock(
-        ComponentId(6), starting_value=0.0
+
+    mocker.patch(
+        "frequenz.sdk.microgrid._data_sourcing.microgrid_api_source.MeterData.subscribe",
+        side_effect=_new_meter_data_mock(ComponentId(4), starting_value=100.0),
     )
-    mock_client.battery_data = _new_battery_data_mock(
-        ComponentId(9), starting_value=9.0
+    mocker.patch(
+        "frequenz.sdk.microgrid._data_sourcing.microgrid_api_source.InverterData.subscribe",
+        side_effect=_new_inverter_data_mock(ComponentId(6), starting_value=0.0),
     )
-    mock_client.ev_charger_data = _new_ev_charger_data_mock(
-        ComponentId(12), starting_value=-13.0
+    mocker.patch(
+        "frequenz.sdk.microgrid._data_sourcing.microgrid_api_source.BatteryData.subscribe",
+        side_effect=_new_battery_data_mock(ComponentId(9), starting_value=9.0),
     )
+    mocker.patch(
+        "frequenz.sdk.microgrid._data_sourcing.microgrid_api_source.EVChargerData.subscribe",
+        side_effect=_new_ev_charger_data_mock(ComponentId(12), starting_value=-13.0),
+    )
+
     mock_conn_manager = mock.MagicMock(name="connection_manager")
     mocker.patch(
         "frequenz.sdk.microgrid._data_sourcing"
@@ -245,7 +255,7 @@ def _new_streamer_mock(
     constructor: Callable[[ComponentId, datetime, float], T],
     component_id: ComponentId,
     starting_value: float,
-) -> mock.AsyncMock:
+) -> mock.Mock:
     """Get a mock streamer."""
 
     async def generate_data(starting_value: float) -> AsyncIterator[T]:
@@ -255,12 +265,10 @@ def _new_streamer_mock(
             await asyncio.sleep(0)  # Let other tasks run
             value += 1.0
 
-    return mock.AsyncMock(name=name, return_value=generate_data(starting_value))
+    return mock.Mock(name=name, return_value=generate_data(starting_value))
 
 
-def _new_meter_data_mock(
-    component_id: ComponentId, starting_value: float
-) -> mock.AsyncMock:
+def _new_meter_data_mock(component_id: ComponentId, starting_value: float) -> mock.Mock:
     """Get a mock streamer for meter data."""
     return _new_streamer_mock(
         f"meter_data_mock(id={component_id}, starting_value={starting_value})",
@@ -272,7 +280,7 @@ def _new_meter_data_mock(
 
 def _new_inverter_data_mock(
     component_id: ComponentId, starting_value: float
-) -> mock.AsyncMock:
+) -> mock.Mock:
     """Get a mock streamer for inverter data."""
     return _new_streamer_mock(
         f"inverter_data_mock(id={component_id}, starting_value={starting_value})",
@@ -284,7 +292,7 @@ def _new_inverter_data_mock(
 
 def _new_battery_data_mock(
     component_id: ComponentId, starting_value: float
-) -> mock.AsyncMock:
+) -> mock.Mock:
     """Get a mock streamer for battery data."""
     return _new_streamer_mock(
         f"battery_data_mock(id={component_id}, starting_value={starting_value})",
@@ -296,7 +304,7 @@ def _new_battery_data_mock(
 
 def _new_ev_charger_data_mock(
     component_id: ComponentId, starting_value: float
-) -> mock.AsyncMock:
+) -> mock.Mock:
     """Get a mock streamer for EV charger data."""
     return _new_streamer_mock(
         f"ev_charger_data_mock(id={component_id}, starting_value={starting_value})",

--- a/tests/microgrid/test_data_sourcing.py
+++ b/tests/microgrid/test_data_sourcing.py
@@ -14,15 +14,9 @@ import pytest_mock
 from frequenz.channels import Broadcast
 from frequenz.client.common.microgrid import MicrogridId
 from frequenz.client.common.microgrid.components import ComponentId
-from frequenz.client.microgrid import (
-    BatteryComponentState,
-    BatteryRelayState,
-    EVChargerCableState,
-    EVChargerComponentState,
-    InverterComponentState,
-)
 from frequenz.client.microgrid.component import (
     BatteryInverter,
+    ComponentStateCode,
     DcEvCharger,
     LiIonBattery,
     Meter,
@@ -187,6 +181,9 @@ def _new_meter_data(
         reactive_power=value,
         reactive_power_per_phase=(value, value, value),
         voltage_per_phase=(value, value, value),
+        states=frozenset(),
+        warnings=frozenset(),
+        errors=frozenset(),
     )
 
 
@@ -207,8 +204,9 @@ def _new_inverter_data(
         active_power_exclusion_upper_bound=value,
         active_power_inclusion_lower_bound=value,
         active_power_inclusion_upper_bound=value,
-        component_state=InverterComponentState.UNSPECIFIED,
-        errors=[],
+        states={ComponentStateCode.UNSPECIFIED},
+        errors=frozenset(),
+        warnings=frozenset(),
     )
 
 
@@ -220,8 +218,6 @@ def _new_battery_data(
         timestamp=timestamp,
         soc=value,
         temperature=value,
-        component_state=BatteryComponentState.UNSPECIFIED,
-        errors=[],
         soc_lower_bound=value,
         soc_upper_bound=value,
         capacity=value,
@@ -229,7 +225,9 @@ def _new_battery_data(
         power_exclusion_upper_bound=value,
         power_inclusion_lower_bound=value,
         power_inclusion_upper_bound=value,
-        relay_state=BatteryRelayState.UNSPECIFIED,
+        states={ComponentStateCode.UNSPECIFIED},
+        errors=frozenset(),
+        warnings=frozenset(),
     )
 
 
@@ -250,8 +248,9 @@ def _new_ev_charger_data(
         active_power_exclusion_upper_bound=value,
         active_power_inclusion_lower_bound=value,
         active_power_inclusion_upper_bound=value,
-        cable_state=EVChargerCableState.UNSPECIFIED,
-        component_state=EVChargerComponentState.UNSPECIFIED,
+        states={ComponentStateCode.UNSPECIFIED},
+        errors=frozenset(),
+        warnings=frozenset(),
     )
 
 

--- a/tests/microgrid/test_data_sourcing.py
+++ b/tests/microgrid/test_data_sourcing.py
@@ -20,7 +20,6 @@ from frequenz.client.microgrid import (
     Component,
     ComponentCategory,
     ComponentData,
-    ComponentMetricId,
     EVChargerCableState,
     EVChargerComponentState,
     EVChargerData,
@@ -28,6 +27,7 @@ from frequenz.client.microgrid import (
     InverterData,
     MeterData,
 )
+from frequenz.client.microgrid.metrics import Metric
 from frequenz.quantities import Quantity
 
 from frequenz.sdk._internal._channels import ChannelRegistry
@@ -86,7 +86,7 @@ async def test_data_sourcing_actor(  # pylint: disable=too-many-locals
 
     async with DataSourcingActor(req_chan.new_receiver(), registry):
         active_power_request_4 = ComponentMetricRequest(
-            "test-namespace", ComponentId(4), ComponentMetricId.ACTIVE_POWER, None
+            "test-namespace", ComponentId(4), Metric.AC_ACTIVE_POWER, None
         )
         active_power_recv_4 = registry.get_or_create(
             Sample[Quantity], active_power_request_4.get_channel_name()
@@ -94,7 +94,7 @@ async def test_data_sourcing_actor(  # pylint: disable=too-many-locals
         await req_sender.send(active_power_request_4)
 
         reactive_power_request_4 = ComponentMetricRequest(
-            "test-namespace", ComponentId(4), ComponentMetricId.REACTIVE_POWER, None
+            "test-namespace", ComponentId(4), Metric.AC_REACTIVE_POWER, None
         )
         reactive_power_recv_4 = registry.get_or_create(
             Sample[Quantity], reactive_power_request_4.get_channel_name()
@@ -102,7 +102,7 @@ async def test_data_sourcing_actor(  # pylint: disable=too-many-locals
         await req_sender.send(reactive_power_request_4)
 
         active_power_request_6 = ComponentMetricRequest(
-            "test-namespace", ComponentId(6), ComponentMetricId.ACTIVE_POWER, None
+            "test-namespace", ComponentId(6), Metric.AC_ACTIVE_POWER, None
         )
         active_power_recv_6 = registry.get_or_create(
             Sample[Quantity], active_power_request_6.get_channel_name()
@@ -110,7 +110,7 @@ async def test_data_sourcing_actor(  # pylint: disable=too-many-locals
         await req_sender.send(active_power_request_6)
 
         soc_request_9 = ComponentMetricRequest(
-            "test-namespace", ComponentId(9), ComponentMetricId.SOC, None
+            "test-namespace", ComponentId(9), Metric.BATTERY_SOC_PCT, None
         )
         soc_recv_9 = registry.get_or_create(
             Sample[Quantity], soc_request_9.get_channel_name()
@@ -118,7 +118,7 @@ async def test_data_sourcing_actor(  # pylint: disable=too-many-locals
         await req_sender.send(soc_request_9)
 
         soc2_request_9 = ComponentMetricRequest(
-            "test-namespace", ComponentId(9), ComponentMetricId.SOC, None
+            "test-namespace", ComponentId(9), Metric.BATTERY_SOC_PCT, None
         )
         soc2_recv_9 = registry.get_or_create(
             Sample[Quantity], soc2_request_9.get_channel_name()
@@ -126,7 +126,7 @@ async def test_data_sourcing_actor(  # pylint: disable=too-many-locals
         await req_sender.send(soc2_request_9)
 
         active_power_request_12 = ComponentMetricRequest(
-            "test-namespace", ComponentId(12), ComponentMetricId.ACTIVE_POWER, None
+            "test-namespace", ComponentId(12), Metric.AC_ACTIVE_POWER, None
         )
         active_power_recv_12 = registry.get_or_create(
             Sample[Quantity], active_power_request_12.get_channel_name()

--- a/tests/microgrid/test_data_sourcing.py
+++ b/tests/microgrid/test_data_sourcing.py
@@ -12,15 +12,20 @@ from unittest import mock
 import pytest
 import pytest_mock
 from frequenz.channels import Broadcast
+from frequenz.client.common.microgrid import MicrogridId
 from frequenz.client.common.microgrid.components import ComponentId
 from frequenz.client.microgrid import (
     BatteryComponentState,
     BatteryRelayState,
-    Component,
-    ComponentCategory,
     EVChargerCableState,
     EVChargerComponentState,
     InverterComponentState,
+)
+from frequenz.client.microgrid.component import (
+    BatteryInverter,
+    DcEvCharger,
+    LiIonBattery,
+    Meter,
 )
 from frequenz.client.microgrid.metrics import Metric
 from frequenz.quantities import Quantity
@@ -41,6 +46,8 @@ from frequenz.sdk.timeseries import Sample
 
 T = TypeVar("T", bound=ComponentData)
 
+_MICROGRID_ID = MicrogridId(1)
+
 
 @pytest.fixture
 def mock_connection_manager(mocker: pytest_mock.MockFixture) -> mock.Mock:
@@ -49,12 +56,10 @@ def mock_connection_manager(mocker: pytest_mock.MockFixture) -> mock.Mock:
     mock_client.list_components = mock.AsyncMock(
         name="list_components()",
         return_value=[
-            Component(component_id=ComponentId(4), category=ComponentCategory.METER),
-            Component(component_id=ComponentId(6), category=ComponentCategory.INVERTER),
-            Component(component_id=ComponentId(9), category=ComponentCategory.BATTERY),
-            Component(
-                component_id=ComponentId(12), category=ComponentCategory.EV_CHARGER
-            ),
+            Meter(id=ComponentId(4), microgrid_id=_MICROGRID_ID),
+            BatteryInverter(id=ComponentId(6), microgrid_id=_MICROGRID_ID),
+            LiIonBattery(id=ComponentId(9), microgrid_id=_MICROGRID_ID),
+            DcEvCharger(id=ComponentId(12), microgrid_id=_MICROGRID_ID),
         ],
     )
 

--- a/tests/microgrid/test_datapipeline.py
+++ b/tests/microgrid/test_datapipeline.py
@@ -9,14 +9,13 @@ from datetime import timedelta
 import async_solipsism
 import pytest
 import time_machine
+from frequenz.client.common.microgrid import MicrogridId
 from frequenz.client.common.microgrid.components import ComponentId
-from frequenz.client.microgrid import (
-    Component,
-    ComponentCategory,
-    InverterType,
-)
 from frequenz.client.microgrid.component import (
+    BatteryInverter,
     ComponentConnection,
+    GridConnectionPoint,
+    LiIonBattery,
 )
 from pytest_mock import MockerFixture
 
@@ -30,6 +29,9 @@ from ..utils.mock_microgrid_client import MockMicrogridClient
 def event_loop_policy() -> async_solipsism.EventLoopPolicy:
     """Return an event loop policy that uses the async solipsism event loop."""
     return async_solipsism.EventLoopPolicy()
+
+
+_MICROGRID_ID = MicrogridId(1)
 
 
 # loop time is advanced but not the system time
@@ -61,15 +63,16 @@ async def test_actors_started(
 
     assert datapipeline._battery_power_wrapper._power_distributing_actor is None
 
+    grid_1 = GridConnectionPoint(
+        id=ComponentId(1), microgrid_id=_MICROGRID_ID, rated_fuse_current=10_000
+    )
+    bat_inverter_4 = BatteryInverter(id=ComponentId(4), microgrid_id=_MICROGRID_ID)
+    battery_15 = LiIonBattery(id=ComponentId(15), microgrid_id=_MICROGRID_ID)
     mock_client = MockMicrogridClient(
-        {
-            Component(ComponentId(1), ComponentCategory.GRID),
-            Component(ComponentId(4), ComponentCategory.INVERTER, InverterType.BATTERY),
-            Component(ComponentId(15), ComponentCategory.BATTERY),
-        },
+        components={grid_1, bat_inverter_4, battery_15},
         connections={
-            ComponentConnection(source=ComponentId(1), destination=ComponentId(4)),
-            ComponentConnection(source=ComponentId(4), destination=ComponentId(15)),
+            ComponentConnection(source=grid_1.id, destination=bat_inverter_4.id),
+            ComponentConnection(source=bat_inverter_4.id, destination=battery_15.id),
         },
     )
     mock_client.initialize(mocker)

--- a/tests/microgrid/test_datapipeline.py
+++ b/tests/microgrid/test_datapipeline.py
@@ -13,8 +13,10 @@ from frequenz.client.common.microgrid.components import ComponentId
 from frequenz.client.microgrid import (
     Component,
     ComponentCategory,
-    Connection,
     InverterType,
+)
+from frequenz.client.microgrid.component import (
+    ComponentConnection,
 )
 from pytest_mock import MockerFixture
 
@@ -66,8 +68,8 @@ async def test_actors_started(
             Component(ComponentId(15), ComponentCategory.BATTERY),
         },
         connections={
-            Connection(ComponentId(1), ComponentId(4)),
-            Connection(ComponentId(4), ComponentId(15)),
+            ComponentConnection(source=ComponentId(1), destination=ComponentId(4)),
+            ComponentConnection(source=ComponentId(4), destination=ComponentId(15)),
         },
     )
     mock_client.initialize(mocker)

--- a/tests/microgrid/test_graph.py
+++ b/tests/microgrid/test_graph.py
@@ -7,23 +7,34 @@
 # pylint: disable=invalid-name,missing-function-docstring,too-many-statements
 # pylint: disable=too-many-lines,protected-access
 
+import re
 from unittest import mock
 
 import pytest
+from frequenz.client.common.microgrid import MicrogridId
 from frequenz.client.common.microgrid.components import ComponentId
-from frequenz.client.microgrid import (
-    Component,
-    ComponentCategory,
-    ComponentMetadata,
-    Fuse,
-    InverterType,
-    MicrogridApiClient,
-)
+from frequenz.client.microgrid import MicrogridApiClient
 from frequenz.client.microgrid.component import (
+    Battery,
+    BatteryInverter,
+    Chp,
+    Component,
     ComponentConnection,
+    EvCharger,
+    GridConnectionPoint,
+    Inverter,
+    Meter,
+    SolarInverter,
+    UnrecognizedComponent,
+    UnspecifiedBattery,
+    UnspecifiedComponent,
+    UnspecifiedEvCharger,
+    UnspecifiedInverter,
 )
 
 import frequenz.sdk.microgrid.component_graph as gr
+
+_MICROGRID_ID = MicrogridId(1)
 
 
 def _add_components(graph: gr._MicrogridComponentGraph, *components: Component) -> None:
@@ -46,7 +57,7 @@ def _add_connections(
         *connections: The connections to add.
     """
     graph._graph.add_edges_from(
-        (c.start, c.end, {gr._DATA_KEY: c}) for c in connections
+        (c.source, c.destination, {gr._DATA_KEY: c}) for c in connections
     )
 
 
@@ -59,13 +70,13 @@ def _check_predecessors_and_successors(graph: gr.ComponentGraph) -> None:
     }
 
     for conn in graph.connections():
-        if conn.end not in expected_predecessors:
-            expected_predecessors[conn.end] = set()
-        expected_predecessors[conn.end].add(components[conn.start])
+        if conn.destination not in expected_predecessors:
+            expected_predecessors[conn.destination] = set()
+        expected_predecessors[conn.destination].add(components[conn.source])
 
-        if conn.start not in expected_successors:
-            expected_successors[conn.start] = set()
-        expected_successors[conn.start].add(components[conn.end])
+        if conn.source not in expected_successors:
+            expected_successors[conn.source] = set()
+        expected_successors[conn.source].add(components[conn.destination])
 
     for component_id in components.keys():
         assert set(graph.predecessors(component_id)) == expected_predecessors.get(
@@ -88,11 +99,15 @@ class TestComponentGraph:
     def sample_input_components(self) -> set[Component]:
         """Create a sample set of components for testing purposes."""
         return {
-            Component(ComponentId(11), ComponentCategory.GRID),
-            Component(ComponentId(21), ComponentCategory.METER),
-            Component(ComponentId(41), ComponentCategory.METER),
-            Component(ComponentId(51), ComponentCategory.INVERTER),
-            Component(ComponentId(61), ComponentCategory.BATTERY),
+            GridConnectionPoint(
+                id=ComponentId(11),
+                microgrid_id=_MICROGRID_ID,
+                rated_fuse_current=10_000,
+            ),
+            Meter(id=ComponentId(21), microgrid_id=_MICROGRID_ID),
+            Meter(id=ComponentId(41), microgrid_id=_MICROGRID_ID),
+            BatteryInverter(id=ComponentId(51), microgrid_id=_MICROGRID_ID),
+            UnspecifiedBattery(id=ComponentId(61), microgrid_id=_MICROGRID_ID),
         }
 
     @pytest.fixture()
@@ -136,33 +151,28 @@ class TestComponentGraph:
         ):
             graph.successors(ComponentId(1))
 
+        expected_connection = ComponentConnection(
+            source=ComponentId(1), destination=ComponentId(3)
+        )
+
+        expected_components = [
+            GridConnectionPoint(
+                id=ComponentId(1), microgrid_id=_MICROGRID_ID, rated_fuse_current=10_000
+            ),
+            Meter(id=ComponentId(3), microgrid_id=_MICROGRID_ID),
+        ]
         # simplest valid microgrid: a grid endpoint and a meter
         _graph_implementation.refresh_from(
-            components={
-                Component(ComponentId(1), ComponentCategory.GRID),
-                Component(ComponentId(3), ComponentCategory.METER),
-            },
-            connections={
-                ComponentConnection(source=ComponentId(1), destination=ComponentId(3))
-            },
+            components=set(expected_components),
+            connections={expected_connection},
         )
-        expected_components = {
-            Component(ComponentId(1), ComponentCategory.GRID),
-            Component(ComponentId(3), ComponentCategory.METER),
-        }
         assert len(graph.components()) == len(expected_components)
-        assert graph.components() == expected_components
-        assert graph.connections() == {
-            ComponentConnection(source=ComponentId(1), destination=ComponentId(3))
-        }
+        assert graph.components() == set(expected_components)
+        assert graph.connections() == {expected_connection}
 
         assert graph.predecessors(ComponentId(1)) == set()
-        assert graph.successors(ComponentId(1)) == {
-            Component(ComponentId(3), ComponentCategory.METER)
-        }
-        assert graph.predecessors(ComponentId(3)) == {
-            Component(ComponentId(1), ComponentCategory.GRID)
-        }
+        assert graph.successors(ComponentId(1)) == {expected_components[1]}
+        assert graph.predecessors(ComponentId(3)) == {expected_components[0]}
         assert graph.successors(ComponentId(3)) == set()
         with pytest.raises(
             KeyError,
@@ -176,11 +186,19 @@ class TestComponentGraph:
             graph.successors(ComponentId(2))
 
         input_components = {
-            ComponentId(101): Component(ComponentId(101), ComponentCategory.GRID),
-            ComponentId(102): Component(ComponentId(102), ComponentCategory.METER),
-            ComponentId(104): Component(ComponentId(104), ComponentCategory.METER),
-            ComponentId(105): Component(ComponentId(105), ComponentCategory.INVERTER),
-            ComponentId(106): Component(ComponentId(106), ComponentCategory.BATTERY),
+            ComponentId(101): GridConnectionPoint(
+                id=ComponentId(101),
+                microgrid_id=_MICROGRID_ID,
+                rated_fuse_current=10_000,
+            ),
+            ComponentId(102): Meter(id=ComponentId(102), microgrid_id=_MICROGRID_ID),
+            ComponentId(104): Meter(id=ComponentId(104), microgrid_id=_MICROGRID_ID),
+            ComponentId(105): BatteryInverter(
+                id=ComponentId(105), microgrid_id=_MICROGRID_ID
+            ),
+            ComponentId(106): UnspecifiedBattery(
+                id=ComponentId(106), microgrid_id=_MICROGRID_ID
+            ),
         }
         input_connections = {
             ComponentConnection(source=ComponentId(101), destination=ComponentId(102)),
@@ -218,24 +236,40 @@ class TestComponentGraph:
         [
             ({1}, set()),
             ({1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, set()),
-            ({11}, {Component(ComponentId(11), ComponentCategory.GRID)}),
-            ({21}, {Component(ComponentId(21), ComponentCategory.METER)}),
-            ({41}, {Component(ComponentId(41), ComponentCategory.METER)}),
-            ({51}, {Component(ComponentId(51), ComponentCategory.INVERTER)}),
-            ({61}, {Component(ComponentId(61), ComponentCategory.BATTERY)}),
+            (
+                {11},
+                {
+                    GridConnectionPoint(
+                        id=ComponentId(11),
+                        microgrid_id=_MICROGRID_ID,
+                        rated_fuse_current=10_000,
+                    )
+                },
+            ),
+            ({21}, {Meter(id=ComponentId(21), microgrid_id=_MICROGRID_ID)}),
+            ({41}, {Meter(id=ComponentId(41), microgrid_id=_MICROGRID_ID)}),
+            ({51}, {BatteryInverter(id=ComponentId(51), microgrid_id=_MICROGRID_ID)}),
+            (
+                {61},
+                {UnspecifiedBattery(id=ComponentId(61), microgrid_id=_MICROGRID_ID)},
+            ),
             (
                 {11, 61},
                 {
-                    Component(ComponentId(11), ComponentCategory.GRID),
-                    Component(ComponentId(61), ComponentCategory.BATTERY),
+                    GridConnectionPoint(
+                        id=ComponentId(11),
+                        microgrid_id=_MICROGRID_ID,
+                        rated_fuse_current=10_000,
+                    ),
+                    UnspecifiedBattery(id=ComponentId(61), microgrid_id=_MICROGRID_ID),
                 },
             ),
             (
                 {9, 51, 41, 21, 101},
                 {
-                    Component(ComponentId(41), ComponentCategory.METER),
-                    Component(ComponentId(51), ComponentCategory.INVERTER),
-                    Component(ComponentId(21), ComponentCategory.METER),
+                    Meter(id=ComponentId(41), microgrid_id=_MICROGRID_ID),
+                    BatteryInverter(id=ComponentId(51), microgrid_id=_MICROGRID_ID),
+                    Meter(id=ComponentId(21), microgrid_id=_MICROGRID_ID),
                 },
             ),
         ],
@@ -255,47 +289,53 @@ class TestComponentGraph:
     @pytest.mark.parametrize(
         "types, expected",
         [
-            ({ComponentCategory.EV_CHARGER}, set()),
+            ({EvCharger}, set()),
             (
-                {ComponentCategory.BATTERY, ComponentCategory.EV_CHARGER},
-                {Component(ComponentId(61), ComponentCategory.BATTERY)},
+                {Battery, EvCharger},
+                {UnspecifiedBattery(id=ComponentId(61), microgrid_id=_MICROGRID_ID)},
             ),
             (
-                {ComponentCategory.GRID},
-                {Component(ComponentId(11), ComponentCategory.GRID)},
-            ),
-            (
-                {ComponentCategory.METER},
+                {GridConnectionPoint},
                 {
-                    Component(ComponentId(21), ComponentCategory.METER),
-                    Component(ComponentId(41), ComponentCategory.METER),
+                    GridConnectionPoint(
+                        id=ComponentId(11),
+                        microgrid_id=_MICROGRID_ID,
+                        rated_fuse_current=10_000,
+                    )
                 },
             ),
             (
-                {ComponentCategory.INVERTER},
-                {Component(ComponentId(51), ComponentCategory.INVERTER)},
-            ),
-            (
-                {ComponentCategory.BATTERY},
-                {Component(ComponentId(61), ComponentCategory.BATTERY)},
-            ),
-            (
-                {ComponentCategory.GRID, ComponentCategory.BATTERY},
+                {Meter},
                 {
-                    Component(ComponentId(11), ComponentCategory.GRID),
-                    Component(ComponentId(61), ComponentCategory.BATTERY),
+                    Meter(id=ComponentId(21), microgrid_id=_MICROGRID_ID),
+                    Meter(id=ComponentId(41), microgrid_id=_MICROGRID_ID),
                 },
             ),
             (
+                {BatteryInverter},
+                {BatteryInverter(id=ComponentId(51), microgrid_id=_MICROGRID_ID)},
+            ),
+            (
+                {Battery},
+                {UnspecifiedBattery(id=ComponentId(61), microgrid_id=_MICROGRID_ID)},
+            ),
+            (
+                {GridConnectionPoint, Battery},
                 {
-                    ComponentCategory.METER,
-                    ComponentCategory.BATTERY,
-                    ComponentCategory.EV_CHARGER,
+                    GridConnectionPoint(
+                        id=ComponentId(11),
+                        microgrid_id=_MICROGRID_ID,
+                        rated_fuse_current=10_000,
+                    ),
+                    UnspecifiedBattery(id=ComponentId(61), microgrid_id=_MICROGRID_ID),
                 },
+            ),
+            (
+                {Meter, Battery, EvCharger},
                 {
-                    Component(ComponentId(21), ComponentCategory.METER),
-                    Component(ComponentId(61), ComponentCategory.BATTERY),
-                    Component(ComponentId(41), ComponentCategory.METER),
+                    Meter(id=ComponentId(21), microgrid_id=_MICROGRID_ID),
+                    Meter(id=ComponentId(41), microgrid_id=_MICROGRID_ID),
+                    UnspecifiedBattery(id=ComponentId(61), microgrid_id=_MICROGRID_ID),
                 },
             ),
         ],
@@ -314,21 +354,27 @@ class TestComponentGraph:
         [
             (
                 {11},
-                {ComponentCategory.GRID},
-                {Component(ComponentId(11), ComponentCategory.GRID)},
+                {GridConnectionPoint},
+                {
+                    GridConnectionPoint(
+                        id=ComponentId(11),
+                        microgrid_id=_MICROGRID_ID,
+                        rated_fuse_current=10_000,
+                    )
+                },
             ),
-            ({31}, {ComponentCategory.GRID}, set()),
+            ({31}, {GridConnectionPoint}, set()),
             (
                 {61},
-                {ComponentCategory.BATTERY},
-                {Component(ComponentId(61), ComponentCategory.BATTERY)},
+                {Battery},
+                {UnspecifiedBattery(id=ComponentId(61), microgrid_id=_MICROGRID_ID)},
             ),
             (
                 {11, 21, 31, 61},
-                {ComponentCategory.METER, ComponentCategory.BATTERY},
+                {Meter, Battery},
                 {
-                    Component(ComponentId(61), ComponentCategory.BATTERY),
-                    Component(ComponentId(21), ComponentCategory.METER),
+                    UnspecifiedBattery(id=ComponentId(61), microgrid_id=_MICROGRID_ID),
+                    Meter(id=ComponentId(21), microgrid_id=_MICROGRID_ID),
                 },
             ),
         ],
@@ -357,346 +403,347 @@ class TestComponentGraph:
         assert len(sample_graph.components()) == len(sample_input_components)
         assert sample_graph.components() == sample_input_components
 
-    def test_connection_filters(self) -> None:
+    def test_connection_filters(self) -> None:  # pylint: disable=too-many-locals
         """Test the graph connection query with filters."""
+        # Components
+        grid_1 = GridConnectionPoint(
+            id=ComponentId(1), microgrid_id=_MICROGRID_ID, rated_fuse_current=10_000
+        )
+        meter_2 = Meter(id=ComponentId(2), microgrid_id=_MICROGRID_ID)
+        meter_3 = Meter(id=ComponentId(3), microgrid_id=_MICROGRID_ID)
+        charger_4 = UnspecifiedEvCharger(id=ComponentId(4), microgrid_id=_MICROGRID_ID)
+        charger_5 = UnspecifiedEvCharger(id=ComponentId(5), microgrid_id=_MICROGRID_ID)
+        charger_6 = UnspecifiedEvCharger(id=ComponentId(6), microgrid_id=_MICROGRID_ID)
+
+        components = {grid_1, meter_2, meter_3, charger_4, charger_5, charger_6}
+
+        # Connections
+        conn_1_2 = ComponentConnection(source=grid_1.id, destination=meter_2.id)
+        conn_1_3 = ComponentConnection(source=grid_1.id, destination=meter_3.id)
+        conn_2_4 = ComponentConnection(source=meter_2.id, destination=charger_4.id)
+        conn_2_5 = ComponentConnection(source=meter_2.id, destination=charger_5.id)
+        conn_2_6 = ComponentConnection(source=meter_2.id, destination=charger_6.id)
+
+        connections = {conn_1_2, conn_1_3, conn_2_4, conn_2_5, conn_2_6}
         _graph_implementation = gr._MicrogridComponentGraph(
-            components={
-                Component(ComponentId(1), ComponentCategory.GRID),
-                Component(ComponentId(2), ComponentCategory.METER),
-                Component(ComponentId(3), ComponentCategory.METER),
-                Component(ComponentId(4), ComponentCategory.EV_CHARGER),
-                Component(ComponentId(5), ComponentCategory.EV_CHARGER),
-                Component(ComponentId(6), ComponentCategory.EV_CHARGER),
-            },
-            connections={
-                ComponentConnection(source=ComponentId(1), destination=ComponentId(2)),
-                ComponentConnection(source=ComponentId(1), destination=ComponentId(3)),
-                ComponentConnection(source=ComponentId(2), destination=ComponentId(4)),
-                ComponentConnection(source=ComponentId(2), destination=ComponentId(5)),
-                ComponentConnection(source=ComponentId(2), destination=ComponentId(6)),
-            },
+            components=components,
+            connections=connections,
         )
         graph: gr.ComponentGraph = _graph_implementation
 
         # without any filter applied, we get back all the connections in the graph
-        assert graph.connections() == {
-            ComponentConnection(source=ComponentId(1), destination=ComponentId(2)),
-            ComponentConnection(source=ComponentId(1), destination=ComponentId(3)),
-            ComponentConnection(source=ComponentId(2), destination=ComponentId(4)),
-            ComponentConnection(source=ComponentId(2), destination=ComponentId(5)),
-            ComponentConnection(source=ComponentId(2), destination=ComponentId(6)),
-        }
+        assert graph.connections() == connections
 
         # with start filter applied, we get back only connections whose `start`
         # component matches one of the provided IDs
         assert graph.connections(matching_sources=ComponentId(8)) == set()
         assert graph.connections(matching_sources=ComponentId(7)) == set()
-        assert graph.connections(matching_sources=ComponentId(6)) == set()
-        assert graph.connections(matching_sources=ComponentId(5)) == set()
-        assert graph.connections(matching_sources=ComponentId(4)) == set()
-        assert graph.connections(matching_sources=ComponentId(3)) == set()
-        assert graph.connections(matching_sources=ComponentId(2)) == {
-            ComponentConnection(source=ComponentId(2), destination=ComponentId(4)),
-            ComponentConnection(source=ComponentId(2), destination=ComponentId(5)),
-            ComponentConnection(source=ComponentId(2), destination=ComponentId(6)),
+        assert graph.connections(matching_sources={charger_6.id}) == set()
+        assert graph.connections(matching_sources={charger_5.id}) == set()
+        assert graph.connections(matching_sources={charger_4.id}) == set()
+        assert graph.connections(matching_sources={meter_3.id}) == set()
+        assert graph.connections(matching_sources={meter_2.id}) == {
+            conn_2_4,
+            conn_2_5,
+            conn_2_6,
         }
-        assert graph.connections(matching_sources=ComponentId(1)) == {
-            ComponentConnection(source=ComponentId(1), destination=ComponentId(2)),
-            ComponentConnection(source=ComponentId(1), destination=ComponentId(3)),
-        }
+        assert graph.connections(matching_sources={grid_1.id}) == {conn_1_2, conn_1_3}
         assert graph.connections(
-            matching_sources={ComponentId(1), ComponentId(3), ComponentId(5)}
-        ) == {
-            ComponentConnection(source=ComponentId(1), destination=ComponentId(2)),
-            ComponentConnection(source=ComponentId(1), destination=ComponentId(3)),
-        }
+            matching_sources={grid_1.id, meter_3.id, charger_5.id}
+        ) == {conn_1_2, conn_1_3}
         assert graph.connections(
-            matching_sources={
-                ComponentId(1),
-                ComponentId(2),
-                ComponentId(5),
-                ComponentId(6),
-            }
-        ) == {
-            ComponentConnection(source=ComponentId(1), destination=ComponentId(2)),
-            ComponentConnection(source=ComponentId(1), destination=ComponentId(3)),
-            ComponentConnection(source=ComponentId(2), destination=ComponentId(4)),
-            ComponentConnection(source=ComponentId(2), destination=ComponentId(5)),
-            ComponentConnection(source=ComponentId(2), destination=ComponentId(6)),
-        }
+            matching_sources={grid_1.id, meter_2.id, charger_5.id, charger_6.id}
+        ) == {conn_1_2, conn_1_3, conn_2_4, conn_2_5, conn_2_6}
 
         # with end filter applied, we get back only connections whose `end`
         # component matches one of the provided IDs
         assert graph.connections(matching_destinations=ComponentId(8)) == set()
-        assert graph.connections(matching_destinations=ComponentId(6)) == {
-            ComponentConnection(source=ComponentId(2), destination=ComponentId(6))
-        }
-        assert graph.connections(matching_destinations=ComponentId(5)) == {
-            ComponentConnection(source=ComponentId(2), destination=ComponentId(5))
-        }
-        assert graph.connections(matching_destinations=ComponentId(4)) == {
-            ComponentConnection(source=ComponentId(2), destination=ComponentId(4))
-        }
-        assert graph.connections(matching_destinations=ComponentId(3)) == {
-            ComponentConnection(source=ComponentId(1), destination=ComponentId(3))
-        }
-        assert graph.connections(matching_destinations=ComponentId(2)) == {
-            ComponentConnection(source=ComponentId(1), destination=ComponentId(2))
-        }
-        assert graph.connections(matching_destinations=ComponentId(1)) == set()
+        assert graph.connections(matching_destinations={charger_6.id}) == {conn_2_6}
+        assert graph.connections(matching_destinations={charger_5.id}) == {conn_2_5}
+        assert graph.connections(matching_destinations={charger_4.id}) == {conn_2_4}
+        assert graph.connections(matching_destinations={meter_3.id}) == {conn_1_3}
+        assert graph.connections(matching_destinations={meter_2.id}) == {conn_1_2}
+        assert graph.connections(matching_destinations={grid_1.id}) == set()
         assert graph.connections(
-            matching_destinations={ComponentId(1), ComponentId(2), ComponentId(3)}
+            matching_destinations={grid_1.id, meter_2.id, meter_3.id}
         ) == {
-            ComponentConnection(source=ComponentId(1), destination=ComponentId(2)),
-            ComponentConnection(source=ComponentId(1), destination=ComponentId(3)),
+            conn_1_2,
+            conn_1_3,
         }
         assert graph.connections(
-            matching_destinations={ComponentId(4), ComponentId(5), ComponentId(6)}
-        ) == {
-            ComponentConnection(source=ComponentId(2), destination=ComponentId(4)),
-            ComponentConnection(source=ComponentId(2), destination=ComponentId(5)),
-            ComponentConnection(source=ComponentId(2), destination=ComponentId(6)),
-        }
+            matching_destinations={charger_4.id, charger_5.id, charger_6.id}
+        ) == {conn_2_4, conn_2_5, conn_2_6}
 
         assert graph.connections(
             matching_destinations={
-                ComponentId(2),
-                ComponentId(4),
-                ComponentId(6),
+                meter_2.id,
+                charger_4.id,
+                charger_6.id,
                 ComponentId(8),
             }
-        ) == {
-            ComponentConnection(source=ComponentId(1), destination=ComponentId(2)),
-            ComponentConnection(source=ComponentId(2), destination=ComponentId(4)),
-            ComponentConnection(source=ComponentId(2), destination=ComponentId(6)),
-        }
-        assert graph.connections(matching_destinations=ComponentId(1)) == set()
+        ) == {conn_1_2, conn_2_4, conn_2_6}
+        assert graph.connections(matching_destinations={grid_1.id}) == set()
 
         # when both filters are applied, they are combined via AND logic, i.e.
         # a connection must have its `start` matching one of the provided start
         # values, and its `end` matching one of the provided end values
         assert graph.connections(
-            matching_sources=ComponentId(1), matching_destinations=ComponentId(2)
-        ) == {ComponentConnection(source=ComponentId(1), destination=ComponentId(2))}
+            matching_sources={grid_1.id}, matching_destinations={meter_2.id}
+        ) == {conn_1_2}
         assert (
             graph.connections(
-                matching_sources=ComponentId(2),
-                matching_destinations=ComponentId(3),
+                matching_sources={meter_2.id}, matching_destinations={meter_3.id}
             )
             == set()
         )
         assert graph.connections(
-            matching_sources={ComponentId(1), ComponentId(2)},
-            matching_destinations={ComponentId(3), ComponentId(4)},
+            matching_sources={grid_1.id, meter_2.id},
+            matching_destinations={meter_3.id, charger_4.id},
         ) == {
-            ComponentConnection(source=ComponentId(1), destination=ComponentId(3)),
-            ComponentConnection(source=ComponentId(2), destination=ComponentId(4)),
+            conn_1_3,
+            conn_2_4,
         }
         assert graph.connections(
-            matching_sources={ComponentId(2), ComponentId(3)},
-            matching_destinations={ComponentId(5), ComponentId(6), ComponentId(7)},
+            matching_sources={meter_2.id, meter_3.id},
+            matching_destinations={charger_5.id, charger_6.id, ComponentId(7)},
         ) == {
-            ComponentConnection(source=ComponentId(2), destination=ComponentId(5)),
-            ComponentConnection(source=ComponentId(2), destination=ComponentId(6)),
+            conn_2_5,
+            conn_2_6,
         }
 
     def test_dfs_search_two_grid_meters(self) -> None:
         """Test DFS searching PV components in a graph with two grid meters."""
-        grid = Component(ComponentId(1), ComponentCategory.GRID)
-        pv_inverters = {
-            Component(ComponentId(4), ComponentCategory.INVERTER, InverterType.SOLAR),
-            Component(ComponentId(5), ComponentCategory.INVERTER, InverterType.SOLAR),
-        }
+        grid_1 = GridConnectionPoint(
+            id=ComponentId(1), microgrid_id=_MICROGRID_ID, rated_fuse_current=10_000
+        )
+        solar_inverter_4 = SolarInverter(id=ComponentId(4), microgrid_id=_MICROGRID_ID)
+        solar_inverter_5 = SolarInverter(id=ComponentId(5), microgrid_id=_MICROGRID_ID)
+        meter_2 = Meter(id=ComponentId(2), microgrid_id=_MICROGRID_ID)
+        meter_3 = Meter(id=ComponentId(3), microgrid_id=_MICROGRID_ID)
 
         graph = gr._MicrogridComponentGraph(
-            components={
-                grid,
-                Component(ComponentId(2), ComponentCategory.METER),
-                Component(ComponentId(3), ComponentCategory.METER),
-            }.union(pv_inverters),
+            components={grid_1, meter_2, meter_3, solar_inverter_4, solar_inverter_5},
             connections={
-                ComponentConnection(source=ComponentId(1), destination=ComponentId(2)),
-                ComponentConnection(source=ComponentId(1), destination=ComponentId(3)),
-                ComponentConnection(source=ComponentId(2), destination=ComponentId(4)),
-                ComponentConnection(source=ComponentId(2), destination=ComponentId(5)),
+                ComponentConnection(source=grid_1.id, destination=meter_2.id),
+                ComponentConnection(source=grid_1.id, destination=meter_3.id),
+                ComponentConnection(source=meter_2.id, destination=solar_inverter_4.id),
+                ComponentConnection(source=meter_2.id, destination=solar_inverter_5.id),
             },
         )
 
-        result = graph.dfs(grid, set(), graph.is_pv_inverter)
-        assert result == pv_inverters
+        result = graph.dfs(grid_1, set(), graph.is_pv_inverter)
+        assert result == {solar_inverter_4, solar_inverter_5}
 
     def test_dfs_search_grid_meter(self) -> None:
         """Test DFS searching PV components in a graph with a single grid meter."""
-        grid = Component(ComponentId(1), ComponentCategory.GRID)
-        pv_meters = {
-            Component(ComponentId(3), ComponentCategory.METER),
-            Component(ComponentId(4), ComponentCategory.METER),
-        }
+        grid_1 = GridConnectionPoint(
+            id=ComponentId(1), microgrid_id=_MICROGRID_ID, rated_fuse_current=10_000
+        )
+        meter_2 = Meter(id=ComponentId(2), microgrid_id=_MICROGRID_ID)
+        solar_meter_3 = Meter(id=ComponentId(3), microgrid_id=_MICROGRID_ID)
+        solar_meter_4 = Meter(id=ComponentId(4), microgrid_id=_MICROGRID_ID)
+        solar_inverter_5 = SolarInverter(id=ComponentId(5), microgrid_id=_MICROGRID_ID)
+        solar_inverter_6 = SolarInverter(id=ComponentId(6), microgrid_id=_MICROGRID_ID)
+
+        solar_meters = {solar_meter_3, solar_meter_4}
 
         graph = gr._MicrogridComponentGraph(
             components={
-                grid,
-                Component(ComponentId(2), ComponentCategory.METER),
-                Component(
-                    ComponentId(5), ComponentCategory.INVERTER, InverterType.SOLAR
-                ),
-                Component(
-                    ComponentId(6), ComponentCategory.INVERTER, InverterType.SOLAR
-                ),
-            }.union(pv_meters),
+                grid_1,
+                meter_2,
+                *solar_meters,
+                solar_inverter_5,
+                solar_inverter_6,
+            },
             connections={
-                ComponentConnection(source=ComponentId(1), destination=ComponentId(2)),
-                ComponentConnection(source=ComponentId(2), destination=ComponentId(3)),
-                ComponentConnection(source=ComponentId(2), destination=ComponentId(4)),
-                ComponentConnection(source=ComponentId(3), destination=ComponentId(5)),
-                ComponentConnection(source=ComponentId(4), destination=ComponentId(6)),
+                ComponentConnection(source=grid_1.id, destination=meter_2.id),
+                ComponentConnection(source=meter_2.id, destination=solar_meter_3.id),
+                ComponentConnection(source=meter_2.id, destination=solar_meter_4.id),
+                ComponentConnection(
+                    source=solar_meter_3.id, destination=solar_inverter_5.id
+                ),
+                ComponentConnection(
+                    source=solar_meter_4.id, destination=solar_inverter_6.id
+                ),
             },
         )
 
-        result = graph.dfs(grid, set(), graph.is_pv_chain)
-        assert result == pv_meters
+        result = graph.dfs(grid_1, set(), graph.is_pv_chain)
+        assert result == solar_meters
 
     def test_dfs_search_grid_meter_no_pv_meter(self) -> None:
         """Test DFS searching PV components in a graph with a single grid meter."""
-        grid = Component(ComponentId(1), ComponentCategory.GRID)
-        pv_inverters = {
-            Component(ComponentId(3), ComponentCategory.INVERTER, InverterType.SOLAR),
-            Component(ComponentId(4), ComponentCategory.INVERTER, InverterType.SOLAR),
-        }
+        grid_1 = GridConnectionPoint(
+            id=ComponentId(1), microgrid_id=_MICROGRID_ID, rated_fuse_current=10_000
+        )
+        meter_2 = Meter(id=ComponentId(2), microgrid_id=_MICROGRID_ID)
+        solar_inverter_3 = SolarInverter(id=ComponentId(3), microgrid_id=_MICROGRID_ID)
+        solar_inverter_4 = SolarInverter(id=ComponentId(4), microgrid_id=_MICROGRID_ID)
+        solar_inverters = {solar_inverter_3, solar_inverter_4}
 
         graph = gr._MicrogridComponentGraph(
-            components={
-                grid,
-                Component(ComponentId(2), ComponentCategory.METER),
-            }.union(pv_inverters),
+            components={grid_1, meter_2, *solar_inverters},
             connections={
-                ComponentConnection(source=ComponentId(1), destination=ComponentId(2)),
-                ComponentConnection(source=ComponentId(2), destination=ComponentId(3)),
-                ComponentConnection(source=ComponentId(2), destination=ComponentId(4)),
+                ComponentConnection(source=grid_1.id, destination=meter_2.id),
+                ComponentConnection(source=meter_2.id, destination=solar_inverter_3.id),
+                ComponentConnection(source=meter_2.id, destination=solar_inverter_4.id),
             },
         )
 
-        result = graph.dfs(grid, set(), graph.is_pv_chain)
-        assert result == pv_inverters
+        result = graph.dfs(grid_1, set(), graph.is_pv_chain)
+        assert result == solar_inverters
 
     def test_dfs_search_no_grid_meter(self) -> None:
         """Test DFS searching PV components in a graph with no grid meter."""
-        grid = Component(ComponentId(1), ComponentCategory.GRID)
-        pv_meters = {
-            Component(ComponentId(3), ComponentCategory.METER),
-            Component(ComponentId(4), ComponentCategory.METER),
-        }
+        grid_1 = GridConnectionPoint(
+            id=ComponentId(1), microgrid_id=_MICROGRID_ID, rated_fuse_current=10_000
+        )
+        meter_2 = Meter(id=ComponentId(2), microgrid_id=_MICROGRID_ID)
+        solar_meter_3 = Meter(id=ComponentId(3), microgrid_id=_MICROGRID_ID)
+        solar_meter_4 = Meter(id=ComponentId(4), microgrid_id=_MICROGRID_ID)
+        solar_meters = {solar_meter_3, solar_meter_4}
+        solar_inverter_5 = SolarInverter(id=ComponentId(5), microgrid_id=_MICROGRID_ID)
+        solar_inverter_6 = SolarInverter(id=ComponentId(6), microgrid_id=_MICROGRID_ID)
 
         graph = gr._MicrogridComponentGraph(
             components={
-                grid,
-                Component(ComponentId(2), ComponentCategory.METER),
-                Component(
-                    ComponentId(5), ComponentCategory.INVERTER, InverterType.SOLAR
-                ),
-                Component(
-                    ComponentId(6), ComponentCategory.INVERTER, InverterType.SOLAR
-                ),
-            }.union(pv_meters),
+                grid_1,
+                meter_2,
+                *solar_meters,
+                solar_inverter_5,
+                solar_inverter_6,
+            },
             connections={
-                ComponentConnection(source=ComponentId(1), destination=ComponentId(2)),
-                ComponentConnection(source=ComponentId(1), destination=ComponentId(3)),
-                ComponentConnection(source=ComponentId(1), destination=ComponentId(4)),
-                ComponentConnection(source=ComponentId(3), destination=ComponentId(5)),
-                ComponentConnection(source=ComponentId(4), destination=ComponentId(6)),
+                ComponentConnection(source=grid_1.id, destination=meter_2.id),
+                ComponentConnection(source=grid_1.id, destination=solar_meter_3.id),
+                ComponentConnection(source=grid_1.id, destination=solar_meter_4.id),
+                ComponentConnection(
+                    source=solar_meter_3.id, destination=solar_inverter_5.id
+                ),
+                ComponentConnection(
+                    source=solar_meter_4.id, destination=solar_inverter_6.id
+                ),
             },
         )
 
-        result = graph.dfs(grid, set(), graph.is_pv_chain)
-        assert result == pv_meters
+        result = graph.dfs(grid_1, set(), graph.is_pv_chain)
+        assert result == solar_meters
 
     def test_dfs_search_nested_components(self) -> None:
         """Test DFS searching PV components in a graph with nested components."""
-        grid = Component(ComponentId(1), ComponentCategory.GRID)
-        battery_components = {
-            Component(ComponentId(4), ComponentCategory.METER),
-            Component(ComponentId(5), ComponentCategory.METER),
-            Component(ComponentId(6), ComponentCategory.INVERTER, InverterType.BATTERY),
-        }
+        grid_1 = GridConnectionPoint(
+            id=ComponentId(1), microgrid_id=_MICROGRID_ID, rated_fuse_current=10_000
+        )
+        meter_2 = Meter(id=ComponentId(2), microgrid_id=_MICROGRID_ID)
+        meter_3 = Meter(id=ComponentId(3), microgrid_id=_MICROGRID_ID)
+        meter_4 = Meter(id=ComponentId(4), microgrid_id=_MICROGRID_ID)
+        meter_5 = Meter(id=ComponentId(5), microgrid_id=_MICROGRID_ID)
+        battery_inverter_6 = BatteryInverter(
+            id=ComponentId(6), microgrid_id=_MICROGRID_ID
+        )
+        battery_inverter_7 = BatteryInverter(
+            id=ComponentId(7), microgrid_id=_MICROGRID_ID
+        )
+        battery_inverter_8 = BatteryInverter(
+            id=ComponentId(8), microgrid_id=_MICROGRID_ID
+        )
+        battery_components = {meter_4, meter_5, battery_inverter_6}
 
         graph = gr._MicrogridComponentGraph(
             components={
-                grid,
-                Component(ComponentId(2), ComponentCategory.METER),
-                Component(ComponentId(3), ComponentCategory.METER),
-                Component(
-                    ComponentId(7), ComponentCategory.INVERTER, InverterType.BATTERY
-                ),
-                Component(
-                    ComponentId(8), ComponentCategory.INVERTER, InverterType.BATTERY
-                ),
+                grid_1,
+                meter_2,
+                meter_3,
+                battery_inverter_7,
+                battery_inverter_8,
             }.union(battery_components),
             connections={
-                ComponentConnection(source=ComponentId(1), destination=ComponentId(2)),
-                ComponentConnection(source=ComponentId(2), destination=ComponentId(3)),
-                ComponentConnection(source=ComponentId(2), destination=ComponentId(6)),
-                ComponentConnection(source=ComponentId(3), destination=ComponentId(4)),
-                ComponentConnection(source=ComponentId(3), destination=ComponentId(5)),
-                ComponentConnection(source=ComponentId(4), destination=ComponentId(7)),
-                ComponentConnection(source=ComponentId(5), destination=ComponentId(8)),
+                ComponentConnection(source=grid_1.id, destination=meter_2.id),
+                ComponentConnection(source=meter_2.id, destination=meter_3.id),
+                ComponentConnection(
+                    source=meter_2.id, destination=battery_inverter_6.id
+                ),
+                ComponentConnection(source=meter_3.id, destination=meter_4.id),
+                ComponentConnection(source=meter_3.id, destination=meter_5.id),
+                ComponentConnection(
+                    source=meter_4.id, destination=battery_inverter_7.id
+                ),
+                ComponentConnection(
+                    source=meter_5.id, destination=battery_inverter_8.id
+                ),
             },
         )
 
-        assert set() == graph.dfs(grid, set(), graph.is_pv_chain)
-        assert battery_components == graph.dfs(grid, set(), graph.is_battery_chain)
+        assert set() == graph.dfs(grid_1, set(), graph.is_pv_chain)
+        assert battery_components == graph.dfs(grid_1, set(), graph.is_battery_chain)
 
     def test_find_first_descendant_component(self) -> None:
         """Test scenarios for finding the first descendant component."""
+        grid_1 = GridConnectionPoint(
+            id=ComponentId(1), microgrid_id=_MICROGRID_ID, rated_fuse_current=10_000
+        )
+        meter_2 = Meter(id=ComponentId(2), microgrid_id=_MICROGRID_ID)
+        meter_3 = Meter(id=ComponentId(3), microgrid_id=_MICROGRID_ID)
+        battery_inverter_4 = BatteryInverter(
+            id=ComponentId(4), microgrid_id=_MICROGRID_ID
+        )
+        solar_inverter_5 = SolarInverter(id=ComponentId(5), microgrid_id=_MICROGRID_ID)
+        ev_charger_6 = UnspecifiedEvCharger(
+            id=ComponentId(6), microgrid_id=_MICROGRID_ID
+        )
+
         graph = gr._MicrogridComponentGraph(
             components={
-                Component(ComponentId(1), ComponentCategory.GRID),
-                Component(ComponentId(2), ComponentCategory.METER),
-                Component(ComponentId(3), ComponentCategory.METER),
-                Component(
-                    ComponentId(4), ComponentCategory.INVERTER, InverterType.BATTERY
-                ),
-                Component(
-                    ComponentId(5), ComponentCategory.INVERTER, InverterType.SOLAR
-                ),
-                Component(ComponentId(6), ComponentCategory.EV_CHARGER),
+                grid_1,
+                meter_2,
+                meter_3,
+                battery_inverter_4,
+                solar_inverter_5,
+                ev_charger_6,
             },
             connections={
-                ComponentConnection(source=ComponentId(1), destination=ComponentId(2)),
-                ComponentConnection(source=ComponentId(2), destination=ComponentId(3)),
-                ComponentConnection(source=ComponentId(2), destination=ComponentId(4)),
-                ComponentConnection(source=ComponentId(2), destination=ComponentId(5)),
-                ComponentConnection(source=ComponentId(3), destination=ComponentId(6)),
+                ComponentConnection(source=grid_1.id, destination=meter_2.id),
+                ComponentConnection(source=meter_2.id, destination=meter_3.id),
+                ComponentConnection(
+                    source=meter_2.id, destination=battery_inverter_4.id
+                ),
+                ComponentConnection(source=meter_2.id, destination=solar_inverter_5.id),
+                ComponentConnection(source=meter_3.id, destination=ev_charger_6.id),
             },
         )
 
         # Find the first descendant component of the grid endpoint.
         result = graph.find_first_descendant_component(
-            descendant_categories=(ComponentCategory.METER,),
+            descendants=[Meter],
         )
-        assert result == Component(ComponentId(2), ComponentCategory.METER)
+        assert result == meter_2
 
         # Find the first descendant component of the grid,
         # considering meter or inverter categories.
         result = graph.find_first_descendant_component(
-            descendant_categories=(ComponentCategory.METER, ComponentCategory.INVERTER),
+            descendants=[Meter, Inverter],
         )
-        assert result == Component(ComponentId(2), ComponentCategory.METER)
+        assert result == meter_2
+
+        # Find the first descendant component of the grid,
+        # considering only meter category - should return the first meter.
+        result = graph.find_first_descendant_component(
+            descendants=[Meter],
+        )
+        assert result == meter_2
 
         # Verify behavior when component is not found in immediate descendant
         # categories for the first meter.
         with pytest.raises(ValueError):
             graph.find_first_descendant_component(
-                descendant_categories=(
-                    ComponentCategory.EV_CHARGER,
-                    ComponentCategory.BATTERY,
-                ),
+                descendants=[EvCharger, Battery],
             )
 
         # Verify behavior when component is not found in immediate descendant
         # categories from the grid component as root.
         with pytest.raises(ValueError):
             graph.find_first_descendant_component(
-                descendant_categories=(ComponentCategory.INVERTER,),
+                descendants=[Inverter],
             )
 
 
@@ -719,22 +766,24 @@ class Test_MicrogridComponentGraph:
         with pytest.raises(gr.InvalidGraphError):
             empty_graph.validate()
 
+        grid_1 = GridConnectionPoint(
+            id=ComponentId(1), microgrid_id=_MICROGRID_ID, rated_fuse_current=10_000
+        )
+        meter_2 = Meter(id=ComponentId(2), microgrid_id=_MICROGRID_ID)
+        unrecognized_3 = UnrecognizedComponent(
+            id=ComponentId(3), microgrid_id=_MICROGRID_ID, category=666
+        )
+        conn_1_2 = ComponentConnection(source=grid_1.id, destination=meter_2.id)
+        conn_1_3 = ComponentConnection(source=grid_1.id, destination=unrecognized_3.id)
+
         # if components and connections are provided,
         # must provide both non-empty, not one or the
         # other
         with pytest.raises(gr.InvalidGraphError):
-            gr._MicrogridComponentGraph(
-                components={Component(ComponentId(1), ComponentCategory.GRID)}
-            )
+            gr._MicrogridComponentGraph(components={grid_1})
 
         with pytest.raises(gr.InvalidGraphError):
-            gr._MicrogridComponentGraph(
-                connections={
-                    ComponentConnection(
-                        source=ComponentId(1), destination=ComponentId(2)
-                    )
-                }
-            )
+            gr._MicrogridComponentGraph(connections={conn_1_2})
 
         # if both are provided, the graph data must itself
         # be valid (we give just a couple of cases of each
@@ -745,78 +794,29 @@ class Test_MicrogridComponentGraph:
         # minimal valid microgrid data: a grid endpoint
         # connected to a meter
         grid_and_meter = gr._MicrogridComponentGraph(
-            components={
-                Component(ComponentId(1), ComponentCategory.GRID),
-                Component(ComponentId(2), ComponentCategory.METER),
-            },
-            connections={
-                ComponentConnection(source=ComponentId(1), destination=ComponentId(2))
-            },
+            components={grid_1, meter_2}, connections={conn_1_2}
         )
-        expected = {
-            Component(ComponentId(1), ComponentCategory.GRID),
-            Component(ComponentId(2), ComponentCategory.METER),
-        }
+        expected = {grid_1, meter_2}
         assert len(grid_and_meter.components()) == len(expected)
         assert set(grid_and_meter.components()) == expected
-        assert list(grid_and_meter.connections()) == [
-            ComponentConnection(source=ComponentId(1), destination=ComponentId(2))
-        ]
+        assert list(grid_and_meter.connections()) == [conn_1_2]
         grid_and_meter.validate()
 
         # invalid graph data: unknown component category
         with pytest.raises(gr.InvalidGraphError):
             gr._MicrogridComponentGraph(
-                components={
-                    Component(ComponentId(1), ComponentCategory.GRID),
-                    Component(ComponentId(2), ComponentCategory.METER),
-                    Component(ComponentId(3), 666),  # type: ignore
-                },
-                connections={
-                    ComponentConnection(
-                        source=ComponentId(1), destination=ComponentId(2)
-                    ),
-                    ComponentConnection(
-                        source=ComponentId(1), destination=ComponentId(3)
-                    ),
-                },
+                components={grid_1, meter_2, unrecognized_3},
+                connections={conn_1_2, conn_1_3},
             )
 
         # invalid graph data: a connection between components that do not exist
         with pytest.raises(gr.InvalidGraphError):
             gr._MicrogridComponentGraph(
-                components={
-                    Component(ComponentId(1), ComponentCategory.GRID),
-                    Component(ComponentId(2), ComponentCategory.METER),
-                },
-                connections={
-                    ComponentConnection(
-                        source=ComponentId(1), destination=ComponentId(2)
-                    ),
-                    ComponentConnection(
-                        source=ComponentId(1), destination=ComponentId(3)
-                    ),
-                },
+                components={grid_1, meter_2},
+                connections={conn_1_2, conn_1_3},
             )
 
-        # invalid graph data: one of the connections is not valid
-        with pytest.raises(gr.InvalidGraphError):
-            gr._MicrogridComponentGraph(
-                components={
-                    Component(ComponentId(1), ComponentCategory.GRID),
-                    Component(ComponentId(2), ComponentCategory.METER),
-                },
-                connections={
-                    ComponentConnection(
-                        source=ComponentId(1), destination=ComponentId(2)
-                    ),
-                    ComponentConnection(
-                        source=ComponentId(2), destination=ComponentId(2)
-                    ),
-                },
-            )
-
-    def test_refresh_from(self) -> None:
+    def test_refresh_from(self) -> None:  # pylint: disable=too-many-locals
         """Test the refresh_from method."""
         graph = gr._MicrogridComponentGraph()
         assert set(graph.components()) == set()
@@ -832,24 +832,44 @@ class Test_MicrogridComponentGraph:
         with pytest.raises(gr.InvalidGraphError):
             graph.validate()
 
+        grid_1 = GridConnectionPoint(
+            id=ComponentId(1), microgrid_id=_MICROGRID_ID, rated_fuse_current=10_000
+        )
+        meter_2 = Meter(id=ComponentId(2), microgrid_id=_MICROGRID_ID)
+        meter_3 = Meter(id=ComponentId(3), microgrid_id=_MICROGRID_ID)
+        meter_4 = Meter(id=ComponentId(4), microgrid_id=_MICROGRID_ID)
+        inverter_5 = UnspecifiedInverter(id=ComponentId(5), microgrid_id=_MICROGRID_ID)
+        battery_6 = UnspecifiedBattery(id=ComponentId(6), microgrid_id=_MICROGRID_ID)
+        grid_7 = GridConnectionPoint(
+            id=ComponentId(7), microgrid_id=_MICROGRID_ID, rated_fuse_current=10_000
+        )
+        meter_8 = Meter(id=ComponentId(8), microgrid_id=_MICROGRID_ID)
+        inverter_9 = UnspecifiedInverter(id=ComponentId(9), microgrid_id=_MICROGRID_ID)
+        grid_10 = GridConnectionPoint(
+            id=ComponentId(10), microgrid_id=_MICROGRID_ID, rated_fuse_current=10_000
+        )
+        meter_11 = Meter(id=ComponentId(11), microgrid_id=_MICROGRID_ID)
+
+        conn_1_2 = ComponentConnection(source=grid_1.id, destination=meter_2.id)
+        conn_2_3 = ComponentConnection(source=meter_2.id, destination=meter_3.id)
+        conn_2_4 = ComponentConnection(source=meter_2.id, destination=meter_4.id)
+        conn_4_5 = ComponentConnection(source=meter_4.id, destination=inverter_5.id)
+        conn_5_6 = ComponentConnection(source=inverter_5.id, destination=battery_6.id)
+        conn_7_8 = ComponentConnection(source=meter_3.id, destination=meter_4.id)
+        conn_8_9 = ComponentConnection(source=meter_4.id, destination=inverter_5.id)
+        conn_9_8 = ComponentConnection(source=inverter_5.id, destination=meter_3.id)
+        conn_9_7 = ComponentConnection(source=inverter_5.id, destination=grid_7.id)
+        conn_10_11 = ComponentConnection(source=grid_10.id, destination=meter_11.id)
+
         with pytest.raises(gr.InvalidGraphError):
-            graph.refresh_from(
-                set(),
-                {
-                    ComponentConnection(
-                        source=ComponentId(1), destination=ComponentId(2)
-                    )
-                },
-            )
+            graph.refresh_from(set(), {conn_1_2})
         assert set(graph.components()) == set()
         assert list(graph.connections()) == []
         with pytest.raises(gr.InvalidGraphError):
             graph.validate()
 
         with pytest.raises(gr.InvalidGraphError):
-            graph.refresh_from(
-                {Component(ComponentId(1), ComponentCategory.GRID)}, set()
-            )
+            graph.refresh_from({grid_1}, set())
         assert set(graph.components()) == set()
         assert list(graph.connections()) == []
         with pytest.raises(gr.InvalidGraphError):
@@ -858,18 +878,18 @@ class Test_MicrogridComponentGraph:
         # if both are provided, valid graph data must be present
 
         # invalid component
-        with pytest.raises(gr.InvalidGraphError):
+        with pytest.raises(ValueError, match=r"ComponentId can't be negative."):
             graph.refresh_from(
                 components={
-                    Component(ComponentId(0), ComponentCategory.GRID),
-                    Component(ComponentId(1), ComponentCategory.METER),
-                    Component(ComponentId(2), ComponentCategory.METER),
+                    GridConnectionPoint(
+                        id=ComponentId(-1),
+                        microgrid_id=_MICROGRID_ID,
+                        rated_fuse_current=10_000,
+                    ),
+                    meter_2,
+                    meter_3,
                 },
-                connections={
-                    ComponentConnection(
-                        source=ComponentId(1), destination=ComponentId(2)
-                    )
-                },
+                connections={conn_1_2},
             )
         assert set(graph.components()) == set()
         assert list(graph.connections()) == []
@@ -877,20 +897,14 @@ class Test_MicrogridComponentGraph:
             graph.validate()
 
         # invalid connection
-        with pytest.raises(gr.InvalidGraphError):
+        with pytest.raises(
+            ValueError, match=r"Source and destination components must be different"
+        ):
             graph.refresh_from(
-                components={
-                    Component(ComponentId(1), ComponentCategory.GRID),
-                    Component(ComponentId(2), ComponentCategory.METER),
-                    Component(ComponentId(3), ComponentCategory.METER),
-                },
+                components={grid_1, meter_2, meter_3},
                 connections={
-                    ComponentConnection(
-                        source=ComponentId(1), destination=ComponentId(1)
-                    ),
-                    ComponentConnection(
-                        source=ComponentId(2), destination=ComponentId(3)
-                    ),
+                    ComponentConnection(source=grid_1.id, destination=grid_1.id),
+                    conn_2_3,
                 },
             )
         assert set(graph.components()) == set()
@@ -898,37 +912,16 @@ class Test_MicrogridComponentGraph:
         with pytest.raises(gr.InvalidGraphError):
             graph.validate()
 
+        expected_components = {grid_1, meter_2, meter_4, inverter_5, battery_6}
+        expected_connections = {conn_1_2, conn_2_4, conn_4_5, conn_5_6}
         # valid graph with both load and battery setup
         graph.refresh_from(
-            components={
-                Component(ComponentId(1), ComponentCategory.GRID),
-                Component(ComponentId(2), ComponentCategory.METER),
-                Component(ComponentId(4), ComponentCategory.METER),
-                Component(ComponentId(5), ComponentCategory.INVERTER),
-                Component(ComponentId(6), ComponentCategory.BATTERY),
-            },
-            connections={
-                ComponentConnection(source=ComponentId(1), destination=ComponentId(2)),
-                ComponentConnection(source=ComponentId(2), destination=ComponentId(4)),
-                ComponentConnection(source=ComponentId(4), destination=ComponentId(5)),
-                ComponentConnection(source=ComponentId(5), destination=ComponentId(6)),
-            },
+            components=expected_components,
+            connections=expected_connections,
         )
-        expected = {
-            Component(ComponentId(1), ComponentCategory.GRID),
-            Component(ComponentId(2), ComponentCategory.METER),
-            Component(ComponentId(4), ComponentCategory.METER),
-            Component(ComponentId(5), ComponentCategory.INVERTER),
-            Component(ComponentId(6), ComponentCategory.BATTERY),
-        }
-        assert len(graph.components()) == len(expected)
-        assert set(graph.components()) == expected
-        assert graph.connections() == {
-            ComponentConnection(source=ComponentId(1), destination=ComponentId(2)),
-            ComponentConnection(source=ComponentId(2), destination=ComponentId(4)),
-            ComponentConnection(source=ComponentId(4), destination=ComponentId(5)),
-            ComponentConnection(source=ComponentId(5), destination=ComponentId(6)),
-        }
+        assert len(graph.components()) == len(expected_components)
+        assert set(graph.components()) == expected_components
+        assert graph.connections() == expected_connections
         graph.validate()
 
         # if invalid graph data is provided (in this case, the graph
@@ -936,33 +929,13 @@ class Test_MicrogridComponentGraph:
         # graph will remain unchanged
         with pytest.raises(gr.InvalidGraphError):
             graph.refresh_from(
-                components={
-                    Component(ComponentId(7), ComponentCategory.GRID),
-                    Component(ComponentId(8), ComponentCategory.METER),
-                    Component(ComponentId(9), ComponentCategory.INVERTER),
-                },
-                connections={
-                    ComponentConnection(
-                        source=ComponentId(7), destination=ComponentId(8)
-                    ),
-                    ComponentConnection(
-                        source=ComponentId(8), destination=ComponentId(9)
-                    ),
-                    ComponentConnection(
-                        source=ComponentId(9), destination=ComponentId(8)
-                    ),
-                },
+                components={grid_7, meter_8, inverter_9},
+                connections={conn_7_8, conn_8_9, conn_9_8},
             )
 
-        assert len(graph.components()) == len(expected)
-        assert graph.components() == expected
-
-        assert graph.connections() == {
-            ComponentConnection(source=ComponentId(1), destination=ComponentId(2)),
-            ComponentConnection(source=ComponentId(2), destination=ComponentId(4)),
-            ComponentConnection(source=ComponentId(4), destination=ComponentId(5)),
-            ComponentConnection(source=ComponentId(5), destination=ComponentId(6)),
-        }
+        assert len(graph.components()) == len(expected_components)
+        assert graph.components() == expected_components
+        assert graph.connections() == expected_connections
         graph.validate()
 
         # confirm that if `correct_errors` callback is not `None`,
@@ -976,14 +949,10 @@ class Test_MicrogridComponentGraph:
         with pytest.raises(gr.InvalidGraphError):
             graph.refresh_from(
                 components={
-                    Component(ComponentId(7), ComponentCategory.GRID),
-                    Component(ComponentId(9), ComponentCategory.METER),
+                    grid_7,
+                    inverter_9,
                 },
-                connections={
-                    ComponentConnection(
-                        source=ComponentId(9), destination=ComponentId(7)
-                    )
-                },
+                connections={conn_9_7},
                 correct_errors=pretend_to_correct_errors,
             )
 
@@ -991,25 +960,17 @@ class Test_MicrogridComponentGraph:
 
         # if valid graph data is provided, then the existing graph
         # contents will be overwritten
+        expected_components = {
+            grid_10,
+            meter_11,
+        }
         graph.refresh_from(
-            components={
-                Component(ComponentId(10), ComponentCategory.GRID),
-                Component(ComponentId(11), ComponentCategory.METER),
-            },
-            connections={
-                ComponentConnection(source=ComponentId(10), destination=ComponentId(11))
-            },
+            components=expected_components,
+            connections={conn_10_11},
         )
-
-        expected = {
-            Component(ComponentId(10), ComponentCategory.GRID),
-            Component(ComponentId(11), ComponentCategory.METER),
-        }
-        assert len(graph.components()) == len(expected)
-        assert set(graph.components()) == expected
-        assert graph.connections() == {
-            ComponentConnection(source=ComponentId(10), destination=ComponentId(11))
-        }
+        assert len(graph.components()) == len(expected_components)
+        assert set(graph.components()) == expected_components
+        assert graph.connections() == {conn_10_11}
         graph.validate()
 
     async def test_refresh_from_client(self) -> None:
@@ -1037,7 +998,9 @@ class Test_MicrogridComponentGraph:
             graph.validate()
 
         client.list_components.return_value = [
-            Component(ComponentId(1), ComponentCategory.GRID)
+            GridConnectionPoint(
+                id=ComponentId(1), microgrid_id=_MICROGRID_ID, rated_fuse_current=10_000
+            )
         ]
         with pytest.raises(gr.InvalidGraphError):
             await graph.refresh_from_client(client)
@@ -1060,86 +1023,61 @@ class Test_MicrogridComponentGraph:
         # if both are provided, valid graph data must be present
 
         # valid graph with meter, and EV charger
-        client.list_components.return_value = [
-            Component(
-                ComponentId(101),
-                ComponentCategory.GRID,
-                metadata=ComponentMetadata(fuse=Fuse(max_current=0.0)),
-            ),
-            Component(ComponentId(111), ComponentCategory.METER),
-            Component(ComponentId(131), ComponentCategory.EV_CHARGER),
+        grid_101 = GridConnectionPoint(
+            id=ComponentId(101), microgrid_id=_MICROGRID_ID, rated_fuse_current=0
+        )
+        meter_111 = Meter(id=ComponentId(111), microgrid_id=_MICROGRID_ID)
+        charger_131 = UnspecifiedEvCharger(
+            id=ComponentId(131), microgrid_id=_MICROGRID_ID
+        )
+        expected_components = [grid_101, meter_111, charger_131]
+        expected_connections = [
+            ComponentConnection(source=grid_101.id, destination=meter_111.id),
+            ComponentConnection(source=meter_111.id, destination=charger_131.id),
         ]
-        client.list_connections.return_value = [
-            ComponentConnection(source=ComponentId(101), destination=ComponentId(111)),
-            ComponentConnection(source=ComponentId(111), destination=ComponentId(131)),
-        ]
+        client.list_components.return_value = expected_components
+        client.list_connections.return_value = expected_connections
         await graph.refresh_from_client(client)
 
         # Note: we need to add GriMetadata as a dict here, because that's what
         # the ComponentGraph does too, and we need to be able to compare the
         # two graphs.
-        expected = {
-            Component(
-                ComponentId(101),
-                ComponentCategory.GRID,
-                None,
-                ComponentMetadata(fuse=Fuse(max_current=0.0)),
-            ),
-            Component(ComponentId(111), ComponentCategory.METER),
-            Component(ComponentId(131), ComponentCategory.EV_CHARGER),
-        }
-        assert len(graph.components()) == len(expected)
-        assert graph.components() == expected
-        assert graph.connections() == {
-            ComponentConnection(source=ComponentId(101), destination=ComponentId(111)),
-            ComponentConnection(source=ComponentId(111), destination=ComponentId(131)),
-        }
+        assert graph.components() == set(expected_components)
+        assert graph.connections() == set(expected_connections)
         graph.validate()
 
         # if valid graph data is provided, then the existing graph
         # contents will be overwritten
-        client.list_components.return_value = [
-            Component(
-                ComponentId(707),
-                ComponentCategory.GRID,
-                metadata=ComponentMetadata(fuse=Fuse(max_current=0.0)),
-            ),
-            Component(ComponentId(717), ComponentCategory.METER),
-            Component(
-                ComponentId(727), ComponentCategory.INVERTER, type=InverterType.NONE
-            ),
-            Component(ComponentId(737), ComponentCategory.BATTERY),
-            Component(ComponentId(747), ComponentCategory.METER),
+        grid_707 = GridConnectionPoint(
+            id=ComponentId(707), microgrid_id=_MICROGRID_ID, rated_fuse_current=0
+        )
+        meter_717 = Meter(id=ComponentId(717), microgrid_id=_MICROGRID_ID)
+        inverter_727 = UnspecifiedInverter(
+            id=ComponentId(727), microgrid_id=_MICROGRID_ID
+        )
+        battery_737 = UnspecifiedBattery(
+            id=ComponentId(737), microgrid_id=_MICROGRID_ID
+        )
+        meter_747 = Meter(id=ComponentId(747), microgrid_id=_MICROGRID_ID)
+        expected_components = [
+            grid_707,
+            meter_717,
+            inverter_727,
+            battery_737,
+            meter_747,
         ]
-        client.list_connections.return_value = [
-            ComponentConnection(source=ComponentId(707), destination=ComponentId(717)),
-            ComponentConnection(source=ComponentId(717), destination=ComponentId(727)),
-            ComponentConnection(source=ComponentId(727), destination=ComponentId(737)),
-            ComponentConnection(source=ComponentId(717), destination=ComponentId(747)),
+        expected_connections = [
+            ComponentConnection(source=grid_707.id, destination=meter_717.id),
+            ComponentConnection(source=meter_717.id, destination=inverter_727.id),
+            ComponentConnection(source=inverter_727.id, destination=battery_737.id),
+            ComponentConnection(source=meter_717.id, destination=meter_747.id),
         ]
+        client.list_components.return_value = expected_components
+        client.list_connections.return_value = expected_connections
         await graph.refresh_from_client(client)
 
-        expected = {
-            Component(
-                ComponentId(707),
-                ComponentCategory.GRID,
-                None,
-                ComponentMetadata(fuse=Fuse(max_current=0.0)),
-            ),
-            Component(ComponentId(717), ComponentCategory.METER),
-            Component(ComponentId(727), ComponentCategory.INVERTER, InverterType.NONE),
-            Component(ComponentId(737), ComponentCategory.BATTERY),
-            Component(ComponentId(747), ComponentCategory.METER),
-        }
-        assert len(graph.components()) == len(expected)
-        assert graph.components() == expected
-
-        assert graph.connections() == {
-            ComponentConnection(source=ComponentId(707), destination=ComponentId(717)),
-            ComponentConnection(source=ComponentId(717), destination=ComponentId(727)),
-            ComponentConnection(source=ComponentId(717), destination=ComponentId(747)),
-            ComponentConnection(source=ComponentId(727), destination=ComponentId(737)),
-        }
+        assert graph.components() == set(expected_components)
+        assert graph.connections() == set(expected_connections)
         graph.validate()
 
     def test_validate(self) -> None:
@@ -1169,51 +1107,51 @@ class Test_MicrogridComponentGraph:
 
         # graph root is not valid: multiple potential root nodes
         graph._graph.clear()
-        _add_components(
-            graph,
-            Component(ComponentId(1), ComponentCategory.GRID),
-            Component(ComponentId(2), ComponentCategory.NONE),
-            Component(ComponentId(3), ComponentCategory.METER),
+        grid_1 = GridConnectionPoint(
+            id=ComponentId(1), microgrid_id=_MICROGRID_ID, rated_fuse_current=10_000
         )
+        unspecified_2 = UnspecifiedComponent(
+            id=ComponentId(2), microgrid_id=_MICROGRID_ID
+        )
+        meter_3 = Meter(id=ComponentId(3), microgrid_id=_MICROGRID_ID)
+        _add_components(graph, grid_1, unspecified_2, meter_3)
         _add_connections(
             graph,
-            ComponentConnection(source=ComponentId(1), destination=ComponentId(3)),
-            ComponentConnection(source=ComponentId(2), destination=ComponentId(3)),
+            ComponentConnection(source=grid_1.id, destination=meter_3.id),
+            ComponentConnection(source=unspecified_2.id, destination=meter_3.id),
         )
         with pytest.raises(gr.InvalidGraphError, match="Multiple potential root nodes"):
             graph.validate()
 
         # grid endpoint is not set up correctly: multiple grid endpoints
         graph._graph.clear()
-        _add_components(
-            graph,
-            Component(ComponentId(1), ComponentCategory.GRID),
-            Component(ComponentId(2), ComponentCategory.GRID),
-            Component(ComponentId(3), ComponentCategory.METER),
+        grid_2 = GridConnectionPoint(
+            id=ComponentId(2), microgrid_id=_MICROGRID_ID, rated_fuse_current=10_000
         )
+        _add_components(graph, grid_1, grid_2, meter_3)
         _add_connections(
             graph,
-            ComponentConnection(source=ComponentId(1), destination=ComponentId(2)),
-            ComponentConnection(source=ComponentId(2), destination=ComponentId(3)),
+            ComponentConnection(source=grid_1.id, destination=meter_3.id),
+            ComponentConnection(source=grid_2.id, destination=meter_3.id),
         )
         with pytest.raises(
-            gr.InvalidGraphError, match="Multiple grid endpoints in component graph"
+            gr.InvalidGraphError,
+            match=re.escape(
+                r"Multiple potential root nodes: CID1<GridConnectionPoint>, "
+                r"CID2<GridConnectionPoint>"
+            ),
         ):
             graph.validate()
 
         # leaf components are not set up correctly: a battery has
         # a successor in the graph
         graph._graph.clear()
-        _add_components(
-            graph,
-            Component(ComponentId(1), ComponentCategory.GRID),
-            Component(ComponentId(2), ComponentCategory.BATTERY),
-            Component(ComponentId(3), ComponentCategory.METER),
-        )
+        battery_2 = UnspecifiedBattery(id=ComponentId(2), microgrid_id=_MICROGRID_ID)
+        _add_components(graph, grid_1, battery_2, meter_3)
         _add_connections(
             graph,
-            ComponentConnection(source=ComponentId(1), destination=ComponentId(2)),
-            ComponentConnection(source=ComponentId(2), destination=ComponentId(3)),
+            ComponentConnection(source=grid_1.id, destination=battery_2.id),
+            ComponentConnection(source=battery_2.id, destination=meter_3.id),
         )
         with pytest.raises(
             gr.InvalidGraphError, match="Leaf components with graph successors"
@@ -1235,7 +1173,10 @@ class Test_MicrogridComponentGraph:
 
         # graph has no connections
         graph._graph.clear()
-        _add_components(graph, Component(ComponentId(1), ComponentCategory.GRID))
+        grid_1 = GridConnectionPoint(
+            id=ComponentId(1), microgrid_id=_MICROGRID_ID, rated_fuse_current=10_000
+        )
+        _add_components(graph, grid_1)
         with pytest.raises(
             gr.InvalidGraphError, match="No connections in component graph!"
         ):
@@ -1243,17 +1184,14 @@ class Test_MicrogridComponentGraph:
 
         # graph is not a tree
         graph._graph.clear()
-        _add_components(
-            graph,
-            Component(ComponentId(1), ComponentCategory.GRID),
-            Component(ComponentId(2), ComponentCategory.INVERTER),
-            Component(ComponentId(3), ComponentCategory.METER),
-        )
+        inverter_2 = UnspecifiedInverter(id=ComponentId(2), microgrid_id=_MICROGRID_ID)
+        meter_3 = Meter(id=ComponentId(3), microgrid_id=_MICROGRID_ID)
+        _add_components(graph, grid_1, inverter_2, meter_3)
         _add_connections(
             graph,
-            ComponentConnection(source=ComponentId(1), destination=ComponentId(2)),
-            ComponentConnection(source=ComponentId(2), destination=ComponentId(3)),
-            ComponentConnection(source=ComponentId(3), destination=ComponentId(2)),
+            ComponentConnection(source=grid_1.id, destination=inverter_2.id),
+            ComponentConnection(source=inverter_2.id, destination=meter_3.id),
+            ComponentConnection(source=meter_3.id, destination=inverter_2.id),
         )
         with pytest.raises(
             gr.InvalidGraphError, match="Component graph is not a tree!"
@@ -1262,15 +1200,14 @@ class Test_MicrogridComponentGraph:
 
         # at least one node is completely unconnected
         # (this violates the tree property):
-        _add_components(
-            graph,
-            Component(ComponentId(1), ComponentCategory.GRID),
-            Component(ComponentId(2), ComponentCategory.METER),
-            Component(ComponentId(3), ComponentCategory.NONE),
+        meter_2 = Meter(id=ComponentId(2), microgrid_id=_MICROGRID_ID)
+        unspecified_3 = UnspecifiedComponent(
+            id=ComponentId(3), microgrid_id=_MICROGRID_ID
         )
+        _add_components(graph, grid_1, meter_2, unspecified_3)
         _add_connections(
             graph,
-            ComponentConnection(source=ComponentId(1), destination=ComponentId(2)),
+            ComponentConnection(source=grid_1.id, destination=meter_2.id),
         )
         with pytest.raises(
             gr.InvalidGraphError, match="Component graph is not a tree!"
@@ -1290,17 +1227,15 @@ class Test_MicrogridComponentGraph:
         # get caught by `_validate_graph` but let's confirm
         # that `_validate_graph_root` also catches it)
         graph._graph.clear()
-        _add_components(
-            graph,
-            Component(ComponentId(1), ComponentCategory.METER),
-            Component(ComponentId(2), ComponentCategory.METER),
-            Component(ComponentId(3), ComponentCategory.METER),
-        )
+        meter_1 = Meter(id=ComponentId(1), microgrid_id=_MICROGRID_ID)
+        meter_2 = Meter(id=ComponentId(2), microgrid_id=_MICROGRID_ID)
+        meter_3 = Meter(id=ComponentId(3), microgrid_id=_MICROGRID_ID)
+        _add_components(graph, meter_1, meter_2, meter_3)
         _add_connections(
             graph,
-            ComponentConnection(source=ComponentId(1), destination=ComponentId(2)),
-            ComponentConnection(source=ComponentId(2), destination=ComponentId(3)),
-            ComponentConnection(source=ComponentId(3), destination=ComponentId(1)),
+            ComponentConnection(source=meter_1.id, destination=meter_2.id),
+            ComponentConnection(source=meter_2.id, destination=meter_3.id),
+            ComponentConnection(source=meter_3.id, destination=meter_1.id),
         )
         with pytest.raises(
             gr.InvalidGraphError, match="No valid root nodes of component graph!"
@@ -1310,16 +1245,13 @@ class Test_MicrogridComponentGraph:
         # there are nodes without predecessors, but not of
         # the valid type(s) NONE, GRID, or JUNCTION
         graph._graph.clear()
-        _add_components(
-            graph,
-            Component(ComponentId(1), ComponentCategory.METER),
-            Component(ComponentId(2), ComponentCategory.INVERTER),
-            Component(ComponentId(3), ComponentCategory.BATTERY),
-        )
+        inverter_2 = UnspecifiedInverter(id=ComponentId(2), microgrid_id=_MICROGRID_ID)
+        battery_3 = UnspecifiedBattery(id=ComponentId(3), microgrid_id=_MICROGRID_ID)
+        _add_components(graph, meter_1, inverter_2, battery_3)
         _add_connections(
             graph,
-            ComponentConnection(source=ComponentId(1), destination=ComponentId(2)),
-            ComponentConnection(source=ComponentId(2), destination=ComponentId(3)),
+            ComponentConnection(source=meter_1.id, destination=inverter_2.id),
+            ComponentConnection(source=inverter_2.id, destination=battery_3.id),
         )
         with pytest.raises(
             gr.InvalidGraphError, match="No valid root nodes of component graph!"
@@ -1329,94 +1261,82 @@ class Test_MicrogridComponentGraph:
         # there are multiple different potentially valid
         # root notes
         graph._graph.clear()
-        _add_components(
-            graph,
-            Component(ComponentId(1), ComponentCategory.NONE),
-            Component(ComponentId(2), ComponentCategory.GRID),
-            Component(ComponentId(3), ComponentCategory.METER),
+        unspecified_1 = UnspecifiedComponent(
+            id=ComponentId(1), microgrid_id=_MICROGRID_ID
         )
+        grid_2 = GridConnectionPoint(
+            id=ComponentId(2), microgrid_id=_MICROGRID_ID, rated_fuse_current=10_000
+        )
+        _add_components(graph, unspecified_1, grid_2, meter_3)
         _add_connections(
             graph,
-            ComponentConnection(source=ComponentId(1), destination=ComponentId(3)),
-            ComponentConnection(source=ComponentId(2), destination=ComponentId(3)),
+            ComponentConnection(source=unspecified_1.id, destination=meter_3.id),
+            ComponentConnection(source=grid_2.id, destination=meter_3.id),
         )
         with pytest.raises(gr.InvalidGraphError, match="Multiple potential root nodes"):
             graph._validate_graph_root()
 
         graph._graph.clear()
-        _add_components(
-            graph,
-            Component(ComponentId(1), ComponentCategory.GRID),
-            Component(ComponentId(2), ComponentCategory.GRID),
-            Component(ComponentId(3), ComponentCategory.METER),
+        grid_1 = GridConnectionPoint(
+            id=ComponentId(1), microgrid_id=_MICROGRID_ID, rated_fuse_current=10_000
         )
+        _add_components(graph, grid_1, grid_2, meter_3)
         _add_connections(
             graph,
-            ComponentConnection(source=ComponentId(1), destination=ComponentId(3)),
-            ComponentConnection(source=ComponentId(2), destination=ComponentId(3)),
+            ComponentConnection(source=grid_1.id, destination=meter_3.id),
+            ComponentConnection(source=grid_2.id, destination=meter_3.id),
         )
         with pytest.raises(gr.InvalidGraphError, match="Multiple potential root nodes"):
             graph._validate_graph_root()
 
         # there is just one potential root node but it has no successors
         graph._graph.clear()
-        _add_components(graph, Component(ComponentId(1), ComponentCategory.NONE))
+        _add_components(graph, unspecified_1)
         with pytest.raises(
-            gr.InvalidGraphError,
-            match=r"Graph root .*component_id=ComponentId\(1\).* has no successors!",
+            gr.InvalidGraphError, match="Graph root .*CID1.* has no successors!"
         ):
             graph._validate_graph_root()
 
         graph._graph.clear()
-        _add_components(graph, Component(ComponentId(2), ComponentCategory.GRID))
+        _add_components(graph, grid_2)
         with pytest.raises(
-            gr.InvalidGraphError,
-            match=r"Graph root .*component_id=ComponentId\(2\).* has no successors!",
+            gr.InvalidGraphError, match="Graph root .*CID2.* has no successors!"
         ):
             graph._validate_graph_root()
 
         graph._graph.clear()
-        _add_components(graph, Component(ComponentId(3), ComponentCategory.GRID))
+        grid_3 = GridConnectionPoint(
+            id=ComponentId(3), microgrid_id=_MICROGRID_ID, rated_fuse_current=10_000
+        )
+        _add_components(graph, grid_3)
         with pytest.raises(
             gr.InvalidGraphError,
-            match=r"Graph root .*component_id=ComponentId\(3\).* has no successors!",
+            match=r"Graph root CID3<GridConnectionPoint> has no successors!",
         ):
             graph._validate_graph_root()
 
         # there is exactly one potential root node and it has successors
         graph._graph.clear()
-        _add_components(
-            graph,
-            Component(ComponentId(1), ComponentCategory.NONE),
-            Component(ComponentId(2), ComponentCategory.METER),
-        )
+        _add_components(graph, unspecified_1, meter_2)
         _add_connections(
             graph,
-            ComponentConnection(source=ComponentId(1), destination=ComponentId(2)),
+            ComponentConnection(source=unspecified_1.id, destination=meter_2.id),
         )
         graph._validate_graph_root()
 
         graph._graph.clear()
-        _add_components(
-            graph,
-            Component(ComponentId(1), ComponentCategory.GRID),
-            Component(ComponentId(2), ComponentCategory.METER),
-        )
+        _add_components(graph, grid_1, meter_2)
         _add_connections(
             graph,
-            ComponentConnection(source=ComponentId(1), destination=ComponentId(2)),
+            ComponentConnection(source=grid_1.id, destination=meter_2.id),
         )
         graph._validate_graph_root()
 
         graph._graph.clear()
-        _add_components(
-            graph,
-            Component(ComponentId(1), ComponentCategory.GRID),
-            Component(ComponentId(2), ComponentCategory.METER),
-        )
+        _add_components(graph, grid_1, meter_2)
         _add_connections(
             graph,
-            ComponentConnection(source=ComponentId(1), destination=ComponentId(2)),
+            ComponentConnection(source=grid_1.id, destination=meter_2.id),
         )
         graph._validate_graph_root()
 
@@ -1432,21 +1352,23 @@ class Test_MicrogridComponentGraph:
         # missing grid endpoint is OK as the graph might have
         # another kind of root
         graph._graph.clear()
-        _add_components(graph, Component(ComponentId(2), ComponentCategory.METER))
+        meter_2 = Meter(id=ComponentId(2), microgrid_id=_MICROGRID_ID)
+        _add_components(graph, meter_2)
         graph._validate_grid_endpoint()
 
         # multiple grid endpoints
         graph._graph.clear()
-        _add_components(
-            graph,
-            Component(ComponentId(1), ComponentCategory.GRID),
-            Component(ComponentId(2), ComponentCategory.METER),
-            Component(ComponentId(3), ComponentCategory.GRID),
+        grid_1 = GridConnectionPoint(
+            id=ComponentId(1), microgrid_id=_MICROGRID_ID, rated_fuse_current=10_000
         )
+        grid_3 = GridConnectionPoint(
+            id=ComponentId(3), microgrid_id=_MICROGRID_ID, rated_fuse_current=10_000
+        )
+        _add_components(graph, grid_1, meter_2, grid_3)
         _add_connections(
             graph,
-            ComponentConnection(source=ComponentId(1), destination=ComponentId(2)),
-            ComponentConnection(source=ComponentId(3), destination=ComponentId(2)),
+            ComponentConnection(source=grid_1.id, destination=meter_2.id),
+            ComponentConnection(source=grid_3.id, destination=meter_2.id),
         )
         with pytest.raises(
             gr.InvalidGraphError,
@@ -1456,29 +1378,27 @@ class Test_MicrogridComponentGraph:
 
         # grid endpoint has predecessors
         graph._graph.clear()
-        _add_components(
-            graph,
-            Component(ComponentId(1), ComponentCategory.GRID),
-            Component(ComponentId(99), ComponentCategory.METER),
-        )
+        meter_99 = Meter(id=ComponentId(99), microgrid_id=_MICROGRID_ID)
+        _add_components(graph, grid_1, meter_99)
         _add_connections(
             graph,
-            ComponentConnection(source=ComponentId(99), destination=ComponentId(1)),
+            ComponentConnection(source=meter_99.id, destination=grid_1.id),
         )
         with pytest.raises(
             gr.InvalidGraphError,
-            match=r"Grid endpoint with CID1 has graph predecessors: \[Component"
-            r"\(component_id=ComponentId\(99\), category=<ComponentCategory.METER.*>, "
-            r"type=None, metadata=None\)\]",
+            match=re.escape(r"Grid endpoint CID1 has predecessors: CID99<Meter>"),
         ):
             graph._validate_grid_endpoint()
 
         # grid endpoint has no successors
         graph._graph.clear()
-        _add_components(graph, Component(ComponentId(101), ComponentCategory.GRID))
+        grid_101 = GridConnectionPoint(
+            id=ComponentId(101), microgrid_id=_MICROGRID_ID, rated_fuse_current=10_000
+        )
+        _add_components(graph, grid_101)
         with pytest.raises(
             gr.InvalidGraphError,
-            match="Grid endpoint with CID101 has no graph successors!",
+            match="Grid endpoint CID101 has no graph successors!",
         ):
             graph._validate_grid_endpoint()
 
@@ -1486,12 +1406,12 @@ class Test_MicrogridComponentGraph:
         graph._graph.clear()
         _add_components(
             graph,
-            Component(ComponentId(1), ComponentCategory.GRID),
-            Component(ComponentId(2), ComponentCategory.METER),
+            grid_1,
+            meter_2,
         )
         _add_connections(
             graph,
-            ComponentConnection(source=ComponentId(1), destination=ComponentId(2)),
+            ComponentConnection(source=grid_1.id, destination=meter_2.id),
         )
         graph._validate_grid_endpoint()
 
@@ -1506,7 +1426,8 @@ class Test_MicrogridComponentGraph:
 
         # missing predecessor for at least one intermediary node
         graph._graph.clear()
-        _add_components(graph, Component(ComponentId(3), ComponentCategory.INVERTER))
+        inverter_3 = UnspecifiedInverter(id=ComponentId(3), microgrid_id=_MICROGRID_ID)
+        _add_components(graph, inverter_3)
         with pytest.raises(
             gr.InvalidGraphError,
             match="Intermediary components without graph predecessors",
@@ -1514,46 +1435,36 @@ class Test_MicrogridComponentGraph:
             graph._validate_intermediary_components()
 
         graph._graph.clear()
-        _add_components(
-            graph,
-            Component(ComponentId(1), ComponentCategory.GRID),
-            Component(ComponentId(3), ComponentCategory.INVERTER),
+        grid_1 = GridConnectionPoint(
+            id=ComponentId(1), microgrid_id=_MICROGRID_ID, rated_fuse_current=10_000
         )
+        _add_components(graph, grid_1, inverter_3)
         _add_connections(
             graph,
-            ComponentConnection(source=ComponentId(1), destination=ComponentId(3)),
+            ComponentConnection(source=grid_1.id, destination=inverter_3.id),
         )
         graph._validate_intermediary_components()
 
         graph._graph.clear()
-        _add_components(
-            graph,
-            Component(ComponentId(1), ComponentCategory.GRID),
-            Component(ComponentId(2), ComponentCategory.METER),
-            Component(ComponentId(3), ComponentCategory.INVERTER),
-        )
+        meter_2 = Meter(id=ComponentId(2), microgrid_id=_MICROGRID_ID)
+        _add_components(graph, grid_1, meter_2, inverter_3)
         _add_connections(
             graph,
-            ComponentConnection(source=ComponentId(1), destination=ComponentId(2)),
-            ComponentConnection(source=ComponentId(2), destination=ComponentId(3)),
+            ComponentConnection(source=grid_1.id, destination=meter_2.id),
+            ComponentConnection(source=meter_2.id, destination=inverter_3.id),
         )
         graph._validate_intermediary_components()
 
         # all intermediary nodes have at least one predecessor
         # and at least one successor
         graph._graph.clear()
-        _add_components(
-            graph,
-            Component(ComponentId(1), ComponentCategory.GRID),
-            Component(ComponentId(2), ComponentCategory.METER),
-            Component(ComponentId(3), ComponentCategory.INVERTER),
-            Component(ComponentId(4), ComponentCategory.BATTERY),
-        )
+        battery_4 = UnspecifiedBattery(id=ComponentId(4), microgrid_id=_MICROGRID_ID)
+        _add_components(graph, grid_1, meter_2, inverter_3, battery_4)
         _add_connections(
             graph,
-            ComponentConnection(source=ComponentId(1), destination=ComponentId(2)),
-            ComponentConnection(source=ComponentId(2), destination=ComponentId(3)),
-            ComponentConnection(source=ComponentId(3), destination=ComponentId(4)),
+            ComponentConnection(source=grid_1.id, destination=meter_2.id),
+            ComponentConnection(source=meter_2.id, destination=inverter_3.id),
+            ComponentConnection(source=inverter_3.id, destination=battery_4.id),
         )
         graph._validate_intermediary_components()
 
@@ -1568,14 +1479,16 @@ class Test_MicrogridComponentGraph:
 
         # missing predecessor for at least one leaf node
         graph._graph.clear()
-        _add_components(graph, Component(ComponentId(3), ComponentCategory.BATTERY))
+        battery_3 = UnspecifiedBattery(id=ComponentId(3), microgrid_id=_MICROGRID_ID)
+        _add_components(graph, battery_3)
         with pytest.raises(
             gr.InvalidGraphError, match="Leaf components without graph predecessors"
         ):
             graph._validate_leaf_components()
 
         graph._graph.clear()
-        _add_components(graph, Component(ComponentId(4), ComponentCategory.EV_CHARGER))
+        charger_4 = UnspecifiedEvCharger(id=ComponentId(4), microgrid_id=_MICROGRID_ID)
+        _add_components(graph, charger_4)
         with pytest.raises(
             gr.InvalidGraphError, match="Leaf components without graph predecessors"
         ):
@@ -1583,17 +1496,15 @@ class Test_MicrogridComponentGraph:
 
         # successors present for at least one leaf node
         graph._graph.clear()
-        _add_components(
-            graph,
-            Component(ComponentId(1), ComponentCategory.GRID),
-            Component(ComponentId(2), ComponentCategory.EV_CHARGER),
-            Component(ComponentId(3), ComponentCategory.BATTERY),
+        grid_1 = GridConnectionPoint(
+            id=ComponentId(1), microgrid_id=_MICROGRID_ID, rated_fuse_current=10_000
         )
-
+        charger_2 = UnspecifiedEvCharger(id=ComponentId(2), microgrid_id=_MICROGRID_ID)
+        _add_components(graph, grid_1, charger_2, battery_3)
         _add_connections(
             graph,
-            ComponentConnection(source=ComponentId(1), destination=ComponentId(2)),
-            ComponentConnection(source=ComponentId(2), destination=ComponentId(3)),
+            ComponentConnection(source=grid_1.id, destination=charger_2.id),
+            ComponentConnection(source=charger_2.id, destination=battery_3.id),
         )
         with pytest.raises(
             gr.InvalidGraphError, match="Leaf components with graph successors"
@@ -1601,16 +1512,11 @@ class Test_MicrogridComponentGraph:
             graph._validate_leaf_components()
 
         graph._graph.clear()
-        _add_components(
-            graph,
-            Component(ComponentId(1), ComponentCategory.GRID),
-            Component(ComponentId(3), ComponentCategory.BATTERY),
-            Component(ComponentId(4), ComponentCategory.EV_CHARGER),
-        )
+        _add_components(graph, grid_1, battery_3, charger_4)
         _add_connections(
             graph,
-            ComponentConnection(source=ComponentId(1), destination=ComponentId(3)),
-            ComponentConnection(source=ComponentId(3), destination=ComponentId(4)),
+            ComponentConnection(source=grid_1.id, destination=battery_3.id),
+            ComponentConnection(source=battery_3.id, destination=charger_4.id),
         )
         with pytest.raises(
             gr.InvalidGraphError, match="Leaf components with graph successors"
@@ -1620,18 +1526,13 @@ class Test_MicrogridComponentGraph:
         # all leaf nodes have at least one predecessor
         # and no successors
         graph._graph.clear()
-        _add_components(
-            graph,
-            Component(ComponentId(1), ComponentCategory.GRID),
-            Component(ComponentId(2), ComponentCategory.METER),
-            Component(ComponentId(3), ComponentCategory.BATTERY),
-            Component(ComponentId(4), ComponentCategory.EV_CHARGER),
-        )
+        meter_2 = Meter(id=ComponentId(2), microgrid_id=_MICROGRID_ID)
+        _add_components(graph, grid_1, meter_2, battery_3, charger_4)
         _add_connections(
             graph,
-            ComponentConnection(source=ComponentId(1), destination=ComponentId(2)),
-            ComponentConnection(source=ComponentId(1), destination=ComponentId(3)),
-            ComponentConnection(source=ComponentId(1), destination=ComponentId(4)),
+            ComponentConnection(source=grid_1.id, destination=meter_2.id),
+            ComponentConnection(source=grid_1.id, destination=battery_3.id),
+            ComponentConnection(source=grid_1.id, destination=charger_4.id),
         )
         graph._validate_leaf_components()
 
@@ -1641,26 +1542,19 @@ class TestComponentTypeIdentification:
 
     def test_no_comp_meters_pv(self) -> None:
         """Test the case where there are no meters in the graph."""
-        grid = Component(ComponentId(1), ComponentCategory.GRID)
-        grid_meter = Component(ComponentId(2), ComponentCategory.METER)
-        pv_inv_1 = Component(
-            ComponentId(3), ComponentCategory.INVERTER, InverterType.SOLAR
+        grid = GridConnectionPoint(
+            id=ComponentId(1), microgrid_id=_MICROGRID_ID, rated_fuse_current=10_000
         )
-        pv_inv_2 = Component(
-            ComponentId(4), ComponentCategory.INVERTER, InverterType.SOLAR
-        )
+        grid_meter = Meter(id=ComponentId(2), microgrid_id=_MICROGRID_ID)
+        solar_inv_3 = SolarInverter(id=ComponentId(3), microgrid_id=_MICROGRID_ID)
+        solar_inv_4 = SolarInverter(id=ComponentId(4), microgrid_id=_MICROGRID_ID)
 
         graph = gr._MicrogridComponentGraph(
-            components={
-                grid,
-                grid_meter,
-                pv_inv_1,
-                pv_inv_2,
-            },
+            components={grid, grid_meter, solar_inv_3, solar_inv_4},
             connections={
-                ComponentConnection(source=ComponentId(1), destination=ComponentId(2)),
-                ComponentConnection(source=ComponentId(2), destination=ComponentId(3)),
-                ComponentConnection(source=ComponentId(2), destination=ComponentId(4)),
+                ComponentConnection(source=grid.id, destination=grid_meter.id),
+                ComponentConnection(source=grid_meter.id, destination=solar_inv_3.id),
+                ComponentConnection(source=grid_meter.id, destination=solar_inv_4.id),
             },
         )
 
@@ -1668,134 +1562,140 @@ class TestComponentTypeIdentification:
         assert not graph.is_pv_meter(grid_meter)
         assert not graph.is_pv_chain(grid_meter)
 
-        assert graph.is_pv_inverter(pv_inv_1) and graph.is_pv_chain(pv_inv_1)
-        assert graph.is_pv_inverter(pv_inv_2) and graph.is_pv_chain(pv_inv_2)
+        assert graph.is_pv_inverter(solar_inv_3) and graph.is_pv_chain(solar_inv_3)
+        assert graph.is_pv_inverter(solar_inv_4) and graph.is_pv_chain(solar_inv_4)
 
     def test_no_comp_meters_mixed(self) -> None:
         """Test the case where there are no meters in the graph."""
-        grid = Component(ComponentId(1), ComponentCategory.GRID)
-        grid_meter = Component(ComponentId(2), ComponentCategory.METER)
-        pv_inv = Component(
-            ComponentId(3), ComponentCategory.INVERTER, InverterType.SOLAR
+        grid_1 = GridConnectionPoint(
+            id=ComponentId(1), microgrid_id=_MICROGRID_ID, rated_fuse_current=10_000
         )
-        battery_inv = Component(
-            ComponentId(4), ComponentCategory.INVERTER, InverterType.BATTERY
-        )
-        battery = Component(ComponentId(5), ComponentCategory.BATTERY)
+        grid_meter_2 = Meter(id=ComponentId(2), microgrid_id=_MICROGRID_ID)
+        solar_inv_3 = SolarInverter(id=ComponentId(3), microgrid_id=_MICROGRID_ID)
+        battery_inv_4 = BatteryInverter(id=ComponentId(4), microgrid_id=_MICROGRID_ID)
+        battery_5 = UnspecifiedBattery(id=ComponentId(5), microgrid_id=_MICROGRID_ID)
 
         graph = gr._MicrogridComponentGraph(
             components={
-                grid,
-                grid_meter,
-                pv_inv,
-                battery_inv,
-                battery,
+                grid_1,
+                grid_meter_2,
+                solar_inv_3,
+                battery_inv_4,
+                battery_5,
             },
             connections={
-                ComponentConnection(source=ComponentId(1), destination=ComponentId(2)),
-                ComponentConnection(source=ComponentId(2), destination=ComponentId(3)),
-                ComponentConnection(source=ComponentId(2), destination=ComponentId(4)),
-                ComponentConnection(source=ComponentId(4), destination=ComponentId(5)),
+                ComponentConnection(source=grid_1.id, destination=grid_meter_2.id),
+                ComponentConnection(source=grid_meter_2.id, destination=solar_inv_3.id),
+                ComponentConnection(
+                    source=grid_meter_2.id, destination=battery_inv_4.id
+                ),
+                ComponentConnection(source=battery_inv_4.id, destination=battery_5.id),
             },
         )
 
-        assert graph.is_grid_meter(grid_meter)
-        assert not graph.is_pv_meter(grid_meter)
-        assert not graph.is_pv_chain(grid_meter)
+        assert graph.is_grid_meter(grid_meter_2)
+        assert not graph.is_pv_meter(grid_meter_2)
+        assert not graph.is_pv_chain(grid_meter_2)
 
-        assert graph.is_pv_inverter(pv_inv) and graph.is_pv_chain(pv_inv)
-        assert not graph.is_battery_inverter(pv_inv) and not graph.is_battery_chain(
-            pv_inv
-        )
+        assert graph.is_pv_inverter(solar_inv_3) and graph.is_pv_chain(solar_inv_3)
+        assert not graph.is_battery_inverter(
+            solar_inv_3
+        ) and not graph.is_battery_chain(solar_inv_3)
 
-        assert graph.is_battery_inverter(battery_inv) and graph.is_battery_chain(
-            battery_inv
+        assert graph.is_battery_inverter(battery_inv_4) and graph.is_battery_chain(
+            battery_inv_4
         )
-        assert not graph.is_pv_inverter(battery_inv) and not graph.is_pv_chain(
-            battery_inv
+        assert not graph.is_pv_inverter(battery_inv_4) and not graph.is_pv_chain(
+            battery_inv_4
         )
 
     def test_with_meters(self) -> None:
         """Test the case where there are meters in the graph."""
-        grid = Component(ComponentId(1), ComponentCategory.GRID)
-        grid_meter = Component(ComponentId(2), ComponentCategory.METER)
-        pv_meter = Component(ComponentId(3), ComponentCategory.METER)
-        pv_inv = Component(
-            ComponentId(4), ComponentCategory.INVERTER, InverterType.SOLAR
+        grid_1 = GridConnectionPoint(
+            id=ComponentId(1), microgrid_id=_MICROGRID_ID, rated_fuse_current=10_000
         )
-        battery_meter = Component(ComponentId(5), ComponentCategory.METER)
-        battery_inv = Component(
-            ComponentId(6), ComponentCategory.INVERTER, InverterType.BATTERY
-        )
-        battery = Component(ComponentId(7), ComponentCategory.BATTERY)
+        grid_meter_2 = Meter(id=ComponentId(2), microgrid_id=_MICROGRID_ID)
+        pv_meter_3 = Meter(id=ComponentId(3), microgrid_id=_MICROGRID_ID)
+        pv_inv_4 = SolarInverter(id=ComponentId(4), microgrid_id=_MICROGRID_ID)
+        battery_meter_5 = Meter(id=ComponentId(5), microgrid_id=_MICROGRID_ID)
+        battery_inv_6 = BatteryInverter(id=ComponentId(6), microgrid_id=_MICROGRID_ID)
+        battery_7 = UnspecifiedBattery(id=ComponentId(7), microgrid_id=_MICROGRID_ID)
 
         graph = gr._MicrogridComponentGraph(
             components={
-                grid,
-                grid_meter,
-                pv_meter,
-                pv_inv,
-                battery_meter,
-                battery_inv,
-                battery,
+                grid_1,
+                grid_meter_2,
+                pv_meter_3,
+                pv_inv_4,
+                battery_meter_5,
+                battery_inv_6,
+                battery_7,
             },
             connections={
-                ComponentConnection(source=ComponentId(1), destination=ComponentId(2)),
-                ComponentConnection(source=ComponentId(2), destination=ComponentId(3)),
-                ComponentConnection(source=ComponentId(3), destination=ComponentId(4)),
-                ComponentConnection(source=ComponentId(2), destination=ComponentId(5)),
-                ComponentConnection(source=ComponentId(5), destination=ComponentId(6)),
-                ComponentConnection(source=ComponentId(6), destination=ComponentId(7)),
+                ComponentConnection(source=grid_1.id, destination=grid_meter_2.id),
+                ComponentConnection(source=grid_meter_2.id, destination=pv_meter_3.id),
+                ComponentConnection(source=pv_meter_3.id, destination=pv_inv_4.id),
+                ComponentConnection(
+                    source=grid_meter_2.id, destination=battery_meter_5.id
+                ),
+                ComponentConnection(
+                    source=battery_meter_5.id, destination=battery_inv_6.id
+                ),
+                ComponentConnection(source=battery_inv_6.id, destination=battery_7.id),
             },
         )
 
-        assert graph.is_grid_meter(grid_meter)
-        assert not graph.is_pv_meter(grid_meter)
-        assert not graph.is_pv_chain(grid_meter)
+        assert graph.is_grid_meter(grid_meter_2)
+        assert not graph.is_pv_meter(grid_meter_2)
+        assert not graph.is_pv_chain(grid_meter_2)
 
-        assert graph.is_pv_meter(pv_meter)
-        assert graph.is_pv_chain(pv_meter)
-        assert graph.is_pv_chain(pv_inv)
-        assert graph.is_pv_inverter(pv_inv)
+        assert graph.is_pv_meter(pv_meter_3)
+        assert graph.is_pv_chain(pv_meter_3)
+        assert graph.is_pv_chain(pv_inv_4)
+        assert graph.is_pv_inverter(pv_inv_4)
 
-        assert graph.is_battery_meter(battery_meter)
-        assert graph.is_battery_chain(battery_meter)
-        assert graph.is_battery_chain(battery_inv)
-        assert graph.is_battery_inverter(battery_inv)
+        assert graph.is_battery_meter(battery_meter_5)
+        assert graph.is_battery_chain(battery_meter_5)
+        assert graph.is_battery_chain(battery_inv_6)
+        assert graph.is_battery_inverter(battery_inv_6)
 
     def test_without_grid_meters(self) -> None:
         """Test the case where there are no grid meters in the graph."""
-        grid = Component(ComponentId(1), ComponentCategory.GRID)
-        ev_meter = Component(ComponentId(2), ComponentCategory.METER)
-        ev_charger = Component(ComponentId(3), ComponentCategory.EV_CHARGER)
-        chp_meter = Component(ComponentId(4), ComponentCategory.METER)
-        chp = Component(ComponentId(5), ComponentCategory.CHP)
+        grid_1 = GridConnectionPoint(
+            id=ComponentId(1), microgrid_id=_MICROGRID_ID, rated_fuse_current=10_000
+        )
+        ev_meter_2 = Meter(id=ComponentId(2), microgrid_id=_MICROGRID_ID)
+        ev_charger_3 = UnspecifiedEvCharger(
+            id=ComponentId(3), microgrid_id=_MICROGRID_ID
+        )
+        chp_meter_4 = Meter(id=ComponentId(4), microgrid_id=_MICROGRID_ID)
+        chp_5 = Chp(id=ComponentId(5), microgrid_id=_MICROGRID_ID)
 
         graph = gr._MicrogridComponentGraph(
             components={
-                grid,
-                ev_meter,
-                ev_charger,
-                chp_meter,
-                chp,
+                grid_1,
+                ev_meter_2,
+                ev_charger_3,
+                chp_meter_4,
+                chp_5,
             },
             connections={
-                ComponentConnection(source=ComponentId(1), destination=ComponentId(2)),
-                ComponentConnection(source=ComponentId(2), destination=ComponentId(3)),
-                ComponentConnection(source=ComponentId(1), destination=ComponentId(4)),
-                ComponentConnection(source=ComponentId(4), destination=ComponentId(5)),
+                ComponentConnection(source=grid_1.id, destination=ev_meter_2.id),
+                ComponentConnection(source=ev_meter_2.id, destination=ev_charger_3.id),
+                ComponentConnection(source=grid_1.id, destination=chp_meter_4.id),
+                ComponentConnection(source=chp_meter_4.id, destination=chp_5.id),
             },
         )
 
-        assert not graph.is_grid_meter(ev_meter)
-        assert not graph.is_grid_meter(chp_meter)
+        assert not graph.is_grid_meter(ev_meter_2)
+        assert not graph.is_grid_meter(chp_meter_4)
 
-        assert graph.is_ev_charger_meter(ev_meter)
-        assert graph.is_ev_charger(ev_charger)
-        assert graph.is_ev_charger_chain(ev_meter)
-        assert graph.is_ev_charger_chain(ev_charger)
+        assert graph.is_ev_charger_meter(ev_meter_2)
+        assert graph.is_ev_charger(ev_charger_3)
+        assert graph.is_ev_charger_chain(ev_meter_2)
+        assert graph.is_ev_charger_chain(ev_charger_3)
 
-        assert graph.is_chp_meter(chp_meter)
-        assert graph.is_chp(chp)
-        assert graph.is_chp_chain(chp_meter)
-        assert graph.is_chp_chain(chp)
+        assert graph.is_chp_meter(chp_meter_4)
+        assert graph.is_chp(chp_5)
+        assert graph.is_chp_chain(chp_meter_4)
+        assert graph.is_chp_chain(chp_5)

--- a/tests/microgrid/test_graph.py
+++ b/tests/microgrid/test_graph.py
@@ -389,18 +389,18 @@ class TestComponentGraph:
 
         # with start filter applied, we get back only connections whose `start`
         # component matches one of the provided IDs
-        assert graph.connections(matching_sources={ComponentId(8)}) == set()
-        assert graph.connections(matching_sources={ComponentId(7)}) == set()
-        assert graph.connections(matching_sources={ComponentId(6)}) == set()
-        assert graph.connections(matching_sources={ComponentId(5)}) == set()
-        assert graph.connections(matching_sources={ComponentId(4)}) == set()
-        assert graph.connections(matching_sources={ComponentId(3)}) == set()
-        assert graph.connections(matching_sources={ComponentId(2)}) == {
+        assert graph.connections(matching_sources=ComponentId(8)) == set()
+        assert graph.connections(matching_sources=ComponentId(7)) == set()
+        assert graph.connections(matching_sources=ComponentId(6)) == set()
+        assert graph.connections(matching_sources=ComponentId(5)) == set()
+        assert graph.connections(matching_sources=ComponentId(4)) == set()
+        assert graph.connections(matching_sources=ComponentId(3)) == set()
+        assert graph.connections(matching_sources=ComponentId(2)) == {
             ComponentConnection(source=ComponentId(2), destination=ComponentId(4)),
             ComponentConnection(source=ComponentId(2), destination=ComponentId(5)),
             ComponentConnection(source=ComponentId(2), destination=ComponentId(6)),
         }
-        assert graph.connections(matching_sources={ComponentId(1)}) == {
+        assert graph.connections(matching_sources=ComponentId(1)) == {
             ComponentConnection(source=ComponentId(1), destination=ComponentId(2)),
             ComponentConnection(source=ComponentId(1), destination=ComponentId(3)),
         }
@@ -427,23 +427,23 @@ class TestComponentGraph:
 
         # with end filter applied, we get back only connections whose `end`
         # component matches one of the provided IDs
-        assert graph.connections(matching_destinations={ComponentId(8)}) == set()
-        assert graph.connections(matching_destinations={ComponentId(6)}) == {
+        assert graph.connections(matching_destinations=ComponentId(8)) == set()
+        assert graph.connections(matching_destinations=ComponentId(6)) == {
             ComponentConnection(source=ComponentId(2), destination=ComponentId(6))
         }
-        assert graph.connections(matching_destinations={ComponentId(5)}) == {
+        assert graph.connections(matching_destinations=ComponentId(5)) == {
             ComponentConnection(source=ComponentId(2), destination=ComponentId(5))
         }
-        assert graph.connections(matching_destinations={ComponentId(4)}) == {
+        assert graph.connections(matching_destinations=ComponentId(4)) == {
             ComponentConnection(source=ComponentId(2), destination=ComponentId(4))
         }
-        assert graph.connections(matching_destinations={ComponentId(3)}) == {
+        assert graph.connections(matching_destinations=ComponentId(3)) == {
             ComponentConnection(source=ComponentId(1), destination=ComponentId(3))
         }
-        assert graph.connections(matching_destinations={ComponentId(2)}) == {
+        assert graph.connections(matching_destinations=ComponentId(2)) == {
             ComponentConnection(source=ComponentId(1), destination=ComponentId(2))
         }
-        assert graph.connections(matching_destinations={ComponentId(1)}) == set()
+        assert graph.connections(matching_destinations=ComponentId(1)) == set()
         assert graph.connections(
             matching_destinations={ComponentId(1), ComponentId(2), ComponentId(3)}
         ) == {
@@ -470,18 +470,18 @@ class TestComponentGraph:
             ComponentConnection(source=ComponentId(2), destination=ComponentId(4)),
             ComponentConnection(source=ComponentId(2), destination=ComponentId(6)),
         }
-        assert graph.connections(matching_destinations={ComponentId(1)}) == set()
+        assert graph.connections(matching_destinations=ComponentId(1)) == set()
 
         # when both filters are applied, they are combined via AND logic, i.e.
         # a connection must have its `start` matching one of the provided start
         # values, and its `end` matching one of the provided end values
         assert graph.connections(
-            matching_sources={ComponentId(1)}, matching_destinations={ComponentId(2)}
+            matching_sources=ComponentId(1), matching_destinations=ComponentId(2)
         ) == {ComponentConnection(source=ComponentId(1), destination=ComponentId(2))}
         assert (
             graph.connections(
-                matching_sources={ComponentId(2)},
-                matching_destinations={ComponentId(3)},
+                matching_sources=ComponentId(2),
+                matching_destinations=ComponentId(3),
             )
             == set()
         )

--- a/tests/microgrid/test_graph.py
+++ b/tests/microgrid/test_graph.py
@@ -959,9 +959,11 @@ class Test_MicrogridComponentGraph:
             graph.validate()
 
         client = mock.MagicMock(name="client", spec=MicrogridApiClient)
-        client.components = mock.AsyncMock(name="client.components()", return_value=[])
-        client.connections = mock.AsyncMock(
-            name="client.connections()", return_value=[]
+        client.list_components = mock.AsyncMock(
+            name="client.list_components()", return_value=[]
+        )
+        client.list_connections = mock.AsyncMock(
+            name="client.list_connections()", return_value=[]
         )
 
         # both components and connections must be non-empty
@@ -972,7 +974,7 @@ class Test_MicrogridComponentGraph:
         with pytest.raises(gr.InvalidGraphError):
             graph.validate()
 
-        client.components.return_value = [
+        client.list_components.return_value = [
             Component(ComponentId(1), ComponentCategory.GRID)
         ]
         with pytest.raises(gr.InvalidGraphError):
@@ -982,8 +984,8 @@ class Test_MicrogridComponentGraph:
         with pytest.raises(gr.InvalidGraphError):
             graph.validate()
 
-        client.components.return_value = []
-        client.connections.return_value = [Connection(ComponentId(1), ComponentId(2))]
+        client.list_components.return_value = []
+        client.list_connections.return_value = [Connection(ComponentId(1), ComponentId(2))]
         with pytest.raises(gr.InvalidGraphError):
             await graph.refresh_from_api(client)
         assert graph.components() == set()
@@ -994,7 +996,7 @@ class Test_MicrogridComponentGraph:
         # if both are provided, valid graph data must be present
 
         # valid graph with meter, and EV charger
-        client.components.return_value = [
+        client.list_components.return_value = [
             Component(
                 ComponentId(101),
                 ComponentCategory.GRID,
@@ -1003,7 +1005,7 @@ class Test_MicrogridComponentGraph:
             Component(ComponentId(111), ComponentCategory.METER),
             Component(ComponentId(131), ComponentCategory.EV_CHARGER),
         ]
-        client.connections.return_value = [
+        client.list_connections.return_value = [
             Connection(ComponentId(101), ComponentId(111)),
             Connection(ComponentId(111), ComponentId(131)),
         ]
@@ -1032,7 +1034,7 @@ class Test_MicrogridComponentGraph:
 
         # if valid graph data is provided, then the existing graph
         # contents will be overwritten
-        client.components.return_value = [
+        client.list_components.return_value = [
             Component(
                 ComponentId(707),
                 ComponentCategory.GRID,
@@ -1045,7 +1047,7 @@ class Test_MicrogridComponentGraph:
             Component(ComponentId(737), ComponentCategory.BATTERY),
             Component(ComponentId(747), ComponentCategory.METER),
         ]
-        client.connections.return_value = [
+        client.list_connections.return_value = [
             Connection(ComponentId(707), ComponentId(717)),
             Connection(ComponentId(717), ComponentId(727)),
             Connection(ComponentId(727), ComponentId(737)),

--- a/tests/microgrid/test_graph.py
+++ b/tests/microgrid/test_graph.py
@@ -950,8 +950,8 @@ class Test_MicrogridComponentGraph:
         assert graph.connections() == {Connection(ComponentId(10), ComponentId(11))}
         graph.validate()
 
-    async def test_refresh_from_api(self) -> None:
-        """Test the refresh_from_api method."""
+    async def test_refresh_from_client(self) -> None:
+        """Test the refresh_from_client method."""
         graph = gr._MicrogridComponentGraph()
         assert graph.components() == set()
         assert graph.connections() == set()
@@ -968,7 +968,7 @@ class Test_MicrogridComponentGraph:
 
         # both components and connections must be non-empty
         with pytest.raises(gr.InvalidGraphError):
-            await graph.refresh_from_api(client)
+            await graph.refresh_from_client(client)
         assert graph.components() == set()
         assert graph.connections() == set()
         with pytest.raises(gr.InvalidGraphError):
@@ -978,7 +978,7 @@ class Test_MicrogridComponentGraph:
             Component(ComponentId(1), ComponentCategory.GRID)
         ]
         with pytest.raises(gr.InvalidGraphError):
-            await graph.refresh_from_api(client)
+            await graph.refresh_from_client(client)
         assert graph.components() == set()
         assert graph.connections() == set()
         with pytest.raises(gr.InvalidGraphError):
@@ -987,7 +987,7 @@ class Test_MicrogridComponentGraph:
         client.list_components.return_value = []
         client.list_connections.return_value = [Connection(ComponentId(1), ComponentId(2))]
         with pytest.raises(gr.InvalidGraphError):
-            await graph.refresh_from_api(client)
+            await graph.refresh_from_client(client)
         assert graph.components() == set()
         assert graph.connections() == set()
         with pytest.raises(gr.InvalidGraphError):
@@ -1009,7 +1009,7 @@ class Test_MicrogridComponentGraph:
             Connection(ComponentId(101), ComponentId(111)),
             Connection(ComponentId(111), ComponentId(131)),
         ]
-        await graph.refresh_from_api(client)
+        await graph.refresh_from_client(client)
 
         # Note: we need to add GriMetadata as a dict here, because that's what
         # the ComponentGraph does too, and we need to be able to compare the
@@ -1053,7 +1053,7 @@ class Test_MicrogridComponentGraph:
             Connection(ComponentId(727), ComponentId(737)),
             Connection(ComponentId(717), ComponentId(747)),
         ]
-        await graph.refresh_from_api(client)
+        await graph.refresh_from_client(client)
 
         expected = {
             Component(

--- a/tests/microgrid/test_graph.py
+++ b/tests/microgrid/test_graph.py
@@ -15,10 +15,12 @@ from frequenz.client.microgrid import (
     Component,
     ComponentCategory,
     ComponentMetadata,
-    Connection,
     Fuse,
     InverterType,
     MicrogridApiClient,
+)
+from frequenz.client.microgrid.component import (
+    ComponentConnection,
 )
 
 import frequenz.sdk.microgrid.component_graph as gr
@@ -35,7 +37,7 @@ def _add_components(graph: gr._MicrogridComponentGraph, *components: Component) 
 
 
 def _add_connections(
-    graph: gr._MicrogridComponentGraph, *connections: Connection
+    graph: gr._MicrogridComponentGraph, *connections: ComponentConnection
 ) -> None:
     """Add connections to the test graph.
 
@@ -94,20 +96,20 @@ class TestComponentGraph:
         }
 
     @pytest.fixture()
-    def sample_input_connections(self) -> set[Connection]:
+    def sample_input_connections(self) -> set[ComponentConnection]:
         """Create a sample set of connections for testing purposes."""
         return {
-            Connection(ComponentId(11), ComponentId(21)),
-            Connection(ComponentId(21), ComponentId(41)),
-            Connection(ComponentId(41), ComponentId(51)),
-            Connection(ComponentId(51), ComponentId(61)),
+            ComponentConnection(source=ComponentId(11), destination=ComponentId(21)),
+            ComponentConnection(source=ComponentId(21), destination=ComponentId(41)),
+            ComponentConnection(source=ComponentId(41), destination=ComponentId(51)),
+            ComponentConnection(source=ComponentId(51), destination=ComponentId(61)),
         }
 
     @pytest.fixture()
     def sample_graph(
         self,
         sample_input_components: set[Component],
-        sample_input_connections: set[Connection],
+        sample_input_connections: set[ComponentConnection],
     ) -> gr.ComponentGraph:
         """Create a sample graph for testing purposes."""
         _graph_implementation = gr._MicrogridComponentGraph(
@@ -140,7 +142,9 @@ class TestComponentGraph:
                 Component(ComponentId(1), ComponentCategory.GRID),
                 Component(ComponentId(3), ComponentCategory.METER),
             },
-            connections={Connection(ComponentId(1), ComponentId(3))},
+            connections={
+                ComponentConnection(source=ComponentId(1), destination=ComponentId(3))
+            },
         )
         expected_components = {
             Component(ComponentId(1), ComponentCategory.GRID),
@@ -148,7 +152,9 @@ class TestComponentGraph:
         }
         assert len(graph.components()) == len(expected_components)
         assert graph.components() == expected_components
-        assert graph.connections() == {Connection(ComponentId(1), ComponentId(3))}
+        assert graph.connections() == {
+            ComponentConnection(source=ComponentId(1), destination=ComponentId(3))
+        }
 
         assert graph.predecessors(ComponentId(1)) == set()
         assert graph.successors(ComponentId(1)) == {
@@ -177,10 +183,10 @@ class TestComponentGraph:
             ComponentId(106): Component(ComponentId(106), ComponentCategory.BATTERY),
         }
         input_connections = {
-            Connection(ComponentId(101), ComponentId(102)),
-            Connection(ComponentId(102), ComponentId(104)),
-            Connection(ComponentId(104), ComponentId(105)),
-            Connection(ComponentId(105), ComponentId(106)),
+            ComponentConnection(source=ComponentId(101), destination=ComponentId(102)),
+            ComponentConnection(source=ComponentId(102), destination=ComponentId(104)),
+            ComponentConnection(source=ComponentId(104), destination=ComponentId(105)),
+            ComponentConnection(source=ComponentId(105), destination=ComponentId(106)),
         }
 
         # more complex microgrid: grid endpoint, load, grid-side meter,
@@ -363,118 +369,135 @@ class TestComponentGraph:
                 Component(ComponentId(6), ComponentCategory.EV_CHARGER),
             },
             connections={
-                Connection(ComponentId(1), ComponentId(2)),
-                Connection(ComponentId(1), ComponentId(3)),
-                Connection(ComponentId(2), ComponentId(4)),
-                Connection(ComponentId(2), ComponentId(5)),
-                Connection(ComponentId(2), ComponentId(6)),
+                ComponentConnection(source=ComponentId(1), destination=ComponentId(2)),
+                ComponentConnection(source=ComponentId(1), destination=ComponentId(3)),
+                ComponentConnection(source=ComponentId(2), destination=ComponentId(4)),
+                ComponentConnection(source=ComponentId(2), destination=ComponentId(5)),
+                ComponentConnection(source=ComponentId(2), destination=ComponentId(6)),
             },
         )
         graph: gr.ComponentGraph = _graph_implementation
 
         # without any filter applied, we get back all the connections in the graph
         assert graph.connections() == {
-            Connection(ComponentId(1), ComponentId(2)),
-            Connection(ComponentId(1), ComponentId(3)),
-            Connection(ComponentId(2), ComponentId(4)),
-            Connection(ComponentId(2), ComponentId(5)),
-            Connection(ComponentId(2), ComponentId(6)),
+            ComponentConnection(source=ComponentId(1), destination=ComponentId(2)),
+            ComponentConnection(source=ComponentId(1), destination=ComponentId(3)),
+            ComponentConnection(source=ComponentId(2), destination=ComponentId(4)),
+            ComponentConnection(source=ComponentId(2), destination=ComponentId(5)),
+            ComponentConnection(source=ComponentId(2), destination=ComponentId(6)),
         }
 
         # with start filter applied, we get back only connections whose `start`
         # component matches one of the provided IDs
-        assert graph.connections(start={ComponentId(8)}) == set()
-        assert graph.connections(start={ComponentId(7)}) == set()
-        assert graph.connections(start={ComponentId(6)}) == set()
-        assert graph.connections(start={ComponentId(5)}) == set()
-        assert graph.connections(start={ComponentId(4)}) == set()
-        assert graph.connections(start={ComponentId(3)}) == set()
-        assert graph.connections(start={ComponentId(2)}) == {
-            Connection(ComponentId(2), ComponentId(4)),
-            Connection(ComponentId(2), ComponentId(5)),
-            Connection(ComponentId(2), ComponentId(6)),
+        assert graph.connections(matching_sources={ComponentId(8)}) == set()
+        assert graph.connections(matching_sources={ComponentId(7)}) == set()
+        assert graph.connections(matching_sources={ComponentId(6)}) == set()
+        assert graph.connections(matching_sources={ComponentId(5)}) == set()
+        assert graph.connections(matching_sources={ComponentId(4)}) == set()
+        assert graph.connections(matching_sources={ComponentId(3)}) == set()
+        assert graph.connections(matching_sources={ComponentId(2)}) == {
+            ComponentConnection(source=ComponentId(2), destination=ComponentId(4)),
+            ComponentConnection(source=ComponentId(2), destination=ComponentId(5)),
+            ComponentConnection(source=ComponentId(2), destination=ComponentId(6)),
         }
-        assert graph.connections(start={ComponentId(1)}) == {
-            Connection(ComponentId(1), ComponentId(2)),
-            Connection(ComponentId(1), ComponentId(3)),
-        }
-        assert graph.connections(
-            start={ComponentId(1), ComponentId(3), ComponentId(5)}
-        ) == {
-            Connection(ComponentId(1), ComponentId(2)),
-            Connection(ComponentId(1), ComponentId(3)),
+        assert graph.connections(matching_sources={ComponentId(1)}) == {
+            ComponentConnection(source=ComponentId(1), destination=ComponentId(2)),
+            ComponentConnection(source=ComponentId(1), destination=ComponentId(3)),
         }
         assert graph.connections(
-            start={ComponentId(1), ComponentId(2), ComponentId(5), ComponentId(6)}
+            matching_sources={ComponentId(1), ComponentId(3), ComponentId(5)}
         ) == {
-            Connection(ComponentId(1), ComponentId(2)),
-            Connection(ComponentId(1), ComponentId(3)),
-            Connection(ComponentId(2), ComponentId(4)),
-            Connection(ComponentId(2), ComponentId(5)),
-            Connection(ComponentId(2), ComponentId(6)),
+            ComponentConnection(source=ComponentId(1), destination=ComponentId(2)),
+            ComponentConnection(source=ComponentId(1), destination=ComponentId(3)),
+        }
+        assert graph.connections(
+            matching_sources={
+                ComponentId(1),
+                ComponentId(2),
+                ComponentId(5),
+                ComponentId(6),
+            }
+        ) == {
+            ComponentConnection(source=ComponentId(1), destination=ComponentId(2)),
+            ComponentConnection(source=ComponentId(1), destination=ComponentId(3)),
+            ComponentConnection(source=ComponentId(2), destination=ComponentId(4)),
+            ComponentConnection(source=ComponentId(2), destination=ComponentId(5)),
+            ComponentConnection(source=ComponentId(2), destination=ComponentId(6)),
         }
 
         # with end filter applied, we get back only connections whose `end`
         # component matches one of the provided IDs
-        assert graph.connections(end={ComponentId(8)}) == set()
-        assert graph.connections(end={ComponentId(6)}) == {
-            Connection(ComponentId(2), ComponentId(6))
+        assert graph.connections(matching_destinations={ComponentId(8)}) == set()
+        assert graph.connections(matching_destinations={ComponentId(6)}) == {
+            ComponentConnection(source=ComponentId(2), destination=ComponentId(6))
         }
-        assert graph.connections(end={ComponentId(5)}) == {
-            Connection(ComponentId(2), ComponentId(5))
+        assert graph.connections(matching_destinations={ComponentId(5)}) == {
+            ComponentConnection(source=ComponentId(2), destination=ComponentId(5))
         }
-        assert graph.connections(end={ComponentId(4)}) == {
-            Connection(ComponentId(2), ComponentId(4))
+        assert graph.connections(matching_destinations={ComponentId(4)}) == {
+            ComponentConnection(source=ComponentId(2), destination=ComponentId(4))
         }
-        assert graph.connections(end={ComponentId(3)}) == {
-            Connection(ComponentId(1), ComponentId(3))
+        assert graph.connections(matching_destinations={ComponentId(3)}) == {
+            ComponentConnection(source=ComponentId(1), destination=ComponentId(3))
         }
-        assert graph.connections(end={ComponentId(2)}) == {
-            Connection(ComponentId(1), ComponentId(2))
+        assert graph.connections(matching_destinations={ComponentId(2)}) == {
+            ComponentConnection(source=ComponentId(1), destination=ComponentId(2))
         }
-        assert graph.connections(end={ComponentId(1)}) == set()
+        assert graph.connections(matching_destinations={ComponentId(1)}) == set()
         assert graph.connections(
-            end={ComponentId(1), ComponentId(2), ComponentId(3)}
+            matching_destinations={ComponentId(1), ComponentId(2), ComponentId(3)}
         ) == {
-            Connection(ComponentId(1), ComponentId(2)),
-            Connection(ComponentId(1), ComponentId(3)),
+            ComponentConnection(source=ComponentId(1), destination=ComponentId(2)),
+            ComponentConnection(source=ComponentId(1), destination=ComponentId(3)),
         }
         assert graph.connections(
-            end={ComponentId(4), ComponentId(5), ComponentId(6)}
+            matching_destinations={ComponentId(4), ComponentId(5), ComponentId(6)}
         ) == {
-            Connection(ComponentId(2), ComponentId(4)),
-            Connection(ComponentId(2), ComponentId(5)),
-            Connection(ComponentId(2), ComponentId(6)),
+            ComponentConnection(source=ComponentId(2), destination=ComponentId(4)),
+            ComponentConnection(source=ComponentId(2), destination=ComponentId(5)),
+            ComponentConnection(source=ComponentId(2), destination=ComponentId(6)),
         }
 
         assert graph.connections(
-            end={ComponentId(2), ComponentId(4), ComponentId(6), ComponentId(8)}
+            matching_destinations={
+                ComponentId(2),
+                ComponentId(4),
+                ComponentId(6),
+                ComponentId(8),
+            }
         ) == {
-            Connection(ComponentId(1), ComponentId(2)),
-            Connection(ComponentId(2), ComponentId(4)),
-            Connection(ComponentId(2), ComponentId(6)),
+            ComponentConnection(source=ComponentId(1), destination=ComponentId(2)),
+            ComponentConnection(source=ComponentId(2), destination=ComponentId(4)),
+            ComponentConnection(source=ComponentId(2), destination=ComponentId(6)),
         }
-        assert graph.connections(end={ComponentId(1)}) == set()
+        assert graph.connections(matching_destinations={ComponentId(1)}) == set()
 
         # when both filters are applied, they are combined via AND logic, i.e.
         # a connection must have its `start` matching one of the provided start
         # values, and its `end` matching one of the provided end values
-        assert graph.connections(start={ComponentId(1)}, end={ComponentId(2)}) == {
-            Connection(ComponentId(1), ComponentId(2))
-        }
-        assert graph.connections(start={ComponentId(2)}, end={ComponentId(3)}) == set()
         assert graph.connections(
-            start={ComponentId(1), ComponentId(2)}, end={ComponentId(3), ComponentId(4)}
+            matching_sources={ComponentId(1)}, matching_destinations={ComponentId(2)}
+        ) == {ComponentConnection(source=ComponentId(1), destination=ComponentId(2))}
+        assert (
+            graph.connections(
+                matching_sources={ComponentId(2)},
+                matching_destinations={ComponentId(3)},
+            )
+            == set()
+        )
+        assert graph.connections(
+            matching_sources={ComponentId(1), ComponentId(2)},
+            matching_destinations={ComponentId(3), ComponentId(4)},
         ) == {
-            Connection(ComponentId(1), ComponentId(3)),
-            Connection(ComponentId(2), ComponentId(4)),
+            ComponentConnection(source=ComponentId(1), destination=ComponentId(3)),
+            ComponentConnection(source=ComponentId(2), destination=ComponentId(4)),
         }
         assert graph.connections(
-            start={ComponentId(2), ComponentId(3)},
-            end={ComponentId(5), ComponentId(6), ComponentId(7)},
+            matching_sources={ComponentId(2), ComponentId(3)},
+            matching_destinations={ComponentId(5), ComponentId(6), ComponentId(7)},
         ) == {
-            Connection(ComponentId(2), ComponentId(5)),
-            Connection(ComponentId(2), ComponentId(6)),
+            ComponentConnection(source=ComponentId(2), destination=ComponentId(5)),
+            ComponentConnection(source=ComponentId(2), destination=ComponentId(6)),
         }
 
     def test_dfs_search_two_grid_meters(self) -> None:
@@ -492,10 +515,10 @@ class TestComponentGraph:
                 Component(ComponentId(3), ComponentCategory.METER),
             }.union(pv_inverters),
             connections={
-                Connection(ComponentId(1), ComponentId(2)),
-                Connection(ComponentId(1), ComponentId(3)),
-                Connection(ComponentId(2), ComponentId(4)),
-                Connection(ComponentId(2), ComponentId(5)),
+                ComponentConnection(source=ComponentId(1), destination=ComponentId(2)),
+                ComponentConnection(source=ComponentId(1), destination=ComponentId(3)),
+                ComponentConnection(source=ComponentId(2), destination=ComponentId(4)),
+                ComponentConnection(source=ComponentId(2), destination=ComponentId(5)),
             },
         )
 
@@ -522,11 +545,11 @@ class TestComponentGraph:
                 ),
             }.union(pv_meters),
             connections={
-                Connection(ComponentId(1), ComponentId(2)),
-                Connection(ComponentId(2), ComponentId(3)),
-                Connection(ComponentId(2), ComponentId(4)),
-                Connection(ComponentId(3), ComponentId(5)),
-                Connection(ComponentId(4), ComponentId(6)),
+                ComponentConnection(source=ComponentId(1), destination=ComponentId(2)),
+                ComponentConnection(source=ComponentId(2), destination=ComponentId(3)),
+                ComponentConnection(source=ComponentId(2), destination=ComponentId(4)),
+                ComponentConnection(source=ComponentId(3), destination=ComponentId(5)),
+                ComponentConnection(source=ComponentId(4), destination=ComponentId(6)),
             },
         )
 
@@ -547,9 +570,9 @@ class TestComponentGraph:
                 Component(ComponentId(2), ComponentCategory.METER),
             }.union(pv_inverters),
             connections={
-                Connection(ComponentId(1), ComponentId(2)),
-                Connection(ComponentId(2), ComponentId(3)),
-                Connection(ComponentId(2), ComponentId(4)),
+                ComponentConnection(source=ComponentId(1), destination=ComponentId(2)),
+                ComponentConnection(source=ComponentId(2), destination=ComponentId(3)),
+                ComponentConnection(source=ComponentId(2), destination=ComponentId(4)),
             },
         )
 
@@ -576,11 +599,11 @@ class TestComponentGraph:
                 ),
             }.union(pv_meters),
             connections={
-                Connection(ComponentId(1), ComponentId(2)),
-                Connection(ComponentId(1), ComponentId(3)),
-                Connection(ComponentId(1), ComponentId(4)),
-                Connection(ComponentId(3), ComponentId(5)),
-                Connection(ComponentId(4), ComponentId(6)),
+                ComponentConnection(source=ComponentId(1), destination=ComponentId(2)),
+                ComponentConnection(source=ComponentId(1), destination=ComponentId(3)),
+                ComponentConnection(source=ComponentId(1), destination=ComponentId(4)),
+                ComponentConnection(source=ComponentId(3), destination=ComponentId(5)),
+                ComponentConnection(source=ComponentId(4), destination=ComponentId(6)),
             },
         )
 
@@ -609,13 +632,13 @@ class TestComponentGraph:
                 ),
             }.union(battery_components),
             connections={
-                Connection(ComponentId(1), ComponentId(2)),
-                Connection(ComponentId(2), ComponentId(3)),
-                Connection(ComponentId(2), ComponentId(6)),
-                Connection(ComponentId(3), ComponentId(4)),
-                Connection(ComponentId(3), ComponentId(5)),
-                Connection(ComponentId(4), ComponentId(7)),
-                Connection(ComponentId(5), ComponentId(8)),
+                ComponentConnection(source=ComponentId(1), destination=ComponentId(2)),
+                ComponentConnection(source=ComponentId(2), destination=ComponentId(3)),
+                ComponentConnection(source=ComponentId(2), destination=ComponentId(6)),
+                ComponentConnection(source=ComponentId(3), destination=ComponentId(4)),
+                ComponentConnection(source=ComponentId(3), destination=ComponentId(5)),
+                ComponentConnection(source=ComponentId(4), destination=ComponentId(7)),
+                ComponentConnection(source=ComponentId(5), destination=ComponentId(8)),
             },
         )
 
@@ -638,11 +661,11 @@ class TestComponentGraph:
                 Component(ComponentId(6), ComponentCategory.EV_CHARGER),
             },
             connections={
-                Connection(ComponentId(1), ComponentId(2)),
-                Connection(ComponentId(2), ComponentId(3)),
-                Connection(ComponentId(2), ComponentId(4)),
-                Connection(ComponentId(2), ComponentId(5)),
-                Connection(ComponentId(3), ComponentId(6)),
+                ComponentConnection(source=ComponentId(1), destination=ComponentId(2)),
+                ComponentConnection(source=ComponentId(2), destination=ComponentId(3)),
+                ComponentConnection(source=ComponentId(2), destination=ComponentId(4)),
+                ComponentConnection(source=ComponentId(2), destination=ComponentId(5)),
+                ComponentConnection(source=ComponentId(3), destination=ComponentId(6)),
             },
         )
 
@@ -706,7 +729,11 @@ class Test_MicrogridComponentGraph:
 
         with pytest.raises(gr.InvalidGraphError):
             gr._MicrogridComponentGraph(
-                connections={Connection(ComponentId(1), ComponentId(2))}
+                connections={
+                    ComponentConnection(
+                        source=ComponentId(1), destination=ComponentId(2)
+                    )
+                }
             )
 
         # if both are provided, the graph data must itself
@@ -722,7 +749,9 @@ class Test_MicrogridComponentGraph:
                 Component(ComponentId(1), ComponentCategory.GRID),
                 Component(ComponentId(2), ComponentCategory.METER),
             },
-            connections={Connection(ComponentId(1), ComponentId(2))},
+            connections={
+                ComponentConnection(source=ComponentId(1), destination=ComponentId(2))
+            },
         )
         expected = {
             Component(ComponentId(1), ComponentCategory.GRID),
@@ -731,7 +760,7 @@ class Test_MicrogridComponentGraph:
         assert len(grid_and_meter.components()) == len(expected)
         assert set(grid_and_meter.components()) == expected
         assert list(grid_and_meter.connections()) == [
-            Connection(ComponentId(1), ComponentId(2))
+            ComponentConnection(source=ComponentId(1), destination=ComponentId(2))
         ]
         grid_and_meter.validate()
 
@@ -744,8 +773,12 @@ class Test_MicrogridComponentGraph:
                     Component(ComponentId(3), 666),  # type: ignore
                 },
                 connections={
-                    Connection(ComponentId(1), ComponentId(2)),
-                    Connection(ComponentId(1), ComponentId(3)),
+                    ComponentConnection(
+                        source=ComponentId(1), destination=ComponentId(2)
+                    ),
+                    ComponentConnection(
+                        source=ComponentId(1), destination=ComponentId(3)
+                    ),
                 },
             )
 
@@ -757,8 +790,12 @@ class Test_MicrogridComponentGraph:
                     Component(ComponentId(2), ComponentCategory.METER),
                 },
                 connections={
-                    Connection(ComponentId(1), ComponentId(2)),
-                    Connection(ComponentId(1), ComponentId(3)),
+                    ComponentConnection(
+                        source=ComponentId(1), destination=ComponentId(2)
+                    ),
+                    ComponentConnection(
+                        source=ComponentId(1), destination=ComponentId(3)
+                    ),
                 },
             )
 
@@ -770,8 +807,12 @@ class Test_MicrogridComponentGraph:
                     Component(ComponentId(2), ComponentCategory.METER),
                 },
                 connections={
-                    Connection(ComponentId(1), ComponentId(2)),
-                    Connection(ComponentId(2), ComponentId(2)),
+                    ComponentConnection(
+                        source=ComponentId(1), destination=ComponentId(2)
+                    ),
+                    ComponentConnection(
+                        source=ComponentId(2), destination=ComponentId(2)
+                    ),
                 },
             )
 
@@ -792,7 +833,14 @@ class Test_MicrogridComponentGraph:
             graph.validate()
 
         with pytest.raises(gr.InvalidGraphError):
-            graph.refresh_from(set(), {Connection(ComponentId(1), ComponentId(2))})
+            graph.refresh_from(
+                set(),
+                {
+                    ComponentConnection(
+                        source=ComponentId(1), destination=ComponentId(2)
+                    )
+                },
+            )
         assert set(graph.components()) == set()
         assert list(graph.connections()) == []
         with pytest.raises(gr.InvalidGraphError):
@@ -817,7 +865,11 @@ class Test_MicrogridComponentGraph:
                     Component(ComponentId(1), ComponentCategory.METER),
                     Component(ComponentId(2), ComponentCategory.METER),
                 },
-                connections={Connection(ComponentId(1), ComponentId(2))},
+                connections={
+                    ComponentConnection(
+                        source=ComponentId(1), destination=ComponentId(2)
+                    )
+                },
             )
         assert set(graph.components()) == set()
         assert list(graph.connections()) == []
@@ -833,8 +885,12 @@ class Test_MicrogridComponentGraph:
                     Component(ComponentId(3), ComponentCategory.METER),
                 },
                 connections={
-                    Connection(ComponentId(1), ComponentId(1)),
-                    Connection(ComponentId(2), ComponentId(3)),
+                    ComponentConnection(
+                        source=ComponentId(1), destination=ComponentId(1)
+                    ),
+                    ComponentConnection(
+                        source=ComponentId(2), destination=ComponentId(3)
+                    ),
                 },
             )
         assert set(graph.components()) == set()
@@ -852,10 +908,10 @@ class Test_MicrogridComponentGraph:
                 Component(ComponentId(6), ComponentCategory.BATTERY),
             },
             connections={
-                Connection(ComponentId(1), ComponentId(2)),
-                Connection(ComponentId(2), ComponentId(4)),
-                Connection(ComponentId(4), ComponentId(5)),
-                Connection(ComponentId(5), ComponentId(6)),
+                ComponentConnection(source=ComponentId(1), destination=ComponentId(2)),
+                ComponentConnection(source=ComponentId(2), destination=ComponentId(4)),
+                ComponentConnection(source=ComponentId(4), destination=ComponentId(5)),
+                ComponentConnection(source=ComponentId(5), destination=ComponentId(6)),
             },
         )
         expected = {
@@ -868,10 +924,10 @@ class Test_MicrogridComponentGraph:
         assert len(graph.components()) == len(expected)
         assert set(graph.components()) == expected
         assert graph.connections() == {
-            Connection(ComponentId(1), ComponentId(2)),
-            Connection(ComponentId(2), ComponentId(4)),
-            Connection(ComponentId(4), ComponentId(5)),
-            Connection(ComponentId(5), ComponentId(6)),
+            ComponentConnection(source=ComponentId(1), destination=ComponentId(2)),
+            ComponentConnection(source=ComponentId(2), destination=ComponentId(4)),
+            ComponentConnection(source=ComponentId(4), destination=ComponentId(5)),
+            ComponentConnection(source=ComponentId(5), destination=ComponentId(6)),
         }
         graph.validate()
 
@@ -886,9 +942,15 @@ class Test_MicrogridComponentGraph:
                     Component(ComponentId(9), ComponentCategory.INVERTER),
                 },
                 connections={
-                    Connection(ComponentId(7), ComponentId(8)),
-                    Connection(ComponentId(8), ComponentId(9)),
-                    Connection(ComponentId(9), ComponentId(8)),
+                    ComponentConnection(
+                        source=ComponentId(7), destination=ComponentId(8)
+                    ),
+                    ComponentConnection(
+                        source=ComponentId(8), destination=ComponentId(9)
+                    ),
+                    ComponentConnection(
+                        source=ComponentId(9), destination=ComponentId(8)
+                    ),
                 },
             )
 
@@ -896,10 +958,10 @@ class Test_MicrogridComponentGraph:
         assert graph.components() == expected
 
         assert graph.connections() == {
-            Connection(ComponentId(1), ComponentId(2)),
-            Connection(ComponentId(2), ComponentId(4)),
-            Connection(ComponentId(4), ComponentId(5)),
-            Connection(ComponentId(5), ComponentId(6)),
+            ComponentConnection(source=ComponentId(1), destination=ComponentId(2)),
+            ComponentConnection(source=ComponentId(2), destination=ComponentId(4)),
+            ComponentConnection(source=ComponentId(4), destination=ComponentId(5)),
+            ComponentConnection(source=ComponentId(5), destination=ComponentId(6)),
         }
         graph.validate()
 
@@ -917,7 +979,11 @@ class Test_MicrogridComponentGraph:
                     Component(ComponentId(7), ComponentCategory.GRID),
                     Component(ComponentId(9), ComponentCategory.METER),
                 },
-                connections={Connection(ComponentId(9), ComponentId(7))},
+                connections={
+                    ComponentConnection(
+                        source=ComponentId(9), destination=ComponentId(7)
+                    )
+                },
                 correct_errors=pretend_to_correct_errors,
             )
 
@@ -930,7 +996,9 @@ class Test_MicrogridComponentGraph:
                 Component(ComponentId(10), ComponentCategory.GRID),
                 Component(ComponentId(11), ComponentCategory.METER),
             },
-            connections={Connection(ComponentId(10), ComponentId(11))},
+            connections={
+                ComponentConnection(source=ComponentId(10), destination=ComponentId(11))
+            },
         )
 
         expected = {
@@ -939,7 +1007,9 @@ class Test_MicrogridComponentGraph:
         }
         assert len(graph.components()) == len(expected)
         assert set(graph.components()) == expected
-        assert graph.connections() == {Connection(ComponentId(10), ComponentId(11))}
+        assert graph.connections() == {
+            ComponentConnection(source=ComponentId(10), destination=ComponentId(11))
+        }
         graph.validate()
 
     async def test_refresh_from_client(self) -> None:
@@ -978,7 +1048,7 @@ class Test_MicrogridComponentGraph:
 
         client.list_components.return_value = []
         client.list_connections.return_value = [
-            Connection(ComponentId(1), ComponentId(2))
+            ComponentConnection(source=ComponentId(1), destination=ComponentId(2))
         ]
         with pytest.raises(gr.InvalidGraphError):
             await graph.refresh_from_client(client)
@@ -1000,8 +1070,8 @@ class Test_MicrogridComponentGraph:
             Component(ComponentId(131), ComponentCategory.EV_CHARGER),
         ]
         client.list_connections.return_value = [
-            Connection(ComponentId(101), ComponentId(111)),
-            Connection(ComponentId(111), ComponentId(131)),
+            ComponentConnection(source=ComponentId(101), destination=ComponentId(111)),
+            ComponentConnection(source=ComponentId(111), destination=ComponentId(131)),
         ]
         await graph.refresh_from_client(client)
 
@@ -1021,8 +1091,8 @@ class Test_MicrogridComponentGraph:
         assert len(graph.components()) == len(expected)
         assert graph.components() == expected
         assert graph.connections() == {
-            Connection(ComponentId(101), ComponentId(111)),
-            Connection(ComponentId(111), ComponentId(131)),
+            ComponentConnection(source=ComponentId(101), destination=ComponentId(111)),
+            ComponentConnection(source=ComponentId(111), destination=ComponentId(131)),
         }
         graph.validate()
 
@@ -1042,10 +1112,10 @@ class Test_MicrogridComponentGraph:
             Component(ComponentId(747), ComponentCategory.METER),
         ]
         client.list_connections.return_value = [
-            Connection(ComponentId(707), ComponentId(717)),
-            Connection(ComponentId(717), ComponentId(727)),
-            Connection(ComponentId(727), ComponentId(737)),
-            Connection(ComponentId(717), ComponentId(747)),
+            ComponentConnection(source=ComponentId(707), destination=ComponentId(717)),
+            ComponentConnection(source=ComponentId(717), destination=ComponentId(727)),
+            ComponentConnection(source=ComponentId(727), destination=ComponentId(737)),
+            ComponentConnection(source=ComponentId(717), destination=ComponentId(747)),
         ]
         await graph.refresh_from_client(client)
 
@@ -1065,10 +1135,10 @@ class Test_MicrogridComponentGraph:
         assert graph.components() == expected
 
         assert graph.connections() == {
-            Connection(ComponentId(707), ComponentId(717)),
-            Connection(ComponentId(717), ComponentId(727)),
-            Connection(ComponentId(717), ComponentId(747)),
-            Connection(ComponentId(727), ComponentId(737)),
+            ComponentConnection(source=ComponentId(707), destination=ComponentId(717)),
+            ComponentConnection(source=ComponentId(717), destination=ComponentId(727)),
+            ComponentConnection(source=ComponentId(717), destination=ComponentId(747)),
+            ComponentConnection(source=ComponentId(727), destination=ComponentId(737)),
         }
         graph.validate()
 
@@ -1107,8 +1177,8 @@ class Test_MicrogridComponentGraph:
         )
         _add_connections(
             graph,
-            Connection(ComponentId(1), ComponentId(3)),
-            Connection(ComponentId(2), ComponentId(3)),
+            ComponentConnection(source=ComponentId(1), destination=ComponentId(3)),
+            ComponentConnection(source=ComponentId(2), destination=ComponentId(3)),
         )
         with pytest.raises(gr.InvalidGraphError, match="Multiple potential root nodes"):
             graph.validate()
@@ -1123,8 +1193,8 @@ class Test_MicrogridComponentGraph:
         )
         _add_connections(
             graph,
-            Connection(ComponentId(1), ComponentId(2)),
-            Connection(ComponentId(2), ComponentId(3)),
+            ComponentConnection(source=ComponentId(1), destination=ComponentId(2)),
+            ComponentConnection(source=ComponentId(2), destination=ComponentId(3)),
         )
         with pytest.raises(
             gr.InvalidGraphError, match="Multiple grid endpoints in component graph"
@@ -1142,8 +1212,8 @@ class Test_MicrogridComponentGraph:
         )
         _add_connections(
             graph,
-            Connection(ComponentId(1), ComponentId(2)),
-            Connection(ComponentId(2), ComponentId(3)),
+            ComponentConnection(source=ComponentId(1), destination=ComponentId(2)),
+            ComponentConnection(source=ComponentId(2), destination=ComponentId(3)),
         )
         with pytest.raises(
             gr.InvalidGraphError, match="Leaf components with graph successors"
@@ -1181,9 +1251,9 @@ class Test_MicrogridComponentGraph:
         )
         _add_connections(
             graph,
-            Connection(ComponentId(1), ComponentId(2)),
-            Connection(ComponentId(2), ComponentId(3)),
-            Connection(ComponentId(3), ComponentId(2)),
+            ComponentConnection(source=ComponentId(1), destination=ComponentId(2)),
+            ComponentConnection(source=ComponentId(2), destination=ComponentId(3)),
+            ComponentConnection(source=ComponentId(3), destination=ComponentId(2)),
         )
         with pytest.raises(
             gr.InvalidGraphError, match="Component graph is not a tree!"
@@ -1198,7 +1268,10 @@ class Test_MicrogridComponentGraph:
             Component(ComponentId(2), ComponentCategory.METER),
             Component(ComponentId(3), ComponentCategory.NONE),
         )
-        _add_connections(graph, Connection(ComponentId(1), ComponentId(2)))
+        _add_connections(
+            graph,
+            ComponentConnection(source=ComponentId(1), destination=ComponentId(2)),
+        )
         with pytest.raises(
             gr.InvalidGraphError, match="Component graph is not a tree!"
         ):
@@ -1225,9 +1298,9 @@ class Test_MicrogridComponentGraph:
         )
         _add_connections(
             graph,
-            Connection(ComponentId(1), ComponentId(2)),
-            Connection(ComponentId(2), ComponentId(3)),
-            Connection(ComponentId(3), ComponentId(1)),
+            ComponentConnection(source=ComponentId(1), destination=ComponentId(2)),
+            ComponentConnection(source=ComponentId(2), destination=ComponentId(3)),
+            ComponentConnection(source=ComponentId(3), destination=ComponentId(1)),
         )
         with pytest.raises(
             gr.InvalidGraphError, match="No valid root nodes of component graph!"
@@ -1245,8 +1318,8 @@ class Test_MicrogridComponentGraph:
         )
         _add_connections(
             graph,
-            Connection(ComponentId(1), ComponentId(2)),
-            Connection(ComponentId(2), ComponentId(3)),
+            ComponentConnection(source=ComponentId(1), destination=ComponentId(2)),
+            ComponentConnection(source=ComponentId(2), destination=ComponentId(3)),
         )
         with pytest.raises(
             gr.InvalidGraphError, match="No valid root nodes of component graph!"
@@ -1264,8 +1337,8 @@ class Test_MicrogridComponentGraph:
         )
         _add_connections(
             graph,
-            Connection(ComponentId(1), ComponentId(3)),
-            Connection(ComponentId(2), ComponentId(3)),
+            ComponentConnection(source=ComponentId(1), destination=ComponentId(3)),
+            ComponentConnection(source=ComponentId(2), destination=ComponentId(3)),
         )
         with pytest.raises(gr.InvalidGraphError, match="Multiple potential root nodes"):
             graph._validate_graph_root()
@@ -1279,8 +1352,8 @@ class Test_MicrogridComponentGraph:
         )
         _add_connections(
             graph,
-            Connection(ComponentId(1), ComponentId(3)),
-            Connection(ComponentId(2), ComponentId(3)),
+            ComponentConnection(source=ComponentId(1), destination=ComponentId(3)),
+            ComponentConnection(source=ComponentId(2), destination=ComponentId(3)),
         )
         with pytest.raises(gr.InvalidGraphError, match="Multiple potential root nodes"):
             graph._validate_graph_root()
@@ -1317,7 +1390,10 @@ class Test_MicrogridComponentGraph:
             Component(ComponentId(1), ComponentCategory.NONE),
             Component(ComponentId(2), ComponentCategory.METER),
         )
-        _add_connections(graph, Connection(ComponentId(1), ComponentId(2)))
+        _add_connections(
+            graph,
+            ComponentConnection(source=ComponentId(1), destination=ComponentId(2)),
+        )
         graph._validate_graph_root()
 
         graph._graph.clear()
@@ -1326,7 +1402,10 @@ class Test_MicrogridComponentGraph:
             Component(ComponentId(1), ComponentCategory.GRID),
             Component(ComponentId(2), ComponentCategory.METER),
         )
-        _add_connections(graph, Connection(ComponentId(1), ComponentId(2)))
+        _add_connections(
+            graph,
+            ComponentConnection(source=ComponentId(1), destination=ComponentId(2)),
+        )
         graph._validate_graph_root()
 
         graph._graph.clear()
@@ -1335,7 +1414,10 @@ class Test_MicrogridComponentGraph:
             Component(ComponentId(1), ComponentCategory.GRID),
             Component(ComponentId(2), ComponentCategory.METER),
         )
-        _add_connections(graph, Connection(ComponentId(1), ComponentId(2)))
+        _add_connections(
+            graph,
+            ComponentConnection(source=ComponentId(1), destination=ComponentId(2)),
+        )
         graph._validate_graph_root()
 
     def test__validate_grid_endpoint(self) -> None:
@@ -1363,8 +1445,8 @@ class Test_MicrogridComponentGraph:
         )
         _add_connections(
             graph,
-            Connection(ComponentId(1), ComponentId(2)),
-            Connection(ComponentId(3), ComponentId(2)),
+            ComponentConnection(source=ComponentId(1), destination=ComponentId(2)),
+            ComponentConnection(source=ComponentId(3), destination=ComponentId(2)),
         )
         with pytest.raises(
             gr.InvalidGraphError,
@@ -1379,7 +1461,10 @@ class Test_MicrogridComponentGraph:
             Component(ComponentId(1), ComponentCategory.GRID),
             Component(ComponentId(99), ComponentCategory.METER),
         )
-        _add_connections(graph, Connection(ComponentId(99), ComponentId(1)))
+        _add_connections(
+            graph,
+            ComponentConnection(source=ComponentId(99), destination=ComponentId(1)),
+        )
         with pytest.raises(
             gr.InvalidGraphError,
             match=r"Grid endpoint with CID1 has graph predecessors: \[Component"
@@ -1404,7 +1489,10 @@ class Test_MicrogridComponentGraph:
             Component(ComponentId(1), ComponentCategory.GRID),
             Component(ComponentId(2), ComponentCategory.METER),
         )
-        _add_connections(graph, Connection(ComponentId(1), ComponentId(2)))
+        _add_connections(
+            graph,
+            ComponentConnection(source=ComponentId(1), destination=ComponentId(2)),
+        )
         graph._validate_grid_endpoint()
 
     def test__validate_intermediary_components(self) -> None:
@@ -1431,7 +1519,10 @@ class Test_MicrogridComponentGraph:
             Component(ComponentId(1), ComponentCategory.GRID),
             Component(ComponentId(3), ComponentCategory.INVERTER),
         )
-        _add_connections(graph, Connection(ComponentId(1), ComponentId(3)))
+        _add_connections(
+            graph,
+            ComponentConnection(source=ComponentId(1), destination=ComponentId(3)),
+        )
         graph._validate_intermediary_components()
 
         graph._graph.clear()
@@ -1443,8 +1534,8 @@ class Test_MicrogridComponentGraph:
         )
         _add_connections(
             graph,
-            Connection(ComponentId(1), ComponentId(2)),
-            Connection(ComponentId(2), ComponentId(3)),
+            ComponentConnection(source=ComponentId(1), destination=ComponentId(2)),
+            ComponentConnection(source=ComponentId(2), destination=ComponentId(3)),
         )
         graph._validate_intermediary_components()
 
@@ -1460,9 +1551,9 @@ class Test_MicrogridComponentGraph:
         )
         _add_connections(
             graph,
-            Connection(ComponentId(1), ComponentId(2)),
-            Connection(ComponentId(2), ComponentId(3)),
-            Connection(ComponentId(3), ComponentId(4)),
+            ComponentConnection(source=ComponentId(1), destination=ComponentId(2)),
+            ComponentConnection(source=ComponentId(2), destination=ComponentId(3)),
+            ComponentConnection(source=ComponentId(3), destination=ComponentId(4)),
         )
         graph._validate_intermediary_components()
 
@@ -1501,8 +1592,8 @@ class Test_MicrogridComponentGraph:
 
         _add_connections(
             graph,
-            Connection(ComponentId(1), ComponentId(2)),
-            Connection(ComponentId(2), ComponentId(3)),
+            ComponentConnection(source=ComponentId(1), destination=ComponentId(2)),
+            ComponentConnection(source=ComponentId(2), destination=ComponentId(3)),
         )
         with pytest.raises(
             gr.InvalidGraphError, match="Leaf components with graph successors"
@@ -1518,8 +1609,8 @@ class Test_MicrogridComponentGraph:
         )
         _add_connections(
             graph,
-            Connection(ComponentId(1), ComponentId(3)),
-            Connection(ComponentId(3), ComponentId(4)),
+            ComponentConnection(source=ComponentId(1), destination=ComponentId(3)),
+            ComponentConnection(source=ComponentId(3), destination=ComponentId(4)),
         )
         with pytest.raises(
             gr.InvalidGraphError, match="Leaf components with graph successors"
@@ -1538,9 +1629,9 @@ class Test_MicrogridComponentGraph:
         )
         _add_connections(
             graph,
-            Connection(ComponentId(1), ComponentId(2)),
-            Connection(ComponentId(1), ComponentId(3)),
-            Connection(ComponentId(1), ComponentId(4)),
+            ComponentConnection(source=ComponentId(1), destination=ComponentId(2)),
+            ComponentConnection(source=ComponentId(1), destination=ComponentId(3)),
+            ComponentConnection(source=ComponentId(1), destination=ComponentId(4)),
         )
         graph._validate_leaf_components()
 
@@ -1567,9 +1658,9 @@ class TestComponentTypeIdentification:
                 pv_inv_2,
             },
             connections={
-                Connection(ComponentId(1), ComponentId(2)),
-                Connection(ComponentId(2), ComponentId(3)),
-                Connection(ComponentId(2), ComponentId(4)),
+                ComponentConnection(source=ComponentId(1), destination=ComponentId(2)),
+                ComponentConnection(source=ComponentId(2), destination=ComponentId(3)),
+                ComponentConnection(source=ComponentId(2), destination=ComponentId(4)),
             },
         )
 
@@ -1601,10 +1692,10 @@ class TestComponentTypeIdentification:
                 battery,
             },
             connections={
-                Connection(ComponentId(1), ComponentId(2)),
-                Connection(ComponentId(2), ComponentId(3)),
-                Connection(ComponentId(2), ComponentId(4)),
-                Connection(ComponentId(4), ComponentId(5)),
+                ComponentConnection(source=ComponentId(1), destination=ComponentId(2)),
+                ComponentConnection(source=ComponentId(2), destination=ComponentId(3)),
+                ComponentConnection(source=ComponentId(2), destination=ComponentId(4)),
+                ComponentConnection(source=ComponentId(4), destination=ComponentId(5)),
             },
         )
 
@@ -1649,12 +1740,12 @@ class TestComponentTypeIdentification:
                 battery,
             },
             connections={
-                Connection(ComponentId(1), ComponentId(2)),
-                Connection(ComponentId(2), ComponentId(3)),
-                Connection(ComponentId(3), ComponentId(4)),
-                Connection(ComponentId(2), ComponentId(5)),
-                Connection(ComponentId(5), ComponentId(6)),
-                Connection(ComponentId(6), ComponentId(7)),
+                ComponentConnection(source=ComponentId(1), destination=ComponentId(2)),
+                ComponentConnection(source=ComponentId(2), destination=ComponentId(3)),
+                ComponentConnection(source=ComponentId(3), destination=ComponentId(4)),
+                ComponentConnection(source=ComponentId(2), destination=ComponentId(5)),
+                ComponentConnection(source=ComponentId(5), destination=ComponentId(6)),
+                ComponentConnection(source=ComponentId(6), destination=ComponentId(7)),
             },
         )
 
@@ -1689,10 +1780,10 @@ class TestComponentTypeIdentification:
                 chp,
             },
             connections={
-                Connection(ComponentId(1), ComponentId(2)),
-                Connection(ComponentId(2), ComponentId(3)),
-                Connection(ComponentId(1), ComponentId(4)),
-                Connection(ComponentId(4), ComponentId(5)),
+                ComponentConnection(source=ComponentId(1), destination=ComponentId(2)),
+                ComponentConnection(source=ComponentId(2), destination=ComponentId(3)),
+                ComponentConnection(source=ComponentId(1), destination=ComponentId(4)),
+                ComponentConnection(source=ComponentId(4), destination=ComponentId(5)),
             },
         )
 

--- a/tests/microgrid/test_graph.py
+++ b/tests/microgrid/test_graph.py
@@ -125,12 +125,12 @@ class TestComponentGraph:
         assert graph.connections() == set()
         with pytest.raises(
             KeyError,
-            match="Component with CID1 not in graph, cannot get predecessors!",
+            match="Component CID1 not in graph, cannot get predecessors!",
         ):
             graph.predecessors(ComponentId(1))
         with pytest.raises(
             KeyError,
-            match="Component with CID1 not in graph, cannot get successors!",
+            match="Component CID1 not in graph, cannot get successors!",
         ):
             graph.successors(ComponentId(1))
 
@@ -160,12 +160,12 @@ class TestComponentGraph:
         assert graph.successors(ComponentId(3)) == set()
         with pytest.raises(
             KeyError,
-            match="Component with CID2 not in graph, cannot get predecessors!",
+            match="Component CID2 not in graph, cannot get predecessors!",
         ):
             graph.predecessors(ComponentId(2))
         with pytest.raises(
             KeyError,
-            match="Component with CID2 not in graph, cannot get successors!",
+            match="Component CID2 not in graph, cannot get successors!",
         ):
             graph.successors(ComponentId(2))
 
@@ -198,12 +198,12 @@ class TestComponentGraph:
 
         with pytest.raises(
             KeyError,
-            match="Component with CID9 not in graph, cannot get predecessors!",
+            match="Component CID9 not in graph, cannot get predecessors!",
         ):
             graph.predecessors(ComponentId(9))
         with pytest.raises(
             KeyError,
-            match="Component with CID99 not in graph, cannot get successors!",
+            match="Component CID99 not in graph, cannot get successors!",
         ):
             graph.successors(ComponentId(99))
 
@@ -234,18 +234,17 @@ class TestComponentGraph:
             ),
         ],
     )
-    def test_filter_graph_components_by_id(
+    def test_matching_ids(
         self,
         sample_graph: gr.ComponentGraph,
         int_ids: set[int],
         expected: set[Component],
     ) -> None:
         """Test the graph component query with component ID filter."""
-        ids = set(ComponentId(id) for id in int_ids)
-        # with component_id filter specified, we get back only components whose ID
-        # matches one of the specified values
-        assert len(sample_graph.components(component_ids=ids)) == len(expected)
-        assert sample_graph.components(component_ids=ids) == expected
+        components = sample_graph.components(
+            matching_ids=(ComponentId(id) for id in int_ids)
+        )
+        assert components == expected
 
     @pytest.mark.parametrize(
         "types, expected",
@@ -295,17 +294,14 @@ class TestComponentGraph:
             ),
         ],
     )
-    def test_filter_graph_components_by_type(
+    def test_matching_types(
         self,
         sample_graph: gr.ComponentGraph,
-        types: set[ComponentCategory],
+        types: set[type[Component]],
         expected: set[Component],
     ) -> None:
-        """Test the graph component query with component category filter."""
-        # with component_id filter specified, we get back only components whose ID
-        # matches one of the specified values
-        assert len(sample_graph.components(component_categories=types)) == len(expected)
-        assert sample_graph.components(component_categories=types) == expected
+        """Test the graph component query with component type filter."""
+        assert sample_graph.components(matching_types=types) == expected
 
     @pytest.mark.parametrize(
         "int_ids, types, expected",
@@ -331,25 +327,21 @@ class TestComponentGraph:
             ),
         ],
     )
-    def test_filter_graph_components_with_composite_filter(
+    def test_matching_ids_and_types(
         self,
         sample_graph: gr.ComponentGraph,
         int_ids: set[int],
-        types: set[ComponentCategory],
+        types: set[type[Component]],
         expected: set[Component],
     ) -> None:
         """Test the graph component query with composite filter."""
-        ids = set(ComponentId(id) for id in int_ids)
         # when both filters are applied, they are combined via AND logic, i.e.
         # the component must have one of the specified IDs and be of one of
         # the specified types
-        assert len(
-            sample_graph.components(component_ids=ids, component_categories=types)
-        ) == len(expected)
-        assert (
-            set(sample_graph.components(component_ids=ids, component_categories=types))
-            == expected
+        components = sample_graph.components(
+            matching_ids=(ComponentId(id) for id in int_ids), matching_types=types
         )
+        assert components == expected
 
     def test_components_without_filters(
         self, sample_input_components: set[Component], sample_graph: gr.ComponentGraph
@@ -985,7 +977,9 @@ class Test_MicrogridComponentGraph:
             graph.validate()
 
         client.list_components.return_value = []
-        client.list_connections.return_value = [Connection(ComponentId(1), ComponentId(2))]
+        client.list_connections.return_value = [
+            Connection(ComponentId(1), ComponentId(2))
+        ]
         with pytest.raises(gr.InvalidGraphError):
             await graph.refresh_from_client(client)
         assert graph.components() == set()

--- a/tests/microgrid/test_graph.py
+++ b/tests/microgrid/test_graph.py
@@ -31,7 +31,7 @@ def _add_components(graph: gr._MicrogridComponentGraph, *components: Component) 
         graph: The graph to add the components to.
         *components: The components to add.
     """
-    graph._graph.add_nodes_from((c.component_id, {gr._DATA_KEY: c}) for c in components)
+    graph._graph.add_nodes_from((c.id, {gr._DATA_KEY: c}) for c in components)
 
 
 def _add_connections(
@@ -53,7 +53,7 @@ def _check_predecessors_and_successors(graph: gr.ComponentGraph) -> None:
     expected_successors: dict[ComponentId, set[Component]] = {}
 
     components: dict[ComponentId, Component] = {
-        component.component_id: component for component in graph.components()
+        component.id: component for component in graph.components()
     }
 
     for conn in graph.connections():

--- a/tests/microgrid/test_grid.py
+++ b/tests/microgrid/test_grid.py
@@ -8,6 +8,7 @@ from contextlib import AsyncExitStack
 import frequenz.client.microgrid as client
 from frequenz.client.common.microgrid.components import ComponentId
 from frequenz.client.microgrid import ComponentCategory
+from frequenz.client.microgrid.metrics import Metric
 from frequenz.quantities import Current, Power, Quantity, ReactivePower
 from pytest_mock import MockerFixture
 
@@ -94,7 +95,7 @@ async def test_grid_power_1(mocker: MockerFixture) -> None:
         grid_meter_recv = get_resampled_stream(
             grid._formula_pool._namespace,  # pylint: disable=protected-access
             mockgrid.meter_ids[0],
-            client.ComponentMetricId.ACTIVE_POWER,
+            Metric.AC_ACTIVE_POWER,
             Power.from_watts,
         )
 
@@ -138,7 +139,7 @@ async def test_grid_power_2(mocker: MockerFixture) -> None:
             get_resampled_stream(
                 grid._formula_pool._namespace,  # pylint: disable=protected-access
                 component_id,
-                client.ComponentMetricId.ACTIVE_POWER,
+                Metric.AC_ACTIVE_POWER,
                 Power.from_watts,
             )
             for component_id in [
@@ -188,7 +189,7 @@ async def test_grid_reactive_power_1(mocker: MockerFixture) -> None:
         grid_meter_recv = get_resampled_stream(
             grid._formula_pool._namespace,  # pylint: disable=protected-access
             mockgrid.meter_ids[0],
-            client.ComponentMetricId.REACTIVE_POWER,
+            Metric.AC_REACTIVE_POWER,
             ReactivePower.from_volt_amperes_reactive,
         )
 
@@ -232,7 +233,7 @@ async def test_grid_reactive_power_2(mocker: MockerFixture) -> None:
             get_resampled_stream(
                 grid._formula_pool._namespace,  # pylint: disable=protected-access
                 component_id,
-                client.ComponentMetricId.REACTIVE_POWER,
+                Metric.AC_REACTIVE_POWER,
                 ReactivePower.from_volt_amperes_reactive,
             )
             for component_id in [

--- a/tests/microgrid/test_grid.py
+++ b/tests/microgrid/test_grid.py
@@ -5,10 +5,15 @@
 
 from contextlib import AsyncExitStack
 
-import frequenz.client.microgrid as client
+from frequenz.client.common.microgrid import MicrogridId
 from frequenz.client.common.microgrid.components import ComponentId
-from frequenz.client.microgrid import ComponentCategory
-from frequenz.client.microgrid.component import ComponentConnection
+from frequenz.client.microgrid.component import (
+    ComponentCategory,
+    ComponentConnection,
+    GridConnectionPoint,
+    Meter,
+    UnspecifiedComponent,
+)
 from frequenz.client.microgrid.metrics import Metric
 from frequenz.quantities import Current, Power, Quantity, ReactivePower
 from pytest_mock import MockerFixture
@@ -21,6 +26,8 @@ from tests.utils.graph_generator import GraphGenerator
 from ..timeseries._formula_engine.utils import equal_float_lists, get_resampled_stream
 from ..timeseries.mock_microgrid import MockMicrogrid
 
+_MICROGRID_ID = MicrogridId(1)
+
 
 async def test_grid_1(mocker: MockerFixture) -> None:
     """Test the grid connection module."""
@@ -29,13 +36,10 @@ async def test_grid_1(mocker: MockerFixture) -> None:
     # the tests, unless we explicitly delete it.
 
     # validate that islands with no grid connection are accepted.
-    components = {
-        client.Component(ComponentId(1), client.ComponentCategory.NONE),
-        client.Component(ComponentId(2), client.ComponentCategory.METER),
-    }
-    connections = {
-        ComponentConnection(source=ComponentId(1), destination=ComponentId(2)),
-    }
+    unspec_1 = UnspecifiedComponent(id=ComponentId(1), microgrid_id=_MICROGRID_ID)
+    meter_2 = Meter(id=ComponentId(2), microgrid_id=_MICROGRID_ID)
+    components = {unspec_1, meter_2}
+    connections = {ComponentConnection(source=unspec_1.id, destination=meter_2.id)}
 
     graph = gr._MicrogridComponentGraph(  # pylint: disable=protected-access
         components=components, connections=connections
@@ -53,18 +57,12 @@ async def test_grid_1(mocker: MockerFixture) -> None:
 
 async def test_grid_2(mocker: MockerFixture) -> None:
     """Validate that microgrids with one grid connection are accepted."""
-    components = {
-        client.Component(
-            ComponentId(1),
-            client.ComponentCategory.GRID,
-            None,
-            client.ComponentMetadata(fuse=client.Fuse(max_current=123.0)),
-        ),
-        client.Component(ComponentId(2), client.ComponentCategory.METER),
-    }
-    connections = {
-        ComponentConnection(source=ComponentId(1), destination=ComponentId(2)),
-    }
+    grid_1 = GridConnectionPoint(
+        id=ComponentId(1), microgrid_id=_MICROGRID_ID, rated_fuse_current=123
+    )
+    meter_2 = Meter(id=ComponentId(2), microgrid_id=_MICROGRID_ID)
+    components = {grid_1, meter_2}
+    connections = {ComponentConnection(source=grid_1.id, destination=meter_2.id)}
 
     graph = gr._MicrogridComponentGraph(  # pylint: disable=protected-access
         components=components, connections=connections

--- a/tests/microgrid/test_grid.py
+++ b/tests/microgrid/test_grid.py
@@ -8,6 +8,7 @@ from contextlib import AsyncExitStack
 import frequenz.client.microgrid as client
 from frequenz.client.common.microgrid.components import ComponentId
 from frequenz.client.microgrid import ComponentCategory
+from frequenz.client.microgrid.component import ComponentConnection
 from frequenz.client.microgrid.metrics import Metric
 from frequenz.quantities import Current, Power, Quantity, ReactivePower
 from pytest_mock import MockerFixture
@@ -33,7 +34,7 @@ async def test_grid_1(mocker: MockerFixture) -> None:
         client.Component(ComponentId(2), client.ComponentCategory.METER),
     }
     connections = {
-        client.Connection(ComponentId(1), ComponentId(2)),
+        ComponentConnection(source=ComponentId(1), destination=ComponentId(2)),
     }
 
     graph = gr._MicrogridComponentGraph(  # pylint: disable=protected-access
@@ -62,7 +63,7 @@ async def test_grid_2(mocker: MockerFixture) -> None:
         client.Component(ComponentId(2), client.ComponentCategory.METER),
     }
     connections = {
-        client.Connection(ComponentId(1), ComponentId(2)),
+        ComponentConnection(source=ComponentId(1), destination=ComponentId(2)),
     }
 
     graph = gr._MicrogridComponentGraph(  # pylint: disable=protected-access

--- a/tests/microgrid/test_grid.py
+++ b/tests/microgrid/test_grid.py
@@ -76,30 +76,6 @@ async def test_grid_2(mocker: MockerFixture) -> None:
         assert grid.fuse == Fuse(max_current=Current.from_amperes(123.0))
 
 
-async def test_grid_3(mocker: MockerFixture) -> None:
-    """Validate that microgrids with a grid connection without a fuse are instantiated."""
-    components = {
-        client.Component(
-            ComponentId(1),
-            client.ComponentCategory.GRID,
-            None,
-            client.GridMetadata(None),
-        ),
-        client.Component(ComponentId(2), client.ComponentCategory.METER),
-    }
-    connections = {client.Connection(ComponentId(1), ComponentId(2))}
-
-    graph = gr._MicrogridComponentGraph(  # pylint: disable=protected-access
-        components=components, connections=connections
-    )
-
-    async with MockMicrogrid(graph=graph, mocker=mocker), AsyncExitStack() as stack:
-        grid = microgrid.grid()
-        assert grid is not None
-        stack.push_async_callback(grid.stop)
-        assert grid.fuse is None
-
-
 async def test_grid_power_1(mocker: MockerFixture) -> None:
     """Test the grid power formula with a grid side meter."""
     mockgrid = MockMicrogrid(grid_meter=True, mocker=mocker)

--- a/tests/microgrid/test_microgrid_api.py
+++ b/tests/microgrid/test_microgrid_api.py
@@ -17,10 +17,12 @@ from frequenz.client.microgrid import (
     ComponentCategory,
     Connection,
     Location,
-    Metadata,
+    MicrogridInfo,
 )
 
 from frequenz.sdk.microgrid import connection_manager
+
+_MICROGRID_ID = MicrogridId(1)
 
 
 class TestMicrogridApi:
@@ -91,17 +93,25 @@ class TestMicrogridApi:
         return connections
 
     @pytest.fixture
-    def metadata(self) -> Metadata:
-        """Fetch the microgrid metadata.
+    def microgrid(self) -> MicrogridInfo:
+        """Fetch the microgrid information.
 
         Returns:
-            the microgrid metadata.
+            the information about the microgrid
         """
-        return Metadata(
-            microgrid_id=MicrogridId(8),
+        return MicrogridInfo(
+            id=_MICROGRID_ID,
+            enterprise_id=EnterpriseId(1),
+            name="test",
+            delivery_area=DeliveryArea(
+                code="test", code_type=EnergyMarketCodeType.EUROPE_EIC
+            ),
+            status=MicrogridStatus.ACTIVE,
+            create_timestamp=datetime.now(tz=timezone.utc),
             location=Location(
                 latitude=52.520008,
                 longitude=13.404954,
+                country_code="DE",
             ),
         )
 
@@ -111,7 +121,7 @@ class TestMicrogridApi:
         _insecure_channel_mock: MagicMock,
         components: list[list[Component]],
         connections: list[list[Connection]],
-        metadata: Metadata,
+        microgrid: MicrogridInfo,
     ) -> None:
         """Test microgrid api.
 
@@ -119,7 +129,7 @@ class TestMicrogridApi:
             _insecure_channel_mock: insecure channel mock from `mock.patch`
             components: components
             connections: connections
-            metadata: the metadata of the microgrid
+            microgrid: the information about the microgrid
         """
         microgrid_client = MagicMock()
         microgrid_client.list_components = AsyncMock(side_effect=components)
@@ -167,8 +177,8 @@ class TestMicrogridApi:
             assert set(graph.components()) == set(components[0])
             assert set(graph.connections()) == set(connections[0])
 
-            assert api.microgrid_id == metadata.microgrid_id
-            assert api.location == metadata.location
+            assert api.microgrid_id == microgrid.id
+            assert api.location == microgrid.location
 
             # It should not be possible to initialize method once again
             with pytest.raises(AssertionError):
@@ -181,8 +191,8 @@ class TestMicrogridApi:
             assert set(graph.components()) == set(components[0])
             assert set(graph.connections()) == set(connections[0])
 
-            assert api.microgrid_id == metadata.microgrid_id
-            assert api.location == metadata.location
+            assert api.microgrid_id == microgrid.id
+            assert api.location == microgrid.location
 
     @mock.patch("grpc.aio.insecure_channel")
     async def test_connection_manager_another_method(
@@ -190,7 +200,7 @@ class TestMicrogridApi:
         _insecure_channel_mock: MagicMock,
         components: list[list[Component]],
         connections: list[list[Connection]],
-        metadata: Metadata,
+        microgrid: MicrogridInfo,
     ) -> None:
         """Test if the api was not deallocated.
 
@@ -198,7 +208,7 @@ class TestMicrogridApi:
             _insecure_channel_mock: insecure channel mock
             components: components
             connections: connections
-            metadata: the metadata of the microgrid
+            microgrid: the information about the microgrid
         """
         microgrid_client = MagicMock()
         microgrid_client.components = AsyncMock(return_value=[])
@@ -210,5 +220,5 @@ class TestMicrogridApi:
         assert set(graph.components()) == set(components[0])
         assert set(graph.connections()) == set(connections[0])
 
-        assert api.microgrid_id == metadata.microgrid_id
-        assert api.location == metadata.location
+        assert api.microgrid_id == microgrid.id
+        assert api.location == microgrid.location

--- a/tests/microgrid/test_microgrid_api.py
+++ b/tests/microgrid/test_microgrid_api.py
@@ -15,9 +15,11 @@ from frequenz.client.common.microgrid.components import ComponentId
 from frequenz.client.microgrid import (
     Component,
     ComponentCategory,
-    Connection,
     Location,
     MicrogridInfo,
+)
+from frequenz.client.microgrid.component import (
+    ComponentConnection,
 )
 
 from frequenz.sdk.microgrid import connection_manager
@@ -63,7 +65,7 @@ class TestMicrogridApi:
 
     # ignore mypy: Untyped decorator makes function "components" untyped
     @pytest.fixture
-    def connections(self) -> list[list[Connection]]:
+    def connections(self) -> list[list[ComponentConnection]]:
         """Get connections between components in the graph.
 
         Override this method to create a graph with different connections.
@@ -74,20 +76,24 @@ class TestMicrogridApi:
         """
         connections = [
             [
-                Connection(ComponentId(1), ComponentId(4)),
-                Connection(ComponentId(1), ComponentId(5)),
-                Connection(ComponentId(1), ComponentId(7)),
-                Connection(ComponentId(7), ComponentId(8)),
-                Connection(ComponentId(8), ComponentId(9)),
-                Connection(ComponentId(1), ComponentId(10)),
-                Connection(ComponentId(10), ComponentId(11)),
-                Connection(ComponentId(11), ComponentId(12)),
+                ComponentConnection(source=ComponentId(1), destination=ComponentId(4)),
+                ComponentConnection(source=ComponentId(1), destination=ComponentId(5)),
+                ComponentConnection(source=ComponentId(1), destination=ComponentId(7)),
+                ComponentConnection(source=ComponentId(7), destination=ComponentId(8)),
+                ComponentConnection(source=ComponentId(8), destination=ComponentId(9)),
+                ComponentConnection(source=ComponentId(1), destination=ComponentId(10)),
+                ComponentConnection(
+                    source=ComponentId(10), destination=ComponentId(11)
+                ),
+                ComponentConnection(
+                    source=ComponentId(11), destination=ComponentId(12)
+                ),
             ],
             [
-                Connection(ComponentId(1), ComponentId(4)),
-                Connection(ComponentId(1), ComponentId(7)),
-                Connection(ComponentId(7), ComponentId(8)),
-                Connection(ComponentId(8), ComponentId(9)),
+                ComponentConnection(source=ComponentId(1), destination=ComponentId(4)),
+                ComponentConnection(source=ComponentId(1), destination=ComponentId(7)),
+                ComponentConnection(source=ComponentId(7), destination=ComponentId(8)),
+                ComponentConnection(source=ComponentId(8), destination=ComponentId(9)),
             ],
         ]
         return connections
@@ -120,7 +126,7 @@ class TestMicrogridApi:
         self,
         _insecure_channel_mock: MagicMock,
         components: list[list[Component]],
-        connections: list[list[Connection]],
+        connections: list[list[ComponentConnection]],
         microgrid: MicrogridInfo,
     ) -> None:
         """Test microgrid api.
@@ -199,7 +205,7 @@ class TestMicrogridApi:
         self,
         _insecure_channel_mock: MagicMock,
         components: list[list[Component]],
-        connections: list[list[Connection]],
+        connections: list[list[ComponentConnection]],
         microgrid: MicrogridInfo,
     ) -> None:
         """Test if the api was not deallocated.

--- a/tests/microgrid/test_microgrid_api.py
+++ b/tests/microgrid/test_microgrid_api.py
@@ -10,16 +10,22 @@ from unittest import mock
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from frequenz.client.common.microgrid import MicrogridId
+from frequenz.client.common.microgrid import EnterpriseId, MicrogridId
 from frequenz.client.common.microgrid.components import ComponentId
 from frequenz.client.microgrid import (
-    Component,
-    ComponentCategory,
+    DeliveryArea,
+    EnergyMarketCodeType,
     Location,
     MicrogridInfo,
+    MicrogridStatus,
 )
 from frequenz.client.microgrid.component import (
+    BatteryInverter,
+    Component,
     ComponentConnection,
+    GridConnectionPoint,
+    LiIonBattery,
+    Meter,
 )
 
 from frequenz.sdk.microgrid import connection_manager
@@ -43,22 +49,30 @@ class TestMicrogridApi:
         """
         components = [
             [
-                Component(ComponentId(1), ComponentCategory.GRID),
-                Component(ComponentId(4), ComponentCategory.METER),
-                Component(ComponentId(5), ComponentCategory.METER),
-                Component(ComponentId(7), ComponentCategory.METER),
-                Component(ComponentId(8), ComponentCategory.INVERTER),
-                Component(ComponentId(9), ComponentCategory.BATTERY),
-                Component(ComponentId(10), ComponentCategory.METER),
-                Component(ComponentId(11), ComponentCategory.INVERTER),
-                Component(ComponentId(12), ComponentCategory.BATTERY),
+                GridConnectionPoint(
+                    id=ComponentId(1),
+                    microgrid_id=_MICROGRID_ID,
+                    rated_fuse_current=10_000,
+                ),
+                Meter(id=ComponentId(4), microgrid_id=_MICROGRID_ID),
+                Meter(id=ComponentId(5), microgrid_id=_MICROGRID_ID),
+                Meter(id=ComponentId(7), microgrid_id=_MICROGRID_ID),
+                BatteryInverter(id=ComponentId(8), microgrid_id=_MICROGRID_ID),
+                LiIonBattery(id=ComponentId(9), microgrid_id=_MICROGRID_ID),
+                Meter(id=ComponentId(10), microgrid_id=_MICROGRID_ID),
+                BatteryInverter(id=ComponentId(11), microgrid_id=_MICROGRID_ID),
+                LiIonBattery(id=ComponentId(12), microgrid_id=_MICROGRID_ID),
             ],
             [
-                Component(ComponentId(1), ComponentCategory.GRID),
-                Component(ComponentId(4), ComponentCategory.METER),
-                Component(ComponentId(7), ComponentCategory.METER),
-                Component(ComponentId(8), ComponentCategory.INVERTER),
-                Component(ComponentId(9), ComponentCategory.BATTERY),
+                GridConnectionPoint(
+                    id=ComponentId(1),
+                    microgrid_id=_MICROGRID_ID,
+                    rated_fuse_current=10_000,
+                ),
+                Meter(id=ComponentId(4), microgrid_id=_MICROGRID_ID),
+                Meter(id=ComponentId(7), microgrid_id=_MICROGRID_ID),
+                BatteryInverter(id=ComponentId(8), microgrid_id=_MICROGRID_ID),
+                LiIonBattery(id=ComponentId(9), microgrid_id=_MICROGRID_ID),
             ],
         ]
         return components

--- a/tests/microgrid/test_microgrid_api.py
+++ b/tests/microgrid/test_microgrid_api.py
@@ -5,6 +5,7 @@
 
 import asyncio
 from asyncio.tasks import ALL_COMPLETED
+from datetime import datetime, timezone
 from unittest import mock
 from unittest.mock import AsyncMock, MagicMock
 
@@ -121,9 +122,9 @@ class TestMicrogridApi:
             metadata: the metadata of the microgrid
         """
         microgrid_client = MagicMock()
-        microgrid_client.components = AsyncMock(side_effect=components)
-        microgrid_client.connections = AsyncMock(side_effect=connections)
-        microgrid_client.metadata = AsyncMock(return_value=metadata)
+        microgrid_client.list_components = AsyncMock(side_effect=components)
+        microgrid_client.list_connections = AsyncMock(side_effect=connections)
+        microgrid_client.get_microgrid_info = AsyncMock(return_value=microgrid)
 
         with mock.patch(
             "frequenz.sdk.microgrid.connection_manager.MicrogridApiClient",

--- a/tests/timeseries/_battery_pool/test_battery_pool.py
+++ b/tests/timeseries/_battery_pool/test_battery_pool.py
@@ -73,7 +73,7 @@ def get_components(
         Components of this category.
     """
     return {
-        component.component_id
+        component.id
         for component in mock_microgrid.component_graph.components(
             component_categories={component_category}
         )
@@ -744,7 +744,7 @@ async def test_battery_pool_power_incomplete_bat_request(mocker: MockerFixture) 
     with pytest.raises(FormulaGenerationError):
         # Request only two of the three batteries behind the inverters
         battery_pool = microgrid.new_battery_pool(
-            priority=5, component_ids=set([bats[1].component_id, bats[0].component_id])
+            priority=5, component_ids=set([bats[1].id, bats[0].id])
         )
         power_receiver = battery_pool.power.new_receiver()
         await mockgrid.mock_resampler.send_bat_inverter_power([2.0])

--- a/tests/timeseries/_battery_pool/test_battery_pool.py
+++ b/tests/timeseries/_battery_pool/test_battery_pool.py
@@ -21,7 +21,7 @@ import pytest
 import time_machine
 from frequenz.channels import Receiver, Sender
 from frequenz.client.common.microgrid.components import ComponentId
-from frequenz.client.microgrid import ComponentCategory
+from frequenz.client.microgrid.component import Battery, Component, ComponentCategory
 from frequenz.quantities import Energy, Percentage, Power, Temperature
 from pytest_mock import MockerFixture
 
@@ -61,21 +61,21 @@ def event_loop_policy() -> async_solipsism.EventLoopPolicy:
 
 
 def get_components(
-    mock_microgrid: MockMicrogridClient, component_category: ComponentCategory
+    mock_microgrid: MockMicrogridClient, component_type: type[Component]
 ) -> set[ComponentId]:
-    """Get components of given category from mock microgrid.
+    """Get components of given type from mock microgrid.
 
     Args:
         mock_microgrid: mock microgrid
-        component_category: components category
+        component_type: components type
 
     Returns:
-        Components of this category.
+        Components of this type.
     """
     return {
         component.id
         for component in mock_microgrid.component_graph.components(
-            component_categories={component_category}
+            matching_types={component_type}
         )
     }
 
@@ -198,7 +198,7 @@ async def setup_batteries_pool(mocker: MockerFixture) -> AsyncIterator[SetupArgs
     # the scope of this tests. This tests should cover BatteryPool only.
     # We use our own battery status channel, where we easily control set of working
     # batteries.
-    all_batteries = get_components(mock_microgrid, ComponentCategory.BATTERY)
+    all_batteries = get_components(mock_microgrid, Battery)
 
     # This is a hack because these tests used to rely on the order in which components
     # are returned from the component graph using `all_batteries[:2]` to get the first 2
@@ -767,7 +767,7 @@ async def run_capacity_test(  # pylint: disable=too-many-locals
 
     # All batteries are working and sending data. Not just the ones in the
     # battery pool.
-    all_batteries = get_components(mock_microgrid, ComponentCategory.BATTERY)
+    all_batteries = get_components(mock_microgrid, Battery)
     await battery_status_sender.send(
         ComponentPoolStatus(working=all_batteries, uncertain=set())
     )
@@ -957,7 +957,7 @@ async def run_soc_test(setup_args: SetupArgs) -> None:
 
     # All batteries are working and sending data. Not just the ones in the
     # battery pool.
-    all_batteries = get_components(mock_microgrid, ComponentCategory.BATTERY)
+    all_batteries = get_components(mock_microgrid, Battery)
     await battery_status_sender.send(
         ComponentPoolStatus(working=all_batteries, uncertain=set())
     )
@@ -1092,7 +1092,7 @@ async def run_power_bounds_test(  # pylint: disable=too-many-locals
 
     # All batteries are working and sending data. Not just the ones in the
     # battery pool.
-    all_batteries = get_components(mock_microgrid, ComponentCategory.BATTERY)
+    all_batteries = get_components(mock_microgrid, Battery)
     await battery_status_sender.send(
         ComponentPoolStatus(working=all_batteries, uncertain=set())
     )
@@ -1344,7 +1344,7 @@ async def run_temperature_test(  # pylint: disable=too-many-locals
     streamer = setup_args.streamer
     battery_status_sender = setup_args.battery_status_sender
 
-    all_batteries = get_components(mock_microgrid, ComponentCategory.BATTERY)
+    all_batteries = get_components(mock_microgrid, Battery)
     await battery_status_sender.send(
         ComponentPoolStatus(working=all_batteries, uncertain=set())
     )

--- a/tests/timeseries/_battery_pool/test_battery_pool.py
+++ b/tests/timeseries/_battery_pool/test_battery_pool.py
@@ -75,7 +75,7 @@ def get_components(
     return {
         component.id
         for component in mock_microgrid.component_graph.components(
-            matching_types={component_type}
+            matching_types=component_type
         )
     }
 

--- a/tests/timeseries/_battery_pool/test_battery_pool.py
+++ b/tests/timeseries/_battery_pool/test_battery_pool.py
@@ -347,6 +347,10 @@ async def test_battery_pool_soc(setup_batteries_pool: SetupArgs) -> None:
     await run_soc_test(setup_batteries_pool)
 
 
+@pytest.mark.skip(
+    reason="Bounds are not calculated properly, see "
+    "https://github.com/frequenz-floss/frequenz-sdk-python/issues/1180"
+)
 async def test_all_batteries_power_bounds(setup_all_batteries: SetupArgs) -> None:
     """Test power bounds metric for battery pool with all components in the microgrid.
 
@@ -356,6 +360,10 @@ async def test_all_batteries_power_bounds(setup_all_batteries: SetupArgs) -> Non
     await run_power_bounds_test(setup_all_batteries)
 
 
+@pytest.mark.skip(
+    reason="Bounds are not calculated properly, see "
+    "https://github.com/frequenz-floss/frequenz-sdk-python/issues/1180"
+)
 async def test_battery_pool_power_bounds(setup_batteries_pool: SetupArgs) -> None:
     """Test power bounds metric for battery pool with subset of components in the microgrid.
 

--- a/tests/timeseries/_battery_pool/test_battery_pool_control_methods.py
+++ b/tests/timeseries/_battery_pool/test_battery_pool_control_methods.py
@@ -7,6 +7,7 @@ import asyncio
 import dataclasses
 import typing
 from datetime import datetime, timedelta, timezone
+from typing import cast
 from unittest.mock import AsyncMock, MagicMock
 
 import async_solipsism
@@ -190,8 +191,9 @@ class TestBatteryPoolControl:
         - single battery pool with all batteries.
         - all batteries are working, then one battery stops working.
         """
-        set_power = typing.cast(
-            AsyncMock, microgrid.connection_manager.get().api_client.set_power
+        set_power = cast(
+            AsyncMock,
+            microgrid.connection_manager.get().api_client.set_component_power_active,
         )
 
         await self._patch_battery_pool_status(mocks, mocker)
@@ -293,8 +295,9 @@ class TestBatteryPoolControl:
         - two battery pools with different batteries.
         - all batteries are working.
         """
-        set_power = typing.cast(
-            AsyncMock, microgrid.connection_manager.get().api_client.set_power
+        set_power = cast(
+            AsyncMock,
+            microgrid.connection_manager.get().api_client.set_component_power_active,
         )
 
         await self._patch_battery_pool_status(mocks, mocker)
@@ -350,8 +353,9 @@ class TestBatteryPoolControl:
         - two battery pools with same batteries, but different priorities.
         - all batteries are working.
         """
-        set_power = typing.cast(
-            AsyncMock, microgrid.connection_manager.get().api_client.set_power
+        set_power = cast(
+            AsyncMock,
+            microgrid.connection_manager.get().api_client.set_component_power_active,
         )
 
         await self._patch_battery_pool_status(mocks, mocker)
@@ -414,8 +418,9 @@ class TestBatteryPoolControl:
         - single battery pool with all batteries.
         - all batteries are working, but have exclusion bounds.
         """
-        set_power = typing.cast(
-            AsyncMock, microgrid.connection_manager.get().api_client.set_power
+        set_power = cast(
+            AsyncMock,
+            microgrid.connection_manager.get().api_client.set_component_power_active,
         )
         await self._patch_battery_pool_status(mocks, mocker)
         await self._init_data_for_batteries(mocks, exclusion_bounds=(-100.0, 100.0))
@@ -555,7 +560,8 @@ class TestBatteryPoolControl:
     async def test_no_resend_0w(self, mocks: Mocks, mocker: MockerFixture) -> None:
         """Test that 0W command is not resent unnecessarily."""
         set_power = typing.cast(
-            AsyncMock, microgrid.connection_manager.get().api_client.set_power
+            AsyncMock,
+            microgrid.connection_manager.get().api_client.set_component_power_active,
         )
         await self._patch_battery_pool_status(mocks, mocker)
         await self._init_data_for_batteries(mocks)

--- a/tests/timeseries/_ev_charger_pool/test_ev_charger_pool_control_methods.py
+++ b/tests/timeseries/_ev_charger_pool/test_ev_charger_pool_control_methods.py
@@ -6,6 +6,7 @@
 import asyncio
 import typing
 from datetime import datetime, timedelta, timezone
+from typing import cast
 from unittest.mock import AsyncMock, MagicMock
 
 import async_solipsism
@@ -197,8 +198,9 @@ class TestEVChargerPoolControl:
         traveller = time_machine.travel(datetime(2012, 12, 12))
         mock_time = traveller.start()
 
-        set_power = typing.cast(
-            AsyncMock, microgrid.connection_manager.get().api_client.set_power
+        set_power = cast(
+            AsyncMock,
+            microgrid.connection_manager.get().api_client.set_component_power_active,
         )
         await self._init_ev_chargers(mocks)
         ev_charger_pool = microgrid.new_ev_charger_pool(priority=5)

--- a/tests/timeseries/_ev_charger_pool/test_ev_charger_pool_control_methods.py
+++ b/tests/timeseries/_ev_charger_pool/test_ev_charger_pool_control_methods.py
@@ -13,7 +13,7 @@ import async_solipsism
 import pytest
 import time_machine
 from frequenz.channels import Receiver
-from frequenz.client.microgrid import EVChargerCableState, EVChargerComponentState
+from frequenz.client.microgrid.component import ComponentStateCode
 from frequenz.quantities import Power, Voltage
 from pytest_mock import MockerFixture
 
@@ -130,8 +130,11 @@ class TestEVChargerPoolControl:
                 EvChargerDataWrapper(
                     evc_id,
                     now,
-                    cable_state=EVChargerCableState.EV_PLUGGED,
-                    component_state=EVChargerComponentState.READY,
+                    states={
+                        ComponentStateCode.READY,
+                        ComponentStateCode.EV_CHARGING_CABLE_PLUGGED_AT_EV,
+                        ComponentStateCode.EV_CHARGING_CABLE_PLUGGED_AT_STATION,
+                    },
                     active_power=0.0,
                     active_power_inclusion_lower_bound=0.0,
                     active_power_inclusion_upper_bound=16.0 * 230.0 * 3,

--- a/tests/timeseries/_formula_engine/test_formula_composition.py
+++ b/tests/timeseries/_formula_engine/test_formula_composition.py
@@ -8,7 +8,7 @@ import math
 from contextlib import AsyncExitStack
 
 import pytest
-from frequenz.client.microgrid import ComponentMetricId
+from frequenz.client.microgrid.metrics import Metric
 from frequenz.quantities import Power
 from pytest_mock import MockerFixture
 
@@ -48,7 +48,7 @@ class TestFormulaComposition:
             grid_meter_recv = get_resampled_stream(
                 grid._formula_pool._namespace,  # pylint: disable=protected-access
                 mockgrid.meter_ids[0],
-                ComponentMetricId.ACTIVE_POWER,
+                Metric.AC_ACTIVE_POWER,
                 Power.from_watts,
             )
             grid_power_recv = grid.power.new_receiver()

--- a/tests/timeseries/_formula_engine/utils.py
+++ b/tests/timeseries/_formula_engine/utils.py
@@ -9,7 +9,7 @@ from math import isclose
 
 from frequenz.channels import Receiver
 from frequenz.client.common.microgrid.components import ComponentId
-from frequenz.client.microgrid import ComponentMetricId
+from frequenz.client.microgrid.metrics import Metric
 
 from frequenz.sdk.microgrid import _data_pipeline
 from frequenz.sdk.timeseries._base_types import QuantityT, Sample
@@ -21,7 +21,7 @@ from frequenz.sdk.timeseries.formula_engine._resampled_formula_builder import (
 def get_resampled_stream(
     namespace: str,
     comp_id: ComponentId,
-    metric_id: ComponentMetricId,
+    metric: Metric,
     create_method: Callable[[float], QuantityT],
 ) -> Receiver[Sample[QuantityT]]:
     """Return the resampled data stream for the given component."""
@@ -34,14 +34,14 @@ def get_resampled_stream(
         formula_name="",
         channel_registry=_data_pipeline._get()._channel_registry,
         resampler_subscription_sender=_data_pipeline._get()._resampling_request_sender(),
-        metric_id=metric_id,
+        metric=metric,
         create_method=create_method,
     )
     # Resampled data is always `Quantity` type, so we need to convert it to the desired
     # output type.
     return builder._get_resampled_receiver(
         comp_id,
-        metric_id,
+        metric,
     ).map(
         lambda sample: Sample(
             sample.timestamp,

--- a/tests/timeseries/_pv_pool/test_pv_pool_control_methods.py
+++ b/tests/timeseries/_pv_pool/test_pv_pool_control_methods.py
@@ -12,7 +12,7 @@ import async_solipsism
 import pytest
 from frequenz.channels import Receiver
 from frequenz.client.common.microgrid.components import ComponentId
-from frequenz.client.microgrid import InverterComponentState
+from frequenz.client.microgrid.component import ComponentStateCode
 from frequenz.quantities import Power
 from pytest_mock import MockerFixture
 
@@ -77,7 +77,7 @@ class TestPVPoolControl:
                 InverterDataWrapper(
                     comp_id,
                     now,
-                    component_state=InverterComponentState.IDLE,
+                    states={ComponentStateCode.READY},
                     active_power=0.0,
                     active_power_inclusion_lower_bound=-10000.0 * (idx + 1),
                     active_power_inclusion_upper_bound=0.0,
@@ -94,10 +94,10 @@ class TestPVPoolControl:
                 InverterDataWrapper(
                     comp_id,
                     now,
-                    component_state=(
-                        InverterComponentState.ERROR
+                    states=(
+                        {ComponentStateCode.ERROR}
                         if comp_id in fail_ids
-                        else InverterComponentState.IDLE
+                        else {ComponentStateCode.READY}
                     ),
                     active_power=0.0,
                     active_power_inclusion_lower_bound=-10000.0 * (idx + 1),

--- a/tests/timeseries/_pv_pool/test_pv_pool_control_methods.py
+++ b/tests/timeseries/_pv_pool/test_pv_pool_control_methods.py
@@ -151,7 +151,8 @@ class TestPVPoolControl:
     ) -> None:
         """Test setting power."""
         set_power = typing.cast(
-            AsyncMock, microgrid.connection_manager.get().api_client.set_power
+            AsyncMock,
+            microgrid.connection_manager.get().api_client.set_component_power_active,
         )
 
         await self._init_pv_inverters(mocks)

--- a/tests/timeseries/mock_microgrid.py
+++ b/tests/timeseries/mock_microgrid.py
@@ -11,16 +11,21 @@ from datetime import datetime, timedelta, timezone
 from types import TracebackType
 from typing import Coroutine
 
+from frequenz.client.common.microgrid import Connection, MicrogridId
 from frequenz.client.common.microgrid.components import ComponentId
-from frequenz.client.microgrid import (
+from frequenz.client.microgrid.component import (
+    AcEvCharger,
+    Battery,
+    BatteryInverter,
+    Chp,
     Component,
-    ComponentCategory,
-    Connection,
-    EVChargerCableState,
-    EVChargerComponentState,
-    Fuse,
-    GridMetadata,
-    InverterType,
+    ComponentStateCode,
+    EvCharger,
+    GridConnectionPoint,
+    Inverter,
+    LiIonBattery,
+    Meter,
+    SolarInverter,
 )
 from pytest_mock import MockerFixture
 
@@ -39,6 +44,8 @@ from ..utils.component_data_wrapper import (
     MeterDataWrapper,
 )
 from .mock_resampler import MockResampler
+
+_MICROGRID_ID = MicrogridId(1)
 
 
 class MockMicrogrid:  # pylint: disable=too-many-instance-attributes
@@ -63,7 +70,7 @@ class MockMicrogrid:  # pylint: disable=too-many-instance-attributes
         num_values: int = 2000,
         sample_rate_s: float = 0.01,
         num_namespaces: int = 1,
-        fuse: Fuse | None = Fuse(10_000.0),
+        rated_fuse_current: int = 10_000,
         graph: _MicrogridComponentGraph | None = None,
         mocker: MockerFixture | None = None,
     ):
@@ -79,7 +86,7 @@ class MockMicrogrid:  # pylint: disable=too-many-instance-attributes
                 to.  Useful in tests where multiple namespaces (logical_meter,
                 battery_pool, etc) are used, and the same metric is used by formulas in
                 different namespaces.
-            fuse: optional, the fuse to use for the grid connection.
+            rated_fuse_current: optional, the rated current of the fuse for the grid connection.
             graph: optional, a graph of components to use instead of the default grid
                 layout. If specified, grid_meter must be None.
             mocker: optional, a mocker to pass to the mock client and mock resampler.
@@ -93,8 +100,10 @@ class MockMicrogrid:  # pylint: disable=too-many-instance-attributes
 
         self._components: set[Component] = (
             {
-                Component(
-                    ComponentId(1), ComponentCategory.GRID, None, GridMetadata(fuse)
+                GridConnectionPoint(
+                    id=ComponentId(1),
+                    microgrid_id=_MICROGRID_ID,
+                    rated_fuse_current=rated_fuse_current,
                 ),
             }
             if graph is None
@@ -113,39 +122,25 @@ class MockMicrogrid:  # pylint: disable=too-many-instance-attributes
 
         self._connect_to = self.grid_id
 
-        def filter_comp(category: ComponentCategory) -> list[ComponentId]:
+        def filter_comp(component_type: type[Component]) -> list[ComponentId]:
             if graph is None:
                 return []
-            return sorted(
-                list(
-                    map(
-                        lambda c: c.id,
-                        graph.components(component_categories={category}),
-                    )
-                )
-            )
+            components = graph.components(matching_types={component_type})
+            return sorted(map(lambda c: c.id, components), key=int)
 
-        def inverters(comp_type: InverterType) -> list[ComponentId]:
+        def inverters(component_type: type[Inverter]) -> list[ComponentId]:
             if graph is None:
                 return []
+            components = graph.components(matching_types={component_type})
+            return sorted(map(lambda c: c.id, components), key=int)
 
-            return sorted(
-                [
-                    c.id
-                    for c in graph.components(
-                        component_categories={ComponentCategory.INVERTER}
-                    )
-                    if c.type == comp_type
-                ]
-            )
+        self.chp_ids: list[ComponentId] = filter_comp(Chp)
+        self.battery_ids: list[ComponentId] = filter_comp(Battery)
+        self.evc_ids: list[ComponentId] = filter_comp(EvCharger)
+        self.meter_ids: list[ComponentId] = filter_comp(Meter)
 
-        self.chp_ids: list[ComponentId] = filter_comp(ComponentCategory.CHP)
-        self.battery_ids: list[ComponentId] = filter_comp(ComponentCategory.BATTERY)
-        self.evc_ids: list[ComponentId] = filter_comp(ComponentCategory.EV_CHARGER)
-        self.meter_ids: list[ComponentId] = filter_comp(ComponentCategory.METER)
-
-        self.battery_inverter_ids: list[ComponentId] = inverters(InverterType.BATTERY)
-        self.pv_inverter_ids: list[ComponentId] = inverters(InverterType.SOLAR)
+        self.battery_inverter_ids: list[ComponentId] = inverters(BatteryInverter)
+        self.pv_inverter_ids: list[ComponentId] = inverters(SolarInverter)
 
         self.bat_inv_map: dict[ComponentId, ComponentId] = (
             {}
@@ -153,10 +148,7 @@ class MockMicrogrid:  # pylint: disable=too-many-instance-attributes
             else {
                 # Hacky, ignores multiple batteries behind one inverter
                 list(graph.successors(c.id))[0].id: c.id
-                for c in graph.components(
-                    component_categories={ComponentCategory.INVERTER}
-                )
-                if c.type == InverterType.BATTERY
+                for c in graph.components(matching_types={BatteryInverter})
             }
         )
 
@@ -182,7 +174,10 @@ class MockMicrogrid:  # pylint: disable=too-many-instance-attributes
             self._connect_to = self._grid_meter_id
             self._connections.add(Connection(self.grid_id, self._grid_meter_id))
             self._components.add(
-                Component(self._grid_meter_id, ComponentCategory.METER)
+                Meter(
+                    id=self._grid_meter_id,
+                    microgrid_id=MicrogridId(1),
+                )
             )
             self.meter_ids.append(self._grid_meter_id)
             self._start_meter_streaming(self._grid_meter_id)
@@ -366,12 +361,7 @@ class MockMicrogrid:  # pylint: disable=too-many-instance-attributes
             meter_id = ComponentId(self._id_increment * 10 + self.meter_id_suffix)
             self._id_increment += 1
             self.meter_ids.append(meter_id)
-            self._components.add(
-                Component(
-                    meter_id,
-                    ComponentCategory.METER,
-                )
-            )
+            self._components.add(Meter(id=meter_id, microgrid_id=_MICROGRID_ID))
             self._connections.add(Connection(self._connect_to, meter_id))
             self._start_meter_streaming(meter_id)
 
@@ -385,23 +375,13 @@ class MockMicrogrid:  # pylint: disable=too-many-instance-attributes
         for _ in range(count):
             chp_id = ComponentId(self._id_increment * 10 + self.chp_id_suffix)
             self.chp_ids.append(chp_id)
-            self._components.add(
-                Component(
-                    chp_id,
-                    ComponentCategory.CHP,
-                )
-            )
+            self._components.add(Chp(id=chp_id, microgrid_id=_MICROGRID_ID))
             if no_meters:
                 self._connections.add(Connection(self._connect_to, chp_id))
             else:
                 meter_id = ComponentId(self._id_increment * 10 + self.meter_id_suffix)
                 self.meter_ids.append(meter_id)
-                self._components.add(
-                    Component(
-                        meter_id,
-                        ComponentCategory.METER,
-                    )
-                )
+                self._components.add(Meter(id=meter_id, microgrid_id=_MICROGRID_ID))
                 self._start_meter_streaming(meter_id)
                 self._connections.add(Connection(self._connect_to, meter_id))
                 self._connections.add(Connection(meter_id, chp_id))
@@ -425,15 +405,8 @@ class MockMicrogrid:  # pylint: disable=too-many-instance-attributes
             self.battery_ids.append(bat_id)
             self.bat_inv_map[bat_id] = inv_id
 
-            self._components.add(
-                Component(inv_id, ComponentCategory.INVERTER, InverterType.BATTERY)
-            )
-            self._components.add(
-                Component(
-                    bat_id,
-                    ComponentCategory.BATTERY,
-                )
-            )
+            self._components.add(BatteryInverter(id=inv_id, microgrid_id=_MICROGRID_ID))
+            self._components.add(LiIonBattery(id=bat_id, microgrid_id=_MICROGRID_ID))
             self._start_battery_streaming(bat_id)
             self._start_inverter_streaming(inv_id)
 
@@ -441,12 +414,7 @@ class MockMicrogrid:  # pylint: disable=too-many-instance-attributes
                 self._connections.add(Connection(self._connect_to, inv_id))
             else:
                 self.meter_ids.append(meter_id)
-                self._components.add(
-                    Component(
-                        meter_id,
-                        ComponentCategory.METER,
-                    )
-                )
+                self._components.add(Meter(id=meter_id, microgrid_id=_MICROGRID_ID))
                 self._start_meter_streaming(meter_id)
                 self._connections.add(Connection(self._connect_to, meter_id))
                 self._connections.add(Connection(meter_id, inv_id))
@@ -466,25 +434,14 @@ class MockMicrogrid:  # pylint: disable=too-many-instance-attributes
 
             self.pv_inverter_ids.append(inv_id)
 
-            self._components.add(
-                Component(
-                    inv_id,
-                    ComponentCategory.INVERTER,
-                    InverterType.SOLAR,
-                )
-            )
+            self._components.add(SolarInverter(id=inv_id, microgrid_id=_MICROGRID_ID))
             self._start_inverter_streaming(inv_id)
 
             if no_meter:
                 self._connections.add(Connection(self._connect_to, inv_id))
             else:
                 self.meter_ids.append(meter_id)
-                self._components.add(
-                    Component(
-                        meter_id,
-                        ComponentCategory.METER,
-                    )
-                )
+                self._components.add(Meter(id=meter_id, microgrid_id=_MICROGRID_ID))
                 self._start_meter_streaming(meter_id)
                 self._connections.add(Connection(self._connect_to, meter_id))
                 self._connections.add(Connection(meter_id, inv_id))
@@ -503,12 +460,7 @@ class MockMicrogrid:  # pylint: disable=too-many-instance-attributes
             self.evc_component_states[evc_id] = EVChargerComponentState.READY
             self.evc_cable_states[evc_id] = EVChargerCableState.UNPLUGGED
 
-            self._components.add(
-                Component(
-                    evc_id,
-                    ComponentCategory.EV_CHARGER,
-                )
-            )
+            self._components.add(AcEvCharger(id=evc_id, microgrid_id=_MICROGRID_ID))
             self._start_ev_charger_streaming(evc_id)
             self._connections.add(Connection(self._connect_to, evc_id))
 

--- a/tests/timeseries/mock_microgrid.py
+++ b/tests/timeseries/mock_microgrid.py
@@ -15,7 +15,6 @@ from frequenz.client.common.microgrid.components import ComponentId
 from frequenz.client.microgrid import (
     Component,
     ComponentCategory,
-    ComponentData,
     Connection,
     EVChargerCableState,
     EVChargerComponentState,
@@ -28,6 +27,7 @@ from pytest_mock import MockerFixture
 from frequenz.sdk import microgrid
 from frequenz.sdk._internal._asyncio import cancel_and_await
 from frequenz.sdk.microgrid import _data_pipeline
+from frequenz.sdk.microgrid._old_component_data import ComponentData
 from frequenz.sdk.microgrid.component_graph import _MicrogridComponentGraph
 from frequenz.sdk.timeseries import ResamplerConfig2
 
@@ -265,12 +265,16 @@ class MockMicrogrid:  # pylint: disable=too-many-instance-attributes
             # for inverters with component_id > 100, send only half the messages.
             if int(comp_id) % 10 == self.inverter_id_suffix:
                 if int(comp_id) < 100 or value <= 5:
-                    await self.mock_client.send(make_comp_data(val_to_send, timestamp))
+                    await self.mock_client.send(
+                        make_comp_data(val_to_send, timestamp).to_samples()
+                    )
             else:
-                await self.mock_client.send(make_comp_data(val_to_send, timestamp))
+                await self.mock_client.send(
+                    make_comp_data(val_to_send, timestamp).to_samples()
+                )
             await asyncio.sleep(self._sample_rate_s)
 
-        await self.mock_client.close_channel(comp_id)
+        await self.mock_client.close_channels(comp_id)
 
     def _start_meter_streaming(self, meter_id: ComponentId) -> None:
         if not self._api_client_streaming:
@@ -532,7 +536,7 @@ class MockMicrogrid:  # pylint: disable=too-many-instance-attributes
                         value + 199.8,
                         value + 200.2,
                     ),
-                )
+                ).to_samples()
             )
 
     async def send_battery_data(self, socs: list[float]) -> None:
@@ -545,7 +549,9 @@ class MockMicrogrid:  # pylint: disable=too-many-instance-attributes
         timestamp = datetime.now(tz=timezone.utc)
         for comp_id, value in zip(self.battery_ids, socs):
             await self.mock_client.send(
-                BatteryDataWrapper(component_id=comp_id, timestamp=timestamp, soc=value)
+                BatteryDataWrapper(
+                    component_id=comp_id, timestamp=timestamp, soc=value
+                ).to_samples()
             )
 
     async def send_battery_inverter_data(self, values: list[float]) -> None:
@@ -560,7 +566,7 @@ class MockMicrogrid:  # pylint: disable=too-many-instance-attributes
             await self.mock_client.send(
                 InverterDataWrapper(
                     component_id=comp_id, timestamp=timestamp, active_power=value
-                )
+                ).to_samples()
             )
 
     async def send_pv_inverter_data(self, values: list[float]) -> None:
@@ -575,7 +581,7 @@ class MockMicrogrid:  # pylint: disable=too-many-instance-attributes
             await self.mock_client.send(
                 InverterDataWrapper(
                     component_id=comp_id, timestamp=timestamp, active_power=value
-                )
+                ).to_samples()
             )
 
     async def send_ev_charger_data(self, values: list[float]) -> None:
@@ -599,7 +605,7 @@ class MockMicrogrid:  # pylint: disable=too-many-instance-attributes
                     ),
                     component_state=self.evc_component_states[comp_id],
                     cable_state=self.evc_cable_states[comp_id],
-                )
+                ).to_samples()
             )
 
     async def cleanup(self) -> None:

--- a/tests/timeseries/mock_microgrid.py
+++ b/tests/timeseries/mock_microgrid.py
@@ -153,8 +153,7 @@ class MockMicrogrid:  # pylint: disable=too-many-instance-attributes
             }
         )
 
-        self.evc_component_states: dict[ComponentId, EVChargerComponentState] = {}
-        self.evc_cable_states: dict[ComponentId, EVChargerCableState] = {}
+        self.evc_states: dict[ComponentId, set[ComponentStateCode]] = {}
 
         self._streaming_coros: list[tuple[ComponentId, Coroutine[None, None, None]]] = (
             []
@@ -343,8 +342,7 @@ class MockMicrogrid:  # pylint: disable=too-many-instance-attributes
                         active_power=value,
                         reactive_power=2 * value,
                         current_per_phase=(value + 10.0, value + 11.0, value + 12.0),
-                        component_state=self.evc_component_states[evc_id],
-                        cable_state=self.evc_cable_states[evc_id],
+                        states=self.evc_states[evc_id],
                     ),
                 ),
             )
@@ -484,8 +482,10 @@ class MockMicrogrid:  # pylint: disable=too-many-instance-attributes
             self._id_increment += 1
 
             self.evc_ids.append(evc_id)
-            self.evc_component_states[evc_id] = EVChargerComponentState.READY
-            self.evc_cable_states[evc_id] = EVChargerCableState.UNPLUGGED
+            self.evc_states[evc_id] = {
+                ComponentStateCode.READY,
+                ComponentStateCode.EV_CHARGING_CABLE_UNPLUGGED,
+            }
 
             self._components.add(AcEvCharger(id=evc_id, microgrid_id=_MICROGRID_ID))
             self._start_ev_charger_streaming(evc_id)
@@ -584,8 +584,7 @@ class MockMicrogrid:  # pylint: disable=too-many-instance-attributes
                         value + 101.0,
                         value + 102.0,
                     ),
-                    component_state=self.evc_component_states[comp_id],
-                    cable_state=self.evc_cable_states[comp_id],
+                    states=self.evc_states[comp_id],
                 ).to_samples()
             )
 

--- a/tests/timeseries/mock_microgrid.py
+++ b/tests/timeseries/mock_microgrid.py
@@ -11,7 +11,7 @@ from datetime import datetime, timedelta, timezone
 from types import TracebackType
 from typing import Coroutine
 
-from frequenz.client.common.microgrid import Connection, MicrogridId
+from frequenz.client.common.microgrid import MicrogridId
 from frequenz.client.common.microgrid.components import ComponentId
 from frequenz.client.microgrid.component import (
     AcEvCharger,
@@ -19,6 +19,7 @@ from frequenz.client.microgrid.component import (
     BatteryInverter,
     Chp,
     Component,
+    ComponentConnection,
     ComponentStateCode,
     EvCharger,
     GridConnectionPoint,
@@ -110,7 +111,7 @@ class MockMicrogrid:  # pylint: disable=too-many-instance-attributes
             else graph.components()
         )
 
-        self._connections: set[Connection] = (
+        self._connections: set[ComponentConnection] = (
             set() if graph is None else graph.connections()
         )
 
@@ -172,7 +173,11 @@ class MockMicrogrid:  # pylint: disable=too-many-instance-attributes
 
         if grid_meter:
             self._connect_to = self._grid_meter_id
-            self._connections.add(Connection(self.grid_id, self._grid_meter_id))
+            self._connections.add(
+                ComponentConnection(
+                    source=self.grid_id, destination=self._grid_meter_id
+                )
+            )
             self._components.add(
                 Meter(
                     id=self._grid_meter_id,
@@ -362,7 +367,9 @@ class MockMicrogrid:  # pylint: disable=too-many-instance-attributes
             self._id_increment += 1
             self.meter_ids.append(meter_id)
             self._components.add(Meter(id=meter_id, microgrid_id=_MICROGRID_ID))
-            self._connections.add(Connection(self._connect_to, meter_id))
+            self._connections.add(
+                ComponentConnection(source=self._connect_to, destination=meter_id)
+            )
             self._start_meter_streaming(meter_id)
 
     def add_chps(self, count: int, no_meters: bool = False) -> None:
@@ -377,14 +384,20 @@ class MockMicrogrid:  # pylint: disable=too-many-instance-attributes
             self.chp_ids.append(chp_id)
             self._components.add(Chp(id=chp_id, microgrid_id=_MICROGRID_ID))
             if no_meters:
-                self._connections.add(Connection(self._connect_to, chp_id))
+                self._connections.add(
+                    ComponentConnection(source=self._connect_to, destination=chp_id)
+                )
             else:
                 meter_id = ComponentId(self._id_increment * 10 + self.meter_id_suffix)
                 self.meter_ids.append(meter_id)
                 self._components.add(Meter(id=meter_id, microgrid_id=_MICROGRID_ID))
                 self._start_meter_streaming(meter_id)
-                self._connections.add(Connection(self._connect_to, meter_id))
-                self._connections.add(Connection(meter_id, chp_id))
+                self._connections.add(
+                    ComponentConnection(source=self._connect_to, destination=meter_id)
+                )
+                self._connections.add(
+                    ComponentConnection(source=meter_id, destination=chp_id)
+                )
 
             self._id_increment += 1
 
@@ -411,14 +424,22 @@ class MockMicrogrid:  # pylint: disable=too-many-instance-attributes
             self._start_inverter_streaming(inv_id)
 
             if no_meter:
-                self._connections.add(Connection(self._connect_to, inv_id))
+                self._connections.add(
+                    ComponentConnection(source=self._connect_to, destination=inv_id)
+                )
             else:
                 self.meter_ids.append(meter_id)
                 self._components.add(Meter(id=meter_id, microgrid_id=_MICROGRID_ID))
                 self._start_meter_streaming(meter_id)
-                self._connections.add(Connection(self._connect_to, meter_id))
-                self._connections.add(Connection(meter_id, inv_id))
-            self._connections.add(Connection(inv_id, bat_id))
+                self._connections.add(
+                    ComponentConnection(source=self._connect_to, destination=meter_id)
+                )
+                self._connections.add(
+                    ComponentConnection(source=meter_id, destination=inv_id)
+                )
+            self._connections.add(
+                ComponentConnection(source=inv_id, destination=bat_id)
+            )
 
     def add_solar_inverters(self, count: int, no_meter: bool = False) -> None:
         """Add pv inverters and connected pv meters to the microgrid.
@@ -438,13 +459,19 @@ class MockMicrogrid:  # pylint: disable=too-many-instance-attributes
             self._start_inverter_streaming(inv_id)
 
             if no_meter:
-                self._connections.add(Connection(self._connect_to, inv_id))
+                self._connections.add(
+                    ComponentConnection(source=self._connect_to, destination=inv_id)
+                )
             else:
                 self.meter_ids.append(meter_id)
                 self._components.add(Meter(id=meter_id, microgrid_id=_MICROGRID_ID))
                 self._start_meter_streaming(meter_id)
-                self._connections.add(Connection(self._connect_to, meter_id))
-                self._connections.add(Connection(meter_id, inv_id))
+                self._connections.add(
+                    ComponentConnection(source=self._connect_to, destination=meter_id)
+                )
+                self._connections.add(
+                    ComponentConnection(source=meter_id, destination=inv_id)
+                )
 
     def add_ev_chargers(self, count: int) -> None:
         """Add EV Chargers to the microgrid.
@@ -462,7 +489,9 @@ class MockMicrogrid:  # pylint: disable=too-many-instance-attributes
 
             self._components.add(AcEvCharger(id=evc_id, microgrid_id=_MICROGRID_ID))
             self._start_ev_charger_streaming(evc_id)
-            self._connections.add(Connection(self._connect_to, evc_id))
+            self._connections.add(
+                ComponentConnection(source=self._connect_to, destination=evc_id)
+            )
 
     async def send_meter_data(self, values: list[float]) -> None:
         """Send raw meter data from the mock microgrid.

--- a/tests/timeseries/mock_microgrid.py
+++ b/tests/timeseries/mock_microgrid.py
@@ -119,7 +119,7 @@ class MockMicrogrid:  # pylint: disable=too-many-instance-attributes
             return sorted(
                 list(
                     map(
-                        lambda c: c.component_id,
+                        lambda c: c.id,
                         graph.components(component_categories={category}),
                     )
                 )
@@ -131,7 +131,7 @@ class MockMicrogrid:  # pylint: disable=too-many-instance-attributes
 
             return sorted(
                 [
-                    c.component_id
+                    c.id
                     for c in graph.components(
                         component_categories={ComponentCategory.INVERTER}
                     )
@@ -152,7 +152,7 @@ class MockMicrogrid:  # pylint: disable=too-many-instance-attributes
             if graph is None
             else {
                 # Hacky, ignores multiple batteries behind one inverter
-                list(graph.successors(c.component_id))[0].component_id: c.component_id
+                list(graph.successors(c.id))[0].id: c.id
                 for c in graph.components(
                     component_categories={ComponentCategory.INVERTER}
                 )

--- a/tests/timeseries/mock_microgrid.py
+++ b/tests/timeseries/mock_microgrid.py
@@ -125,13 +125,13 @@ class MockMicrogrid:  # pylint: disable=too-many-instance-attributes
         def filter_comp(component_type: type[Component]) -> list[ComponentId]:
             if graph is None:
                 return []
-            components = graph.components(matching_types={component_type})
+            components = graph.components(matching_types=component_type)
             return sorted(map(lambda c: c.id, components), key=int)
 
         def inverters(component_type: type[Inverter]) -> list[ComponentId]:
             if graph is None:
                 return []
-            components = graph.components(matching_types={component_type})
+            components = graph.components(matching_types=component_type)
             return sorted(map(lambda c: c.id, components), key=int)
 
         self.chp_ids: list[ComponentId] = filter_comp(Chp)
@@ -148,7 +148,7 @@ class MockMicrogrid:  # pylint: disable=too-many-instance-attributes
             else {
                 # Hacky, ignores multiple batteries behind one inverter
                 list(graph.successors(c.id))[0].id: c.id
-                for c in graph.components(matching_types={BatteryInverter})
+                for c in graph.components(matching_types=BatteryInverter)
             }
         )
 

--- a/tests/timeseries/mock_resampler.py
+++ b/tests/timeseries/mock_resampler.py
@@ -10,7 +10,7 @@ from datetime import datetime
 
 from frequenz.channels import Broadcast, Receiver, Sender
 from frequenz.client.common.microgrid.components import ComponentId
-from frequenz.client.microgrid import ComponentMetricId
+from frequenz.client.microgrid.metrics import Metric
 from frequenz.quantities import Quantity
 from pytest_mock import MockerFixture
 
@@ -50,7 +50,7 @@ class MockResampler:
 
         def metric_senders(
             comp_ids: list[ComponentId],
-            metric_id: ComponentMetricId,
+            metric_id: Metric,
         ) -> list[Sender[Sample[Quantity]]]:
             senders: list[Sender[Sample[Quantity]]] = []
             for comp_id in comp_ids:
@@ -70,45 +70,39 @@ class MockResampler:
 
         # Active power senders
         self._bat_inverter_power_senders = metric_senders(
-            bat_inverter_ids, ComponentMetricId.ACTIVE_POWER
+            bat_inverter_ids, Metric.AC_ACTIVE_POWER
         )
         self._pv_inverter_power_senders = metric_senders(
-            pv_inverter_ids, ComponentMetricId.ACTIVE_POWER
+            pv_inverter_ids, Metric.AC_ACTIVE_POWER
         )
-        self._ev_power_senders = metric_senders(evc_ids, ComponentMetricId.ACTIVE_POWER)
+        self._ev_power_senders = metric_senders(evc_ids, Metric.AC_ACTIVE_POWER)
 
-        self._chp_power_senders = metric_senders(
-            chp_ids, ComponentMetricId.ACTIVE_POWER
-        )
-        self._meter_power_senders = metric_senders(
-            meter_ids, ComponentMetricId.ACTIVE_POWER
-        )
+        self._chp_power_senders = metric_senders(chp_ids, Metric.AC_ACTIVE_POWER)
+        self._meter_power_senders = metric_senders(meter_ids, Metric.AC_ACTIVE_POWER)
         self._non_existing_component_sender = metric_senders(
-            [NON_EXISTING_COMPONENT_ID], ComponentMetricId.ACTIVE_POWER
+            [NON_EXISTING_COMPONENT_ID], Metric.AC_ACTIVE_POWER
         )[0]
 
         # Frequency senders
         self._bat_inverter_frequency_senders = metric_senders(
-            bat_inverter_ids, ComponentMetricId.FREQUENCY
+            bat_inverter_ids, Metric.AC_FREQUENCY
         )
-        self._meter_frequency_senders = metric_senders(
-            meter_ids, ComponentMetricId.FREQUENCY
-        )
+        self._meter_frequency_senders = metric_senders(meter_ids, Metric.AC_FREQUENCY)
 
         # Reactive power senders
         self._meter_reactive_power_senders = metric_senders(
-            meter_ids, ComponentMetricId.REACTIVE_POWER
+            meter_ids, Metric.AC_REACTIVE_POWER
         )
         self._bat_inverter_reactive_power_senders = metric_senders(
-            bat_inverter_ids, ComponentMetricId.REACTIVE_POWER
+            bat_inverter_ids, Metric.AC_REACTIVE_POWER
         )
         self._ev_reactive_power_senders = metric_senders(
-            evc_ids, ComponentMetricId.REACTIVE_POWER
+            evc_ids, Metric.AC_REACTIVE_POWER
         )
 
         def multi_phase_senders(
             ids: list[ComponentId],
-            metrics: tuple[ComponentMetricId, ComponentMetricId, ComponentMetricId],
+            metrics: tuple[Metric, Metric, Metric],
         ) -> list[list[Sender[Sample[Quantity]]]]:
             senders: list[list[Sender[Sample[Quantity]]]] = []
             for comp_id in ids:
@@ -155,9 +149,9 @@ class MockResampler:
             return multi_phase_senders(
                 ids,
                 (
-                    ComponentMetricId.CURRENT_PHASE_1,
-                    ComponentMetricId.CURRENT_PHASE_2,
-                    ComponentMetricId.CURRENT_PHASE_3,
+                    Metric.AC_CURRENT_PHASE_1,
+                    Metric.AC_CURRENT_PHASE_2,
+                    Metric.AC_CURRENT_PHASE_3,
                 ),
             )
 
@@ -167,9 +161,9 @@ class MockResampler:
             return multi_phase_senders(
                 ids,
                 (
-                    ComponentMetricId.VOLTAGE_PHASE_1,
-                    ComponentMetricId.VOLTAGE_PHASE_2,
-                    ComponentMetricId.VOLTAGE_PHASE_3,
+                    Metric.AC_VOLTAGE_PHASE_1_N,
+                    Metric.AC_VOLTAGE_PHASE_2_N,
+                    Metric.AC_VOLTAGE_PHASE_3_N,
                 ),
             )
 
@@ -179,9 +173,9 @@ class MockResampler:
             return multi_phase_senders(
                 ids,
                 (
-                    ComponentMetricId.ACTIVE_POWER_PHASE_1,
-                    ComponentMetricId.ACTIVE_POWER_PHASE_2,
-                    ComponentMetricId.ACTIVE_POWER_PHASE_3,
+                    Metric.AC_ACTIVE_POWER_PHASE_1,
+                    Metric.AC_ACTIVE_POWER_PHASE_2,
+                    Metric.AC_ACTIVE_POWER_PHASE_3,
                 ),
             )
 
@@ -242,7 +236,7 @@ class MockResampler:
             name = request.get_channel_name()
             if name in self._forward_tasks:
                 continue
-            input_chan_recv_name = f"{request.component_id}:{request.metric_id}"
+            input_chan_recv_name = f"{request.component_id}:{request.metric}"
             input_chan_recv = self._input_channels_receivers[input_chan_recv_name].pop()
             assert input_chan_recv is not None
             output_chan_sender: Sender[Sample[Quantity]] = (

--- a/tests/timeseries/test_frequency_streaming.py
+++ b/tests/timeseries/test_frequency_streaming.py
@@ -38,7 +38,7 @@ async def test_grid_frequency_none(mocker: MockerFixture) -> None:
     await mockgrid.mock_client.send(
         component_data_wrapper.MeterDataWrapper(
             mockgrid.meter_ids[0], datetime.now(tz=timezone.utc)
-        )
+        ).to_samples()
     )
 
     val = await grid_freq_recv.receive()
@@ -70,7 +70,7 @@ async def test_grid_frequency_1(mocker: MockerFixture) -> None:
             await mockgrid.mock_client.send(
                 component_data_wrapper.MeterDataWrapper(
                     mockgrid.meter_ids[0], datetime.now(tz=timezone.utc), frequency=freq
-                )
+                ).to_samples()
             )
 
             grid_meter_data.append(Frequency.from_hertz(freq))
@@ -108,7 +108,7 @@ async def test_grid_frequency_no_grid_meter_no_consumer_meter(
             await mockgrid.mock_client.send(
                 component_data_wrapper.MeterDataWrapper(
                     mockgrid.meter_ids[0], datetime.now(tz=timezone.utc), frequency=freq
-                )
+                ).to_samples()
             )
             meter_data.append(Frequency.from_hertz(freq))
 
@@ -145,7 +145,7 @@ async def test_grid_frequency_no_grid_meter(
             await mockgrid.mock_client.send(
                 component_data_wrapper.MeterDataWrapper(
                     mockgrid.meter_ids[0], datetime.now(tz=timezone.utc), frequency=freq
-                )
+                ).to_samples()
             )
             meter_data.append(Frequency.from_hertz(freq))
 
@@ -183,7 +183,7 @@ async def test_grid_frequency_only_inverter(
                     mockgrid.battery_inverter_ids[0],
                     datetime.now(tz=timezone.utc),
                     frequency=freq,
-                )
+                ).to_samples()
             )
 
             meter_data.append(Frequency.from_hertz(freq))

--- a/tests/utils/component_data_streamer.py
+++ b/tests/utils/component_data_streamer.py
@@ -9,9 +9,9 @@ from dataclasses import replace
 from datetime import datetime, timezone
 
 from frequenz.client.common.microgrid.components import ComponentId
-from frequenz.client.microgrid import ComponentData
 
 from frequenz.sdk._internal._asyncio import cancel_and_await
+from frequenz.sdk.microgrid._old_component_data import ComponentData
 
 from .mock_microgrid_client import MockMicrogridClient
 
@@ -108,5 +108,5 @@ class MockComponentDataStreamer:
         while component_id in self._component_data:
             data = self._component_data[component_id]
             new_data = replace(data, timestamp=datetime.now(tz=timezone.utc))
-            await self._mock_microgrid.send(new_data)
+            await self._mock_microgrid.send(new_data.to_samples())
             await asyncio.sleep(sampling_rate)

--- a/tests/utils/component_data_wrapper.py
+++ b/tests/utils/component_data_wrapper.py
@@ -13,21 +13,17 @@ that will need to be updated in such cases.
 from __future__ import annotations
 
 import math
+from collections.abc import Set
 from dataclasses import dataclass, replace
 from datetime import datetime
 
 from frequenz.client.common.microgrid.components import ComponentId
-from frequenz.client.microgrid import (
-    BatteryComponentState,
+from frequenz.client.microgrid.component import ComponentErrorCode, ComponentStateCode
+
+from frequenz.sdk.microgrid._old_component_data import (
     BatteryData,
-    BatteryError,
-    BatteryRelayState,
-    EVChargerCableState,
-    EVChargerComponentState,
     EVChargerData,
-    InverterComponentState,
     InverterData,
-    InverterError,
     MeterData,
 )
 
@@ -51,9 +47,9 @@ class BatteryDataWrapper(BatteryData):
         power_inclusion_upper_bound: float = math.nan,
         power_exclusion_upper_bound: float = math.nan,
         temperature: float = math.nan,
-        relay_state: BatteryRelayState = (BatteryRelayState.UNSPECIFIED),
-        component_state: BatteryComponentState = (BatteryComponentState.UNSPECIFIED),
-        errors: list[BatteryError] | None = None,
+        states: Set[ComponentStateCode] = frozenset(),
+        warnings: Set[ComponentErrorCode] = frozenset(),
+        errors: Set[ComponentErrorCode] = frozenset(),
     ) -> None:
         """Initialize the BatteryDataWrapper.
 
@@ -72,9 +68,9 @@ class BatteryDataWrapper(BatteryData):
             power_inclusion_upper_bound=power_inclusion_upper_bound,
             power_exclusion_upper_bound=power_exclusion_upper_bound,
             temperature=temperature,
-            relay_state=relay_state,
-            component_state=component_state,
-            errors=errors or [],
+            states=states,
+            warnings=warnings,
+            errors=errors,
         )
 
     def copy_with_new_timestamp(self, new_timestamp: datetime) -> BatteryDataWrapper:
@@ -92,7 +88,7 @@ class BatteryDataWrapper(BatteryData):
         return replace(self, timestamp=new_timestamp)
 
 
-@dataclass(frozen=True)
+@dataclass
 class InverterDataWrapper(InverterData):
     """Wrapper for the InverterData with default arguments."""
 
@@ -119,8 +115,9 @@ class InverterDataWrapper(InverterData):
             math.nan,
         ),
         frequency: float = 50.0,
-        component_state: InverterComponentState = InverterComponentState.UNSPECIFIED,
-        errors: list[InverterError] | None = None,
+        states: Set[ComponentStateCode] = frozenset(),
+        warnings: Set[ComponentErrorCode] = frozenset(),
+        errors: Set[ComponentErrorCode] = frozenset(),
     ) -> None:
         """Initialize the InverterDataWrapper.
 
@@ -140,9 +137,10 @@ class InverterDataWrapper(InverterData):
             active_power_exclusion_upper_bound=active_power_exclusion_upper_bound,
             reactive_power=reactive_power,
             reactive_power_per_phase=reactive_power_per_phase,
-            component_state=component_state,
             frequency=frequency,
-            errors=errors or [],
+            states=states,
+            warnings=warnings,
+            errors=errors,
         )
 
     def copy_with_new_timestamp(self, new_timestamp: datetime) -> InverterDataWrapper:
@@ -160,7 +158,7 @@ class InverterDataWrapper(InverterData):
         return replace(self, timestamp=new_timestamp)
 
 
-@dataclass(frozen=True)
+@dataclass
 class EvChargerDataWrapper(EVChargerData):
     """Wrapper for the EvChargerData with default arguments."""
 
@@ -187,8 +185,9 @@ class EvChargerDataWrapper(EVChargerData):
             math.nan,
         ),
         frequency: float = 50.0,
-        cable_state: EVChargerCableState = EVChargerCableState.UNSPECIFIED,
-        component_state: EVChargerComponentState = EVChargerComponentState.UNSPECIFIED,
+        states: Set[ComponentStateCode] = frozenset(),
+        warnings: Set[ComponentErrorCode] = frozenset(),
+        errors: Set[ComponentErrorCode] = frozenset(),
     ) -> None:
         """Initialize the EvChargerDataWrapper.
 
@@ -209,8 +208,9 @@ class EvChargerDataWrapper(EVChargerData):
             reactive_power=reactive_power,
             reactive_power_per_phase=reactive_power_per_phase,
             frequency=frequency,
-            cable_state=cable_state,
-            component_state=component_state,
+            states=states,
+            warnings=warnings,
+            errors=errors,
         )
 
     def copy_with_new_timestamp(self, new_timestamp: datetime) -> EvChargerDataWrapper:
@@ -228,7 +228,7 @@ class EvChargerDataWrapper(EVChargerData):
         return replace(self, timestamp=new_timestamp)
 
 
-@dataclass(frozen=True)
+@dataclass
 class MeterDataWrapper(MeterData):
     """Wrapper for the MeterData with default arguments."""
 
@@ -251,6 +251,9 @@ class MeterDataWrapper(MeterData):
         current_per_phase: tuple[float, float, float] = (math.nan, math.nan, math.nan),
         voltage_per_phase: tuple[float, float, float] = (math.nan, math.nan, math.nan),
         frequency: float = math.nan,
+        states: Set[ComponentStateCode] = frozenset(),
+        warnings: Set[ComponentErrorCode] = frozenset(),
+        errors: Set[ComponentErrorCode] = frozenset(),
     ) -> None:
         """Initialize the MeterDataWrapper.
 
@@ -267,6 +270,9 @@ class MeterDataWrapper(MeterData):
             current_per_phase=current_per_phase,
             voltage_per_phase=voltage_per_phase,
             frequency=frequency,
+            states=states,
+            warnings=warnings,
+            errors=errors,
         )
 
     def copy_with_new_timestamp(self, new_timestamp: datetime) -> MeterDataWrapper:

--- a/tests/utils/component_graph_utils.py
+++ b/tests/utils/component_graph_utils.py
@@ -7,10 +7,10 @@
 from dataclasses import dataclass
 
 from frequenz.client.common.microgrid.components import ComponentId
-from frequenz.client.microgrid import (
+from frequenz.client.microgrid.component import (
     Component,
     ComponentCategory,
-    Connection,
+    ComponentConnection,
     InverterType,
 )
 
@@ -40,7 +40,7 @@ class ComponentGraphConfig:
 
 def create_component_graph_structure(
     component_graph_config: ComponentGraphConfig,
-) -> tuple[set[Component], set[Connection]]:
+) -> tuple[set[Component], set[ComponentConnection]]:
     """Create structure of components graph.
 
     Args:
@@ -56,7 +56,7 @@ def create_component_graph_structure(
         Component(grid_id, ComponentCategory.GRID),
         Component(main_meter_id, ComponentCategory.METER),
     }
-    connections = {Connection(grid_id, main_meter_id)}
+    connections = {ComponentConnection(source=grid_id, destination=main_meter_id)}
 
     junction_id = grid_id
     if component_graph_config.grid_side_meter:
@@ -75,9 +75,9 @@ def create_component_graph_structure(
             Component(inv_id, ComponentCategory.INVERTER, InverterType.BATTERY)
         )
 
-        connections.add(Connection(junction_id, meter_id))
-        connections.add(Connection(meter_id, inv_id))
-        connections.add(Connection(inv_id, battery_id))
+        connections.add(ComponentConnection(source=junction_id, destination=meter_id))
+        connections.add(ComponentConnection(source=meter_id, destination=inv_id))
+        connections.add(ComponentConnection(source=inv_id, destination=battery_id))
 
     for _ in range(component_graph_config.solar_inverters_num):
         meter_id = ComponentId(start_idx)
@@ -88,13 +88,13 @@ def create_component_graph_structure(
         components.add(
             Component(inv_id, ComponentCategory.INVERTER, InverterType.SOLAR)
         )
-        connections.add(Connection(junction_id, meter_id))
-        connections.add(Connection(meter_id, inv_id))
+        connections.add(ComponentConnection(source=junction_id, destination=meter_id))
+        connections.add(ComponentConnection(source=meter_id, destination=inv_id))
 
     for _ in range(component_graph_config.ev_chargers):
         ev_id = ComponentId(start_idx)
         start_idx += 1
 
         components.add(Component(ev_id, ComponentCategory.EV_CHARGER))
-        connections.add(Connection(junction_id, ev_id))
+        connections.add(ComponentConnection(source=junction_id, destination=ev_id))
     return components, connections

--- a/tests/utils/component_graph_utils.py
+++ b/tests/utils/component_graph_utils.py
@@ -6,12 +6,17 @@
 
 from dataclasses import dataclass
 
+from frequenz.client.common.microgrid import MicrogridId
 from frequenz.client.common.microgrid.components import ComponentId
 from frequenz.client.microgrid.component import (
+    BatteryInverter,
     Component,
-    ComponentCategory,
     ComponentConnection,
-    InverterType,
+    DcEvCharger,
+    GridConnectionPoint,
+    LiIonBattery,
+    Meter,
+    SolarInverter,
 )
 
 
@@ -49,12 +54,20 @@ def create_component_graph_structure(
     Returns:
         Create set of components and set of connections between them.
     """
+    microgrid_id = MicrogridId(1)
     grid_id = ComponentId(1)
     main_meter_id = ComponentId(2)
 
     components = {
-        Component(grid_id, ComponentCategory.GRID),
-        Component(main_meter_id, ComponentCategory.METER),
+        GridConnectionPoint(
+            id=grid_id,
+            microgrid_id=microgrid_id,
+            rated_fuse_current=1000,
+        ),
+        Meter(
+            id=main_meter_id,
+            microgrid_id=microgrid_id,
+        ),
     }
     connections = {ComponentConnection(source=grid_id, destination=main_meter_id)}
 
@@ -69,11 +82,9 @@ def create_component_graph_structure(
         battery_id = ComponentId(start_idx + 2)
         start_idx += 3
 
-        components.add(Component(meter_id, ComponentCategory.METER))
-        components.add(Component(battery_id, ComponentCategory.BATTERY))
-        components.add(
-            Component(inv_id, ComponentCategory.INVERTER, InverterType.BATTERY)
-        )
+        components.add(Meter(id=meter_id, microgrid_id=microgrid_id))
+        components.add(LiIonBattery(id=battery_id, microgrid_id=microgrid_id))
+        components.add(BatteryInverter(id=inv_id, microgrid_id=microgrid_id))
 
         connections.add(ComponentConnection(source=junction_id, destination=meter_id))
         connections.add(ComponentConnection(source=meter_id, destination=inv_id))
@@ -84,10 +95,8 @@ def create_component_graph_structure(
         inv_id = ComponentId(start_idx + 1)
         start_idx += 2
 
-        components.add(Component(meter_id, ComponentCategory.METER))
-        components.add(
-            Component(inv_id, ComponentCategory.INVERTER, InverterType.SOLAR)
-        )
+        components.add(Meter(id=meter_id, microgrid_id=microgrid_id))
+        components.add(SolarInverter(id=inv_id, microgrid_id=microgrid_id))
         connections.add(ComponentConnection(source=junction_id, destination=meter_id))
         connections.add(ComponentConnection(source=meter_id, destination=inv_id))
 
@@ -95,6 +104,6 @@ def create_component_graph_structure(
         ev_id = ComponentId(start_idx)
         start_idx += 1
 
-        components.add(Component(ev_id, ComponentCategory.EV_CHARGER))
+        components.add(DcEvCharger(id=ev_id, microgrid_id=microgrid_id))
         connections.add(ComponentConnection(source=junction_id, destination=ev_id))
     return components, connections

--- a/tests/utils/graph_generator.py
+++ b/tests/utils/graph_generator.py
@@ -285,13 +285,13 @@ class GraphGenerator:
         if isinstance(children, (Component, ComponentCategory)):
             rhs = self.component(children)
             update_inverter_type(rhs)
-            return [parent, rhs], [Connection(parent.component_id, rhs.component_id)]
+            return [parent, rhs], [Connection(source=parent.id, destination=rhs.id)]
         if isinstance(children, tuple):
             assert len(children) == 2
             comp, con = self._to_graph(self.component(children[0]), children[1])
             update_inverter_type(comp[0])
             return [parent] + comp, con + [
-                Connection(parent.component_id, comp[0].component_id)
+                Connection(source=parent.id, destination=comp[0].id)
             ]
         if isinstance(children, list):
             comp = []
@@ -312,7 +312,7 @@ class GraphGenerator:
                 update_inverter_type(sub_components[0])
                 comp += sub_components
                 con += sub_con + [
-                    Connection(parent.component_id, sub_components[0].component_id)
+                    Connection(source=parent.id, destination=sub_components[0].id)
                 ]
             return [parent] + comp, con
 
@@ -347,26 +347,26 @@ def test_graph_generator_simple() -> None:
     )
 
     meters = list(graph.components(component_categories={ComponentCategory.METER}))
-    meters.sort(key=lambda x: x.component_id)
+    meters.sort(key=lambda x: x.id)
     assert len(meters) == 4
-    assert len(graph.successors(meters[0].component_id)) == 4
-    assert graph.predecessors(meters[1].component_id) == {meters[0]}
-    assert graph.predecessors(meters[2].component_id) == {meters[0]}
-    assert graph.predecessors(meters[3].component_id) == {meters[0]}
+    assert len(graph.successors(meters[0].id)) == 4
+    assert graph.predecessors(meters[1].id) == {meters[0]}
+    assert graph.predecessors(meters[2].id) == {meters[0]}
+    assert graph.predecessors(meters[3].id) == {meters[0]}
 
     inverters = list(
         graph.components(component_categories={ComponentCategory.INVERTER})
     )
-    inverters.sort(key=lambda x: x.component_id)
+    inverters.sort(key=lambda x: x.id)
     assert len(inverters) == 3
 
-    assert len(graph.successors(inverters[0].component_id)) == 0
+    assert len(graph.successors(inverters[0].id)) == 0
     assert inverters[0].type == InverterType.SOLAR
 
-    assert len(graph.successors(inverters[1].component_id)) == 1
+    assert len(graph.successors(inverters[1].id)) == 1
     assert inverters[1].type == InverterType.BATTERY
 
-    assert len(graph.successors(inverters[2].component_id)) == 1
+    assert len(graph.successors(inverters[2].id)) == 1
     assert inverters[2].type == InverterType.BATTERY
 
     assert len(graph.components(component_categories={ComponentCategory.BATTERY})) == 2
@@ -398,15 +398,15 @@ def test_graph_generator_no_grid_meter() -> None:
 
     meters = list(graph.components(component_categories={ComponentCategory.METER}))
     assert len(meters) == 1
-    assert len(graph.successors(meters[0].component_id)) == 1
+    assert len(graph.successors(meters[0].id)) == 1
 
     inverters = list(
         graph.components(component_categories={ComponentCategory.INVERTER})
     )
     assert len(inverters) == 2
 
-    assert len(graph.successors(inverters[0].component_id)) == 1
-    assert len(graph.successors(inverters[1].component_id)) == 1
+    assert len(graph.successors(inverters[0].id)) == 1
+    assert len(graph.successors(inverters[1].id)) == 1
 
     assert len(graph.components(component_categories={ComponentCategory.BATTERY})) == 2
 

--- a/tests/utils/graph_generator.py
+++ b/tests/utils/graph_generator.py
@@ -3,26 +3,40 @@
 
 """Generate graphs from component data structures."""
 
-from dataclasses import replace
-from typing import Any, overload
+from typing import Any, cast
 
+from frequenz.client.common.microgrid import MicrogridId
 from frequenz.client.common.microgrid.components import ComponentId
 from frequenz.client.microgrid.component import (
+    AcEvCharger,
+    Battery,
+    BatteryInverter,
+    Chp,
     Component,
     ComponentCategory,
     ComponentConnection,
-    ComponentType,
-    GridMetadata,
+    DcEvCharger,
+    EvCharger,
+    EvChargerType,
+    GridConnectionPoint,
+    HybridInverter,
+    Inverter,
     InverterType,
+    LiIonBattery,
+    Meter,
+    SolarInverter,
+    UnspecifiedInverter,
 )
 
 from frequenz.sdk.microgrid.component_graph import _MicrogridComponentGraph
+
+_MICROGRID_ID = MicrogridId(1)
 
 
 class GraphGenerator:
     """Utilities to generate graphs from component data structures."""
 
-    SUFFIXES = {
+    SUFFIXES: dict[ComponentCategory, int] = {
         ComponentCategory.CHP: 5,
         ComponentCategory.EV_CHARGER: 6,
         ComponentCategory.METER: 7,
@@ -119,38 +133,10 @@ class GraphGenerator:
             ],
         )
 
-    @overload
-    def component(
-        self, other: Component, comp_type: ComponentType | None = None
-    ) -> Component:
-        """Just return the given component.
-
-        Args:
-            other: the component to return.
-            comp_type: the component type to set, ignored
-
-        Returns:
-            the given component.
-        """
-
-    @overload
-    def component(
-        self, other: ComponentCategory, comp_type: ComponentType | None = None
-    ) -> Component:
-        """Create a new component with the next available id for the given category.
-
-        Args:
-            other: the component category to get the id for.
-            comp_type: the component type to set.
-
-        Returns:
-            the next available component id for the given category.
-        """
-
     def component(
         self,
         other: ComponentCategory | Component,
-        comp_type: ComponentType | None = None,
+        comp_type: InverterType | EvChargerType | None = None,
     ) -> Component:
         """Make or return a new component.
 
@@ -161,13 +147,65 @@ class GraphGenerator:
         Returns:
             the next available component id for the given category.
         """
-        if isinstance(other, Component):
-            return other
-
-        assert isinstance(other, ComponentCategory)
-        category = other
-
-        return Component(self.new_id()[category], category, comp_type)
+        match other:
+            case Component():
+                return other
+            case ComponentCategory.CHP:
+                return Chp(
+                    id=self.new_id()[other],
+                    microgrid_id=_MICROGRID_ID,
+                )
+            case ComponentCategory.METER:
+                return Meter(
+                    id=self.new_id()[other],
+                    microgrid_id=_MICROGRID_ID,
+                )
+            case ComponentCategory.EV_CHARGER:
+                match comp_type:
+                    case EvChargerType.AC:
+                        return AcEvCharger(
+                            id=self.new_id()[other],
+                            microgrid_id=_MICROGRID_ID,
+                        )
+                    case EvChargerType.DC:
+                        return DcEvCharger(
+                            id=self.new_id()[other],
+                            microgrid_id=_MICROGRID_ID,
+                        )
+                    case _:
+                        assert False, "Unsupported EvChargerType"
+            case ComponentCategory.INVERTER:
+                match comp_type:
+                    case None:
+                        # Will probably be updated later based on the children
+                        return UnspecifiedInverter(
+                            id=self.new_id()[other],
+                            microgrid_id=_MICROGRID_ID,
+                        )
+                    case InverterType.BATTERY:
+                        return BatteryInverter(
+                            id=self.new_id()[other],
+                            microgrid_id=_MICROGRID_ID,
+                        )
+                    case InverterType.SOLAR:
+                        return SolarInverter(
+                            id=self.new_id()[other],
+                            microgrid_id=_MICROGRID_ID,
+                        )
+                    case InverterType.HYBRID:
+                        return HybridInverter(
+                            id=self.new_id()[other],
+                            microgrid_id=_MICROGRID_ID,
+                        )
+                    case _:
+                        assert False, "Unsupported InverterType"
+            case ComponentCategory.BATTERY:
+                return LiIonBattery(
+                    id=self.new_id()[other],
+                    microgrid_id=_MICROGRID_ID,
+                )
+            case _:
+                assert False, "Unsupported ComponentCategory"
 
     def components(self, *component_categories: ComponentCategory) -> list[Component]:
         """Create a list of components with the next available id for each category.
@@ -181,14 +219,16 @@ class GraphGenerator:
         return [self.component(category) for category in component_categories]
 
     @staticmethod
-    def grid() -> Component:
+    def grid() -> GridConnectionPoint:
         """Get a new grid component with default id.
 
         Returns:
             a new grid component with default id.
         """
-        return Component(
-            ComponentId(1), ComponentCategory.GRID, None, GridMetadata(None)
+        return GridConnectionPoint(
+            id=ComponentId(1),
+            microgrid_id=_MICROGRID_ID,
+            rated_fuse_current=1_000_000,
         )
 
     def to_graph(self, components: Any) -> _MicrogridComponentGraph:
@@ -271,16 +311,23 @@ class GraphGenerator:
             ValueError: if the input is invalid.
         """
 
-        def inverter_type(category: ComponentCategory) -> InverterType | None:
-            if category == ComponentCategory.BATTERY:
-                return InverterType.BATTERY
-            return None
-
         def update_inverter_type(successor: Component) -> None:
             nonlocal parent
-            if parent.category == ComponentCategory.INVERTER:
-                if comp_type := inverter_type(successor.category):
-                    parent = replace(parent, type=comp_type)
+            if isinstance(parent, Inverter):
+                match successor.category:
+                    case ComponentCategory.BATTERY:
+                        parent = BatteryInverter(
+                            id=parent.id,
+                            microgrid_id=parent.microgrid_id,
+                            operational_lifetime=parent.operational_lifetime,
+                            name=parent.name,
+                            manufacturer=parent.manufacturer,
+                            model_name=parent.model_name,
+                            rated_bounds=parent.rated_bounds,
+                            category_specific_metadata=parent.category_specific_metadata,
+                        )
+                    case _:
+                        pass
 
         if isinstance(children, (Component, ComponentCategory)):
             rhs = self.component(children)

--- a/tests/utils/graph_generator.py
+++ b/tests/utils/graph_generator.py
@@ -346,7 +346,7 @@ def test_graph_generator_simple() -> None:
         )
     )
 
-    meters = list(graph.components(matching_types={Meter}))
+    meters = list(graph.components(matching_types=Meter))
     meters.sort(key=lambda x: x.id)
     assert len(meters) == 4
     assert len(graph.successors(meters[0].id)) == 4
@@ -356,7 +356,7 @@ def test_graph_generator_simple() -> None:
 
     inverters: list[Inverter] = cast(
         list[Inverter],
-        list(graph.components(matching_types={Inverter})),
+        list(graph.components(matching_types=Inverter)),
     )
     inverters.sort(key=lambda x: x.id)
     assert len(inverters) == 3
@@ -370,8 +370,8 @@ def test_graph_generator_simple() -> None:
     assert len(graph.successors(inverters[2].id)) == 1
     assert inverters[2].type == InverterType.BATTERY
 
-    assert len(graph.components(matching_types={Battery})) == 2
-    assert len(graph.components(matching_types={EvCharger})) == 1
+    assert len(graph.components(matching_types=Battery)) == 2
+    assert len(graph.components(matching_types=EvCharger)) == 1
 
     graph.validate()
 
@@ -397,20 +397,20 @@ def test_graph_generator_no_grid_meter() -> None:
 
     meters: list[Meter] = cast(
         list[Meter],
-        list(graph.components(matching_types={Meter})),
+        list(graph.components(matching_types=Meter)),
     )
     assert len(meters) == 1
     assert len(graph.successors(meters[0].id)) == 1
 
     inverters: list[Inverter] = cast(
         list[Inverter],
-        list(graph.components(matching_types={Inverter})),
+        list(graph.components(matching_types=Inverter)),
     )
     assert len(inverters) == 2
 
     assert len(graph.successors(inverters[0].id)) == 1
     assert len(graph.successors(inverters[1].id)) == 1
 
-    assert len(graph.components(matching_types={Battery})) == 2
+    assert len(graph.components(matching_types=Battery)) == 2
 
     graph.validate()

--- a/tests/utils/graph_generator.py
+++ b/tests/utils/graph_generator.py
@@ -346,7 +346,7 @@ def test_graph_generator_simple() -> None:
         )
     )
 
-    meters = list(graph.components(component_categories={ComponentCategory.METER}))
+    meters = list(graph.components(matching_types={Meter}))
     meters.sort(key=lambda x: x.id)
     assert len(meters) == 4
     assert len(graph.successors(meters[0].id)) == 4
@@ -354,8 +354,9 @@ def test_graph_generator_simple() -> None:
     assert graph.predecessors(meters[2].id) == {meters[0]}
     assert graph.predecessors(meters[3].id) == {meters[0]}
 
-    inverters = list(
-        graph.components(component_categories={ComponentCategory.INVERTER})
+    inverters: list[Inverter] = cast(
+        list[Inverter],
+        list(graph.components(matching_types={Inverter})),
     )
     inverters.sort(key=lambda x: x.id)
     assert len(inverters) == 3
@@ -369,10 +370,8 @@ def test_graph_generator_simple() -> None:
     assert len(graph.successors(inverters[2].id)) == 1
     assert inverters[2].type == InverterType.BATTERY
 
-    assert len(graph.components(component_categories={ComponentCategory.BATTERY})) == 2
-    assert (
-        len(graph.components(component_categories={ComponentCategory.EV_CHARGER})) == 1
-    )
+    assert len(graph.components(matching_types={Battery})) == 2
+    assert len(graph.components(matching_types={EvCharger})) == 1
 
     graph.validate()
 
@@ -396,18 +395,22 @@ def test_graph_generator_no_grid_meter() -> None:
         ]
     )
 
-    meters = list(graph.components(component_categories={ComponentCategory.METER}))
+    meters: list[Meter] = cast(
+        list[Meter],
+        list(graph.components(matching_types={Meter})),
+    )
     assert len(meters) == 1
     assert len(graph.successors(meters[0].id)) == 1
 
-    inverters = list(
-        graph.components(component_categories={ComponentCategory.INVERTER})
+    inverters: list[Inverter] = cast(
+        list[Inverter],
+        list(graph.components(matching_types={Inverter})),
     )
     assert len(inverters) == 2
 
     assert len(graph.successors(inverters[0].id)) == 1
     assert len(graph.successors(inverters[1].id)) == 1
 
-    assert len(graph.components(component_categories={ComponentCategory.BATTERY})) == 2
+    assert len(graph.components(matching_types={Battery})) == 2
 
     graph.validate()

--- a/tests/utils/graph_generator.py
+++ b/tests/utils/graph_generator.py
@@ -7,11 +7,11 @@ from dataclasses import replace
 from typing import Any, overload
 
 from frequenz.client.common.microgrid.components import ComponentId
-from frequenz.client.microgrid import (
+from frequenz.client.microgrid.component import (
     Component,
     ComponentCategory,
+    ComponentConnection,
     ComponentType,
-    Connection,
     GridMetadata,
     InverterType,
 )
@@ -257,7 +257,7 @@ class GraphGenerator:
 
     def _to_graph(
         self, parent: Component, children: Any
-    ) -> tuple[list[Component], list[Connection]]:
+    ) -> tuple[list[Component], list[ComponentConnection]]:
         """Convert a list of components to a graph.
 
         Args:
@@ -285,20 +285,22 @@ class GraphGenerator:
         if isinstance(children, (Component, ComponentCategory)):
             rhs = self.component(children)
             update_inverter_type(rhs)
-            return [parent, rhs], [Connection(source=parent.id, destination=rhs.id)]
+            return [parent, rhs], [
+                ComponentConnection(source=parent.id, destination=rhs.id)
+            ]
         if isinstance(children, tuple):
             assert len(children) == 2
             comp, con = self._to_graph(self.component(children[0]), children[1])
             update_inverter_type(comp[0])
             return [parent] + comp, con + [
-                Connection(source=parent.id, destination=comp[0].id)
+                ComponentConnection(source=parent.id, destination=comp[0].id)
             ]
         if isinstance(children, list):
             comp = []
             con = []
             for _component in children:
                 sub_components: list[Component]
-                sub_con: list[Connection]
+                sub_con: list[ComponentConnection]
 
                 if isinstance(_component, tuple):
                     sub_parent = self.component(_component[0])
@@ -312,7 +314,9 @@ class GraphGenerator:
                 update_inverter_type(sub_components[0])
                 comp += sub_components
                 con += sub_con + [
-                    Connection(source=parent.id, destination=sub_components[0].id)
+                    ComponentConnection(
+                        source=parent.id, destination=sub_components[0].id
+                    )
                 ]
             return [parent] + comp, con
 

--- a/tests/utils/mock_microgrid_client.py
+++ b/tests/utils/mock_microgrid_client.py
@@ -2,32 +2,36 @@
 # Copyright © 2023 Frequenz Energy-as-a-Service GmbH
 
 """Mock microgrid definition."""
-from functools import partial
-from typing import Any
+
+from collections.abc import Iterable
+from dataclasses import dataclass
 from unittest.mock import AsyncMock, MagicMock
 
-from frequenz.channels import Broadcast, Receiver
+from frequenz.channels import Broadcast, Receiver, Sender
 from frequenz.client.common.microgrid import MicrogridId
 from frequenz.client.common.microgrid.components import ComponentId
-from frequenz.client.microgrid import (
-    BatteryData,
+from frequenz.client.microgrid import Location, MicrogridApiClient
+from frequenz.client.microgrid.component import (
     Component,
-    ComponentCategory,
-    ComponentData,
-    Connection,
-    EVChargerData,
-    InverterData,
-    Location,
-    MeterData,
+    ComponentConnection,
+    ComponentDataSamples,
 )
+from frequenz.client.microgrid.metrics import Metric
 from pytest_mock import MockerFixture
 
-from frequenz.sdk._internal._constants import RECEIVER_MAX_SIZE
 from frequenz.sdk.microgrid.component_graph import (
     ComponentGraph,
     _MicrogridComponentGraph,
 )
 from frequenz.sdk.microgrid.connection_manager import ConnectionManager
+
+
+@dataclass(frozen=True)
+class ComponentDataReceiverKey:
+    """Key for the component data receiver."""
+
+    component_id: ComponentId
+    metrics: frozenset[Metric | int]
 
 
 class MockMicrogridClient:
@@ -36,9 +40,11 @@ class MockMicrogridClient:
     def __init__(
         self,
         components: set[Component],
-        connections: set[Connection],
+        connections: set[ComponentConnection],
         microgrid_id: MicrogridId = MicrogridId(8),
-        location: Location = Location(latitude=52.520008, longitude=13.404954),
+        location: Location = Location(
+            latitude=52.520008, longitude=13.404954, country_code="DE"
+        ),
     ):
         """Create mock microgrid with given components and connections.
 
@@ -55,44 +61,22 @@ class MockMicrogridClient:
             location: the location of the microgrid
         """
         self._component_graph = _MicrogridComponentGraph(components, connections)
-
         self._components = components
+        self._connections = connections
+        self._component_data_channels: dict[
+            ComponentDataReceiverKey, Broadcast[ComponentDataSamples]
+        ] = {}
+        self._component_data_senders: dict[
+            ComponentDataReceiverKey, Sender[ComponentDataSamples]
+        ] = {}
 
-        bat_channels = self._create_battery_channels()
-        inv_channels = self._create_inverter_channels()
-        meter_channels = self._create_meter_channels()
-        ev_charger_channels = self._create_ev_charger_channels()
-
-        self._all_channels: dict[ComponentId, Broadcast[Any]] = {
-            **bat_channels,
-            **inv_channels,
-            **meter_channels,
-            **ev_charger_channels,
-        }
-
-        mock_api = self._create_mock_api(
-            bat_channels, inv_channels, meter_channels, ev_charger_channels
+        self._mock_microgrid = MagicMock(
+            spec=ConnectionManager,
+            api_client=self._create_mock_api(),
+            component_graph=self._component_graph,
+            microgrid_id=microgrid_id,
+            location=location,
         )
-        kwargs: dict[str, Any] = {
-            "api_client": mock_api,
-            "component_graph": self._component_graph,
-            "microgrid_id": microgrid_id,
-            "location": location,
-        }
-
-        self._mock_microgrid = MagicMock(spec=ConnectionManager, **kwargs)
-        self._battery_data_senders = {
-            id: channel.new_sender() for id, channel in bat_channels.items()
-        }
-        self._inverter_data_senders = {
-            id: channel.new_sender() for id, channel in inv_channels.items()
-        }
-        self._meter_data_senders = {
-            id: channel.new_sender() for id, channel in meter_channels.items()
-        }
-        self._ev_charger_data_senders = {
-            id: channel.new_sender() for id, channel in ev_charger_channels.items()
-        }
 
     def initialize(self, mocker: MockerFixture) -> None:
         """Mock `microgrid.get` call to return this mock_microgrid.
@@ -128,244 +112,81 @@ class MockMicrogridClient:
         """
         return self._component_graph
 
-    # We need the noqa because the `SenderError` is raised indirectly by `send()`.
-    async def send(self, data: ComponentData) -> None:  # noqa: DOC503
+    async def send(self, data: ComponentDataSamples) -> None:
         """Send component data using channel.
 
         This simulates component sending data. Right now only battery and inverter
         are supported. More components categories can be added if needed.
 
         Args:
-            data: Data to be send
-
-        Raises:
-            RuntimeError: if the type of data is not supported.
-            SenderError: if the underlying channel was closed.
-                A [ChannelClosedError][frequenz.channels.ChannelClosedError] is
-                set as the cause.
+            data: Data to be sent.
         """
-        cid = data.component_id
-        if isinstance(data, BatteryData):
-            await self._battery_data_senders[cid].send(data)
-        elif isinstance(data, InverterData):
-            await self._inverter_data_senders[cid].send(data)
-        elif isinstance(data, MeterData):
-            await self._meter_data_senders[cid].send(data)
-        elif isinstance(data, EVChargerData):
-            await self._ev_charger_data_senders[cid].send(data)
-        else:
-            raise RuntimeError(f"{type(data)} is not supported in MockMicrogridClient.")
+        key = ComponentDataReceiverKey(
+            data.component_id, frozenset(s.metric for s in data.metric_samples)
+        )
+        sender = self._component_data_senders.get(key)
 
-    async def close_channel(self, cid: ComponentId) -> None:
+        if sender is None:
+            sender = self._get_chan(key).new_sender()
+            self._component_data_senders[key] = sender
+
+        await sender.send(data)
+
+    async def close_channels(self, cid: ComponentId) -> None:
         """Close channel for given component id.
 
         Args:
             cid: Component id
         """
-        if cid in self._all_channels:
-            await self._all_channels[cid].close()
+        for key, channel in self._component_data_channels.items():
+            if key.component_id == cid:
+                await channel.close()
 
-    def _create_battery_channels(self) -> dict[ComponentId, Broadcast[BatteryData]]:
-        """Create channels for the batteries.
-
-        Returns:
-            Dictionary where the key is battery id and the value is channel for this
-                battery.
-        """
-        batteries = [
-            c.component_id
-            for c in self.component_graph.components(
-                component_categories={ComponentCategory.BATTERY}
-            )
-        ]
-
-        return {
-            bid: Broadcast[BatteryData](name="battery_data_" + str(bid))
-            for bid in batteries
-        }
-
-    def _create_meter_channels(self) -> dict[ComponentId, Broadcast[MeterData]]:
-        """Create channels for the meters.
-
-        Returns:
-            Dictionary where the key is meter id and the value is channel for this
-                meter.
-        """
-        meters = [
-            c.component_id
-            for c in self.component_graph.components(
-                component_categories={ComponentCategory.METER}
-            )
-        ]
-
-        return {
-            cid: Broadcast[MeterData](name="meter_data_" + str(cid)) for cid in meters
-        }
-
-    def _create_inverter_channels(self) -> dict[ComponentId, Broadcast[InverterData]]:
-        """Create channels for the inverters.
-
-        Returns:
-            Dictionary where the key is inverter id and the value is channel for
-                this inverter.
-        """
-        inverters = [
-            c.component_id
-            for c in self.component_graph.components(
-                component_categories={ComponentCategory.INVERTER}
-            )
-        ]
-
-        return {
-            cid: Broadcast[InverterData](name="inverter_data_" + str(cid))
-            for cid in inverters
-        }
-
-    def _create_ev_charger_channels(
-        self,
-    ) -> dict[ComponentId, Broadcast[EVChargerData]]:
-        """Create channels for the ev chargers.
-
-        Returns:
-            Dictionary where the key is the id of the ev_charger and the value is
-                channel for this ev_charger.
-        """
-        meters = [
-            c.component_id
-            for c in self.component_graph.components(
-                component_categories={ComponentCategory.EV_CHARGER}
-            )
-        ]
-
-        return {
-            cid: Broadcast[EVChargerData](name="meter_data_" + str(cid))
-            for cid in meters
-        }
-
-    def _create_mock_api(
-        self,
-        bat_channels: dict[ComponentId, Broadcast[BatteryData]],
-        inv_channels: dict[ComponentId, Broadcast[InverterData]],
-        meter_channels: dict[ComponentId, Broadcast[MeterData]],
-        ev_charger_channels: dict[ComponentId, Broadcast[EVChargerData]],
-    ) -> MagicMock:
+    def _create_mock_api(self) -> MagicMock:
         """Create mock of MicrogridApiClient.
-
-        Args:
-            bat_channels: battery channels to be returned from
-                MicrogridApiClient.battery_data.
-            inv_channels: inverter channels to be returned from
-                MicrogridApiClient.inverter_data.
-            meter_channels: meter channels to be returned from
-                MicrogridApiClient.meter_data.
-            ev_charger_channels: ev_charger channels to be returned from
-                MicrogridApiClient.ev_charger_data.
 
         Returns:
             Magic mock instance of MicrogridApiClient.
         """
-        api = MagicMock()
-        api.components = AsyncMock(return_value=self._components)
-        # NOTE that has to be partial, because battery_data has id argument and takes
-        # channel based on the argument.
-        api.battery_data = AsyncMock(
-            side_effect=partial(self._get_battery_receiver, channels=bat_channels)
+        api = MagicMock(spec=MicrogridApiClient)
+        api.list_components = AsyncMock(return_value=list(self._components))
+        api.list_connections = AsyncMock(return_value=list(self._connections))
+
+        # Replace individual data methods with the new unified stream method
+        api.receive_component_data_samples_stream = MagicMock(
+            side_effect=self._mock_receiver_component_data_samples_stream
         )
 
-        api.inverter_data = AsyncMock(
-            side_effect=partial(self._get_inverter_receiver, channels=inv_channels)
-        )
-
-        api.meter_data = AsyncMock(
-            side_effect=partial(self._get_meter_receiver, channels=meter_channels)
-        )
-
-        api.ev_charger_data = AsyncMock(
-            side_effect=partial(
-                self._get_ev_charger_receiver, channels=ev_charger_channels
-            )
-        )
-
-        # Can be override in the future
-        api.set_power = AsyncMock(return_value=None)
+        # Can be overridden in the future
+        api.set_component_power_active = AsyncMock(return_value=None)
         return api
 
-    def _get_battery_receiver(
+    def _mock_receiver_component_data_samples_stream(
         self,
-        component_id: ComponentId,
-        channels: dict[ComponentId, Broadcast[BatteryData]],
-        maxsize: int = RECEIVER_MAX_SIZE,
-    ) -> Receiver[BatteryData]:
-        """Return receiver of the broadcast channel for given component_id.
+        component: ComponentId | Component,
+        metrics: Iterable[Metric | int],
+        *,
+        buffer_size: int = 50,
+    ) -> Receiver[ComponentDataSamples]:
+        component_id = component if isinstance(component, ComponentId) else component.id
+        if component_id not in map(lambda c: c.id, self._components):
+            raise ValueError(f"Unknown {component_id}")
 
-        Args:
-            component_id: component_id
-            channels: Broadcast channels
-            maxsize: Max size of the channel
+        key = ComponentDataReceiverKey(component_id, frozenset(metrics))
+        return self._get_chan(key).new_receiver(limit=buffer_size)
 
-        Returns:
-            Receiver from the given channels.
-        """
-        return channels[component_id].new_receiver(
-            name="component" + str(component_id), limit=maxsize
+    def _get_chan(
+        self, key: ComponentDataReceiverKey
+    ) -> Broadcast[ComponentDataSamples]:
+        if chan := self._component_data_channels.get(key):
+            return chan
+
+        metrics_str = ":".join(
+            map(lambda m: m.name if isinstance(m, Metric) else str(m), key.metrics)
         )
-
-    def _get_meter_receiver(
-        self,
-        component_id: ComponentId,
-        channels: dict[ComponentId, Broadcast[MeterData]],
-        maxsize: int = RECEIVER_MAX_SIZE,
-    ) -> Receiver[MeterData]:
-        """Return receiver of the broadcast channel for given component_id.
-
-        Args:
-            component_id: component_id
-            channels: Broadcast channels
-            maxsize: Max size of the channel
-
-        Returns:
-            Receiver from the given channels.
-        """
-        return channels[component_id].new_receiver(
-            name="component" + str(component_id), limit=maxsize
+        chan = Broadcast[ComponentDataSamples](
+            name=f"mock_stream:{key.component_id}:{metrics_str}"
         )
+        self._component_data_channels[key] = chan
 
-    def _get_ev_charger_receiver(
-        self,
-        component_id: ComponentId,
-        channels: dict[ComponentId, Broadcast[EVChargerData]],
-        maxsize: int = RECEIVER_MAX_SIZE,
-    ) -> Receiver[EVChargerData]:
-        """Return receiver of the broadcast channel for given component_id.
-
-        Args:
-            component_id: component_id
-            channels: Broadcast channels
-            maxsize: Max size of the channel
-
-        Returns:
-            Receiver from the given channels.
-        """
-        return channels[component_id].new_receiver(
-            name="component" + str(component_id), limit=maxsize
-        )
-
-    def _get_inverter_receiver(
-        self,
-        component_id: ComponentId,
-        channels: dict[ComponentId, Broadcast[InverterData]],
-        maxsize: int = RECEIVER_MAX_SIZE,
-    ) -> Receiver[InverterData]:
-        """Return receiver of the broadcast channel for given component_id.
-
-        Args:
-            component_id: component_id
-            channels: Broadcast channels
-            maxsize: Max size of the channel
-
-        Returns:
-            Receiver from the given channels.
-        """
-        return channels[component_id].new_receiver(
-            name="component" + str(component_id), limit=maxsize
-        )
+        return chan


### PR DESCRIPTION
This PR migrates the SDK from the old `frequenz-client-microgrid` using the old microgrid API v0.15 to the new using the API v0.18. The main changes involve updating component models, metrics, and data fetching mechanisms to use the new client library structure.