### PR TITLE
Minor improvements and cleanups

### DIFF
--- a/docs/user-guide/glossary.md
+++ b/docs/user-guide/glossary.md
@@ -58,8 +58,8 @@ article](https://en.wikipedia.org/wiki/State_of_charge) for more details.
 
 A local electrical grid that connects a set of different [types of
 components](#component-category) together. It can be connected to the public
-[grid](#grid), or be completely isolated, in which case it is known as an
-island.
+[grid](#grid) (through a [grid connection point](#grid-connection-point)), or be completely isolated, in which case
+it is known as an island.
 
 Components can be grouped into [assets](#assets) and [devices](#devices).
 Assets are core components like generators or storage systems that are crucial from a business perspective,
@@ -104,6 +104,15 @@ A station for charging [EVs](#ev).
 #### Electrolyzer
 
 A device that converts water into hydrogen and oxygen.
+
+#### Grid Connection Point
+
+The point where the local [microgrid](#microgrid) is connected to the public
+electricity [grid](#grid).
+
+#### GCP
+
+[Grid connection point](#grid-connection-point).
 
 #### Grid
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,7 @@ dev-mypy = [
   "types-Markdown == 3.9.0.20250906",
   "types-protobuf == 6.32.1.20250918",
   "types-setuptools == 80.9.0.20250822",
+  "types-networkx == 3.5.0.20251106",
   # For checking the noxfile, docs/ script, and tests
   "frequenz-sdk[dev-mkdocs,dev-noxfile,dev-pytest]",
 ]
@@ -204,13 +205,7 @@ files = ["src", "tests", "examples", "benchmarks", "docs", "noxfile.py"]
 strict = true
 
 [[tool.mypy.overrides]]
-module = [
-  "async_solipsism",
-  "mkdocs_macros.*",
-  # The available stubs packages are outdated or incomplete (WIP/experimental):
-  # https://github.com/frequenz-floss/frequenz-sdk-python/issues/430
-  "networkx",
-]
+module = ["async_solipsism", "mkdocs_macros.*"]
 ignore_missing_imports = true
 
 [tool.setuptools_scm]

--- a/src/frequenz/sdk/microgrid/__init__.py
+++ b/src/frequenz/sdk/microgrid/__init__.py
@@ -32,7 +32,7 @@ flowchart LR
 
 subgraph Left[Measurements only]
 direction LR
-  grid["Grid Connection"]
+  grid["Grid Connection Point"]
   consumer["Consumer"]
   pv["PV Arrays"]
   chp["CHP"]
@@ -57,12 +57,12 @@ junction --- ev
 
 ## Grid
 
-This refers to a microgrid's connection to the external Grid.  The power flowing through
-this connection can be streamed through
+This refers to a microgrid's {{glossary("grid-connection-point")}}.  The power flowing
+through this connection can be streamed through
 [`grid_power`][frequenz.sdk.timeseries.grid.Grid.power].
 
-In locations without a grid connection, this method remains accessible, and streams zero
-values.
+In locations without a grid connection point, this method remains accessible, and
+streams zero values.
 
 ## Consumer
 

--- a/src/frequenz/sdk/microgrid/_power_distributing/_component_managers/_battery_manager.py
+++ b/src/frequenz/sdk/microgrid/_power_distributing/_component_managers/_battery_manager.py
@@ -609,7 +609,7 @@ class BatteryManager(ComponentManager):  # pylint: disable=too-many-instance-att
         for inverter_ids in [
             self._bat_invs_map[battery_id_set] for battery_id_set in unavailable_bat_ids
         ]:
-            unavailable_inv_ids = unavailable_inv_ids.union(inverter_ids)
+            unavailable_inv_ids = unavailable_inv_ids | inverter_ids
 
         result = self._distribution_algorithm.distribute_power(
             request.power, inv_bat_pairs

--- a/src/frequenz/sdk/microgrid/_power_distributing/_component_status/_battery_status_tracker.py
+++ b/src/frequenz/sdk/microgrid/_power_distributing/_component_status/_battery_status_tracker.py
@@ -100,25 +100,25 @@ class BatteryStatusTracker(ComponentStatusTracker, BackgroundService):
     @override
     def __init__(  # pylint: disable=too-many-arguments
         self,
-        *,
         component_id: ComponentId,
-        max_data_age: timedelta,
-        max_blocking_duration: timedelta,
         status_sender: Sender[ComponentStatus],
         set_power_result_receiver: Receiver[SetPowerResult],
+        *,
+        max_data_age: timedelta,
+        max_blocking_duration: timedelta,
     ) -> None:
         """Create class instance.
 
         Args:
             component_id: Id of this battery
+            status_sender: Channel to send status updates.
+            set_power_result_receiver: Channel to receive results of the requests to the
+                components.
             max_data_age: If component stopped sending data, then this is the maximum
                 time when its last message should be considered as valid. After that
                 time, component won't be used until it starts sending data.
             max_blocking_duration: This value tell what should be the maximum
                 timeout used for blocking failing component.
-            status_sender: Channel to send status updates.
-            set_power_result_receiver: Channel to receive results of the requests to the
-                components.
 
         Raises:
             RuntimeError: If battery has no adjacent inverter.

--- a/src/frequenz/sdk/microgrid/_power_distributing/_component_status/_component_status.py
+++ b/src/frequenz/sdk/microgrid/_power_distributing/_component_status/_component_status.py
@@ -88,23 +88,23 @@ class ComponentStatusTracker(BackgroundService, ABC):
     @abstractmethod
     def __init__(  # pylint: disable=too-many-arguments,super-init-not-called
         self,
-        *,
         component_id: ComponentId,
-        max_data_age: timedelta,
-        max_blocking_duration: timedelta,
         status_sender: Sender[ComponentStatus],
         set_power_result_receiver: Receiver[SetPowerResult],
+        *,
+        max_data_age: timedelta,
+        max_blocking_duration: timedelta,
     ) -> None:
         """Create class instance.
 
         Args:
             component_id: Id of this component
+            status_sender: Channel to send status updates.
+            set_power_result_receiver: Channel to receive results of the requests to the
+                components.
             max_data_age: If component stopped sending data, then this is the maximum
                 time when its last message should be considered as valid. After that
                 time, component won't be used until it starts sending data.
             max_blocking_duration: This value tell what should be the maximum
                 timeout used for blocking failing component.
-            status_sender: Channel to send status updates.
-            set_power_result_receiver: Channel to receive results of the requests to the
-                components.
         """

--- a/src/frequenz/sdk/microgrid/_power_distributing/_component_status/_ev_charger_status_tracker.py
+++ b/src/frequenz/sdk/microgrid/_power_distributing/_component_status/_ev_charger_status_tracker.py
@@ -44,25 +44,25 @@ class EVChargerStatusTracker(ComponentStatusTracker, BackgroundService):
     @override
     def __init__(  # pylint: disable=too-many-arguments
         self,
-        *,
         component_id: ComponentId,
-        max_data_age: timedelta,
-        max_blocking_duration: timedelta,
         status_sender: Sender[ComponentStatus],
         set_power_result_receiver: Receiver[SetPowerResult],
+        *,
+        max_data_age: timedelta,
+        max_blocking_duration: timedelta,
     ) -> None:
         """Initialize this instance.
 
         Args:
             component_id: ID of the EV charger to monitor the status of.
-            max_data_age: max duration to wait for, before marking a component as
-                NOT_WORKING, unless new data arrives.
-            max_blocking_duration: duration for which the component status should be
-                UNCERTAIN if a request to the component failed unexpectedly.
             status_sender: Channel sender to send status updates to.
             set_power_result_receiver: Receiver to fetch PowerDistributor responses
                 from, to get the status of the most recent request made for an EV
                 Charger.
+            max_data_age: max duration to wait for, before marking a component as
+                NOT_WORKING, unless new data arrives.
+            max_blocking_duration: duration for which the component status should be
+                UNCERTAIN if a request to the component failed unexpectedly.
         """
         self._component_id = component_id
         self._max_data_age = max_data_age

--- a/src/frequenz/sdk/microgrid/component_graph.py
+++ b/src/frequenz/sdk/microgrid/component_graph.py
@@ -1120,6 +1120,11 @@ class _MicrogridComponentGraph(
                 f"Leaf components with graph successors: {with_successors}"
             )
 
+    @override
+    def __repr__(self) -> str:
+        """Return a string representation of the component graph."""
+        return f"ComponentGraph({self._graph!r})"
+
 
 def _comp_ids_to_iter(
     ids: Iterable[ComponentId] | ComponentId | None,

--- a/src/frequenz/sdk/microgrid/component_graph.py
+++ b/src/frequenz/sdk/microgrid/component_graph.py
@@ -369,7 +369,7 @@ class _MicrogridComponentGraph(
             InvalidGraphError: If `components` and `connections` are not both `None`
                 and either of them is either `None` or empty.
         """
-        self._graph: nx.DiGraph = nx.DiGraph()
+        self._graph: nx.DiGraph[ComponentId] = nx.DiGraph()
 
         if components is None and connections is None:
             return
@@ -437,6 +437,7 @@ class _MicrogridComponentGraph(
         """
         matching_sources = _comp_ids_to_iter(matching_sources)
         matching_destinations = _comp_ids_to_iter(matching_destinations)
+        selection: Iterable[tuple[ComponentId, ComponentId]]
 
         match (matching_sources, matching_destinations):
             case (None, None):
@@ -536,7 +537,7 @@ class _MicrogridComponentGraph(
         if issues:
             raise InvalidGraphError(f"Invalid component data: {', '.join(issues)}")
 
-        new_graph = nx.DiGraph()
+        new_graph: nx.DiGraph[ComponentId] = nx.DiGraph()
         new_graph.add_nodes_from(
             (component.id, {_DATA_KEY: component}) for component in components
         )

--- a/src/frequenz/sdk/microgrid/connection_manager.py
+++ b/src/frequenz/sdk/microgrid/connection_manager.py
@@ -172,16 +172,12 @@ async def initialize(server_url: str) -> None:
             where the port should be an int between `0` and `65535` (defaulting to
             `9090`) and ssl should be a boolean (defaulting to false). For example:
             `grpc://localhost:1090?ssl=true`.
-
-    Raises:
-        AssertionError: If method was called more then once.
     """
     # From Doc: pylint just try to discourage this usage.
     # That doesn't mean you cannot use it.
     global _CONNECTION_MANAGER  # pylint: disable=global-statement
 
-    if _CONNECTION_MANAGER is not None:
-        raise AssertionError("MicrogridApi was already initialized.")
+    assert _CONNECTION_MANAGER is None, "MicrogridApi was already initialized."
 
     _logger.info("Connecting to microgrid at %s", server_url)
 
@@ -190,8 +186,7 @@ async def initialize(server_url: str) -> None:
 
     # Check again that _MICROGRID_API is None in case somebody had the great idea of
     # calling initialize() twice and in parallel.
-    if _CONNECTION_MANAGER is not None:
-        raise AssertionError("MicrogridApi was already initialized.")
+    assert _CONNECTION_MANAGER is None, "MicrogridApi was already initialized."
 
     _CONNECTION_MANAGER = microgrid_api
 

--- a/src/frequenz/sdk/microgrid/connection_manager.py
+++ b/src/frequenz/sdk/microgrid/connection_manager.py
@@ -46,7 +46,7 @@ class ConnectionManager(ABC):
         """Get the MicrogridApiClient.
 
         Returns:
-            api client
+            The microgrid API client used by this connection manager.
         """
 
     @property
@@ -181,14 +181,14 @@ async def initialize(server_url: str) -> None:
 
     _logger.info("Connecting to microgrid at %s", server_url)
 
-    microgrid_api = _InsecureConnectionManager(server_url)
-    await microgrid_api._initialize()  # pylint: disable=protected-access
+    connection_manager = _InsecureConnectionManager(server_url)
+    await connection_manager._initialize()  # pylint: disable=protected-access
 
     # Check again that _MICROGRID_API is None in case somebody had the great idea of
     # calling initialize() twice and in parallel.
     assert _CONNECTION_MANAGER is None, "MicrogridApi was already initialized."
 
-    _CONNECTION_MANAGER = microgrid_api
+    _CONNECTION_MANAGER = connection_manager
 
 
 def get() -> ConnectionManager:

--- a/src/frequenz/sdk/timeseries/battery_pool/_methods.py
+++ b/src/frequenz/sdk/timeseries/battery_pool/_methods.py
@@ -252,11 +252,8 @@ class SendOnUpdate(MetricAggregator[T]):
                 latest_calculation_result = result
                 await sender.send(result)
 
-                if result is None:
-                    sleep_for = min_update_interval.total_seconds()
-                else:
-                    # Sleep for the rest of the time.
-                    # Then we won't send update more frequently then min_update_interval
-                    time_diff = datetime.now(tz=timezone.utc) - result.timestamp
-                    sleep_for = (min_update_interval - time_diff).total_seconds()
+                # Sleep for the rest of the time.
+                # Then we won't send update more frequently than min_update_interval
+                time_diff = datetime.now(tz=timezone.utc) - result.timestamp
+                sleep_for = (min_update_interval - time_diff).total_seconds()
                 await asyncio.sleep(sleep_for)

--- a/tests/timeseries/_battery_pool/test_battery_pool.py
+++ b/tests/timeseries/_battery_pool/test_battery_pool.py
@@ -278,6 +278,7 @@ async def run_scenarios(
         AssertionError: If received metric is not as expected.
     """
     for idx, scenario in enumerate(scenarios):
+        _logger.info("Testing scenario: %d", idx)
         # Update data stream
         old_data = streamer.get_current_component_data(scenario.component_id)
         new_data = replace(old_data, **scenario.new_metrics)

--- a/tests/timeseries/_battery_pool/test_battery_pool_control_methods.py
+++ b/tests/timeseries/_battery_pool/test_battery_pool_control_methods.py
@@ -5,7 +5,7 @@
 
 import asyncio
 import dataclasses
-import typing
+from collections.abc import AsyncIterator, Callable
 from datetime import datetime, timedelta, timezone
 from typing import cast
 from unittest.mock import AsyncMock, MagicMock
@@ -55,7 +55,7 @@ class Mocks:
 
 
 @pytest.fixture
-async def mocks(mocker: MockerFixture) -> typing.AsyncIterator[Mocks]:
+async def mocks(mocker: MockerFixture) -> AsyncIterator[Mocks]:
     """Fixture for the mocks."""
     mockgrid = MockMicrogrid()
     mockgrid.add_batteries(4)
@@ -168,7 +168,7 @@ class TestBatteryPoolControl:
         upper: float,
         dist_result: _power_distributing.Result | None = None,
         expected_result_pred: (
-            typing.Callable[[_power_distributing.Result], bool] | None
+            Callable[[_power_distributing.Result], bool] | None
         ) = None,
     ) -> None:
         assert report.target_power == (
@@ -559,7 +559,7 @@ class TestBatteryPoolControl:
 
     async def test_no_resend_0w(self, mocks: Mocks, mocker: MockerFixture) -> None:
         """Test that 0W command is not resent unnecessarily."""
-        set_power = typing.cast(
+        set_power = cast(
             AsyncMock,
             microgrid.connection_manager.get().api_client.set_component_power_active,
         )

--- a/tests/timeseries/_battery_pool/test_battery_pool_control_methods.py
+++ b/tests/timeseries/_battery_pool/test_battery_pool_control_methods.py
@@ -12,7 +12,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import async_solipsism
 import pytest
-from frequenz.channels import LatestValueCache, Sender
+from frequenz.channels import LatestValueCache, Receiver, Sender
 from frequenz.quantities import Power
 from pytest_mock import MockerFixture
 
@@ -155,7 +155,7 @@ class TestBatteryPoolControl:
 
     def _assert_report(  # pylint: disable=too-many-arguments
         self,
-        report: BatteryPoolReport,
+        report: BatteryPoolReport | None,
         *,
         power: float | None,
         lower: float,
@@ -165,6 +165,7 @@ class TestBatteryPoolControl:
             Callable[[_power_distributing.Result], bool] | None
         ) = None,
     ) -> None:
+        assert report is not None
         assert report.target_power == (
             Power.from_watts(power) if power is not None else None
         )
@@ -174,6 +175,22 @@ class TestBatteryPoolControl:
         if expected_result_pred is not None:
             assert dist_result is not None
             assert expected_result_pred(dist_result)
+
+    async def _recv_reports_until(
+        self,
+        bounds_rx: Receiver[BatteryPoolReport],
+        check: Callable[[BatteryPoolReport], bool],
+    ) -> BatteryPoolReport | None:
+        """Receive reports until the given condition is met."""
+        max_reports = 10
+        ctr = 0
+        while ctr < max_reports:
+            ctr += 1
+            async with asyncio.timeout(10.0):
+                report = await bounds_rx.receive()
+            if check(report):
+                return report
+        return None
 
     async def test_case_1(
         self,
@@ -201,9 +218,12 @@ class TestBatteryPoolControl:
             battery_pool.power_distribution_results.new_receiver()
         )
 
-        self._assert_report(
-            await bounds_rx.receive(), power=None, lower=-4000.0, upper=4000.0
+        report = await self._recv_reports_until(
+            bounds_rx,
+            lambda r: r.bounds is not None
+            and r.bounds.upper == Power.from_watts(4000.0),
         )
+        self._assert_report(report, power=None, lower=-4000.0, upper=4000.0)
 
         await battery_pool.propose_power(Power.from_watts(1000.0))
 
@@ -441,6 +461,7 @@ class TestBatteryPoolControl:
             mocker.call(inv_id, 250.0)
             for inv_id in mocks.microgrid.battery_inverter_ids
         ]
+
         self._assert_report(
             await bounds_rx.receive(),
             power=1000.0,
@@ -458,9 +479,10 @@ class TestBatteryPoolControl:
         # available power.
         await battery_pool.propose_power(Power.from_watts(50.0))
 
-        self._assert_report(
-            await bounds_rx.receive(), power=400.0, lower=-4000.0, upper=4000.0
+        report = await self._recv_reports_until(
+            bounds_rx, lambda r: r.target_power == Power.from_watts(400.0)
         )
+        self._assert_report(report, power=400.0, lower=-4000.0, upper=4000.0)
         await asyncio.sleep(0.0)  # Wait for the power to be distributed.
         assert set_power.call_count == 4
         assert sorted(set_power.call_args_list) == [

--- a/tests/timeseries/_battery_pool/test_battery_pool_control_methods.py
+++ b/tests/timeseries/_battery_pool/test_battery_pool_control_methods.py
@@ -79,13 +79,7 @@ async def mocks(mocker: MockerFixture) -> AsyncIterator[Mocks]:
             dp._battery_power_wrapper.status_channel.new_sender(),
         )
     finally:
-        _ = await asyncio.gather(
-            *[
-                dp._stop(),
-                streamer.stop(),
-                mockgrid.cleanup(),
-            ]
-        )
+        await asyncio.gather(dp._stop(), streamer.stop(), mockgrid.cleanup())
 
 
 class TestBatteryPoolControl:

--- a/tests/timeseries/_ev_charger_pool/test_ev_charger_pool_control_methods.py
+++ b/tests/timeseries/_ev_charger_pool/test_ev_charger_pool_control_methods.py
@@ -177,7 +177,8 @@ class TestEVChargerPoolControl:
             Callable[[_power_distributing.Result], bool] | None
         ) = None,
     ) -> None:
-        assert report is not None and report.target_power == (
+        assert report is not None
+        assert report.target_power == (
             Power.from_watts(power) if power is not None else None
         )
         assert report.bounds is not None

--- a/tests/timeseries/_ev_charger_pool/test_ev_charger_pool_control_methods.py
+++ b/tests/timeseries/_ev_charger_pool/test_ev_charger_pool_control_methods.py
@@ -156,14 +156,13 @@ class TestEVChargerPoolControl:
         """Receive reports until the given condition is met."""
         max_reports = 10
         ctr = 0
-        latest_report: EVChargerPoolReport | None = None
         while ctr < max_reports:
             ctr += 1
-            latest_report = await bounds_rx.receive()
-            if check(latest_report):
-                break
-
-        return latest_report
+            async with asyncio.timeout(10.0):
+                report = await bounds_rx.receive()
+            if check(report):
+                return report
+        return None
 
     def _assert_report(  # pylint: disable=too-many-arguments
         self,

--- a/tests/timeseries/_ev_charger_pool/test_ev_charger_pool_control_methods.py
+++ b/tests/timeseries/_ev_charger_pool/test_ev_charger_pool_control_methods.py
@@ -58,20 +58,15 @@ async def mocks(mocker: MockerFixture) -> AsyncIterator[_Mocks]:
 
     dp = cast(_DataPipeline, microgrid._data_pipeline._DATA_PIPELINE)
 
+    _mocks = _Mocks(
+        mockgrid,
+        streamer,
+        dp._ev_power_wrapper.status_channel.new_sender(),
+    )
     try:
-        yield _Mocks(
-            mockgrid,
-            streamer,
-            dp._ev_power_wrapper.status_channel.new_sender(),
-        )
+        yield _mocks
     finally:
-        _ = await asyncio.gather(
-            *[
-                dp._stop(),
-                streamer.stop(),
-                mockgrid.cleanup(),
-            ]
-        )
+        await _mocks.stop()
 
 
 class TestEVChargerPoolControl:

--- a/tests/timeseries/_ev_charger_pool/test_ev_charger_pool_control_methods.py
+++ b/tests/timeseries/_ev_charger_pool/test_ev_charger_pool_control_methods.py
@@ -206,6 +206,7 @@ class TestEVChargerPoolControl:
         await self._patch_power_distributing_actor(mocker)
 
         bounds_rx = ev_charger_pool.power_status.new_receiver()
+        # Receive reports until all chargers are initialized
         latest_report = await self._recv_reports_until(
             bounds_rx,
             lambda x: x.bounds is not None and x.bounds.upper.as_watts() == 44160.0,
@@ -220,9 +221,11 @@ class TestEVChargerPoolControl:
         set_power.reset_mock()
         await ev_charger_pool.propose_power(Power.from_watts(40000.0))
         # ignore one report because it is not always immediately updated.
-        self._assert_report(
-            await bounds_rx.receive(), power=40000.0, lower=0.0, upper=44160.0
+        latest_report = await self._recv_reports_until(
+            bounds_rx,
+            lambda r: r.target_power == Power.from_watts(40000.0),
         )
+        self._assert_report(latest_report, power=40000.0, lower=0.0, upper=44160.0)
         mock_time.shift(timedelta(seconds=60))
         await asyncio.sleep(0.15)
 
@@ -245,7 +248,7 @@ class TestEVChargerPoolControl:
         # Throttle the power
         set_power.reset_mock()
         await ev_charger_pool.propose_power(Power.from_watts(32000.0))
-        await bounds_rx.receive()
+        await bounds_rx.receive()  # Receive the next report and discard it.
         await asyncio.sleep(0.02)
         assert set_power.call_count == 1
 

--- a/tests/timeseries/_ev_charger_pool/test_ev_charger_pool_control_methods.py
+++ b/tests/timeseries/_ev_charger_pool/test_ev_charger_pool_control_methods.py
@@ -4,7 +4,7 @@
 """Test the EV charger pool control methods."""
 
 import asyncio
-import typing
+from collections.abc import AsyncIterator, Callable
 from datetime import datetime, timedelta, timezone
 from typing import cast
 from unittest.mock import AsyncMock, MagicMock
@@ -42,7 +42,7 @@ def event_loop_policy() -> async_solipsism.EventLoopPolicy:
 
 
 @pytest.fixture
-async def mocks(mocker: MockerFixture) -> typing.AsyncIterator[_Mocks]:
+async def mocks(mocker: MockerFixture) -> AsyncIterator[_Mocks]:
     """Create the mocks."""
     mockgrid = MockMicrogrid(grid_meter=True)
     mockgrid.add_ev_chargers(4)
@@ -56,7 +56,7 @@ async def mocks(mocker: MockerFixture) -> typing.AsyncIterator[_Mocks]:
     )
     streamer = MockComponentDataStreamer(mockgrid.mock_client)
 
-    dp = typing.cast(_DataPipeline, microgrid._data_pipeline._DATA_PIPELINE)
+    dp = cast(_DataPipeline, microgrid._data_pipeline._DATA_PIPELINE)
 
     try:
         yield _Mocks(
@@ -156,7 +156,7 @@ class TestEVChargerPoolControl:
     async def _recv_reports_until(
         self,
         bounds_rx: Receiver[EVChargerPoolReport],
-        check: typing.Callable[[EVChargerPoolReport], bool],
+        check: Callable[[EVChargerPoolReport], bool],
     ) -> EVChargerPoolReport | None:
         """Receive reports until the given condition is met."""
         max_reports = 10
@@ -179,7 +179,7 @@ class TestEVChargerPoolControl:
         upper: float,
         dist_result: _power_distributing.Result | None = None,
         expected_result_pred: (
-            typing.Callable[[_power_distributing.Result], bool] | None
+            Callable[[_power_distributing.Result], bool] | None
         ) = None,
     ) -> None:
         assert report is not None and report.target_power == (

--- a/tests/timeseries/_pv_pool/test_pv_pool_control_methods.py
+++ b/tests/timeseries/_pv_pool/test_pv_pool_control_methods.py
@@ -51,20 +51,15 @@ async def mocks(mocker: MockerFixture) -> typing.AsyncIterator[_Mocks]:
 
     dp = typing.cast(_DataPipeline, microgrid._data_pipeline._DATA_PIPELINE)
 
+    _mocks = _Mocks(
+        mockgrid,
+        streamer,
+        dp._pv_power_wrapper.status_channel.new_sender(),
+    )
     try:
-        yield _Mocks(
-            mockgrid,
-            streamer,
-            dp._pv_power_wrapper.status_channel.new_sender(),
-        )
+        yield _mocks
     finally:
-        _ = await asyncio.gather(
-            *[
-                dp._stop(),
-                streamer.stop(),
-                mockgrid.cleanup(),
-            ]
-        )
+        await _mocks.stop()
 
 
 class TestPVPoolControl:

--- a/tests/timeseries/mock_microgrid.py
+++ b/tests/timeseries/mock_microgrid.py
@@ -260,7 +260,7 @@ class MockMicrogrid:  # pylint: disable=too-many-instance-attributes
     ) -> None:
         for value in range(1, self._num_values + 1):
             timestamp = datetime.now(tz=timezone.utc)
-            val_to_send = value + int(int(comp_id) / 10)
+            val_to_send = value + int(comp_id) // 10
             # for inverters with component_id > 100, send only half the messages.
             if int(comp_id) % 10 == self.inverter_id_suffix:
                 if int(comp_id) < 100 or value <= 5:

--- a/tests/utils/component_graph_utils.py
+++ b/tests/utils/component_graph_utils.py
@@ -19,6 +19,8 @@ from frequenz.client.microgrid.component import (
     SolarInverter,
 )
 
+from frequenz.sdk.microgrid.component_graph import ComponentGraph
+
 
 @dataclass
 class ComponentGraphConfig:
@@ -107,3 +109,18 @@ def create_component_graph_structure(
         components.add(DcEvCharger(id=ev_id, microgrid_id=microgrid_id))
         connections.add(ComponentConnection(source=junction_id, destination=ev_id))
     return components, connections
+
+
+def component_graph_to_mermaid(comp_graph: ComponentGraph) -> str:
+    """Return a string representation of the component graph in Mermaid format."""
+
+    def component_to_mermaid(component: Component) -> str:
+        return f'"{component.id}"["{component}"]'
+
+    def connection_to_mermaid(connection: ComponentConnection) -> str:
+        return f'"{connection.source}" --> "{connection.destination}"'
+
+    components = "\n".join(map(component_to_mermaid, comp_graph.components()))
+    connections = "\n".join(map(connection_to_mermaid, comp_graph.connections()))
+
+    return f"graph TD\n{components}\n{connections}"


### PR DESCRIPTION
This PR focuses on improving test resilience and code maintainability through refactoring, better logging, timeout additions, and various cleanups. The changes enhance test reliability by adding timeout mechanisms to prevent hanging tests and improve code readability through better imports, simplified logic, and consistent parameter ordering.

**Key changes:**
- Added timeout mechanisms (10 seconds) to test report receiving operations to prevent hanging tests
- Refactored test fixtures to use shared `stop()` methods for cleaner cleanup
- Improved type hints for NetworkX graphs and added type stubs to mypy configuration
- Standardized parameter ordering (positional before keyword-only) in component status trackers