### PR TITLE
Make battery power manager algorithm configurable

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,7 +10,7 @@
 
 ## New Features
 
-<!-- Here goes the main new features and examples or instructions on how to use them -->
+- The power manager algorithm for batteries can now be changed from the default ShiftingMatryoshka, by passing it as an argument to `microgrid.initialize()`
 
 ## Bug Fixes
 

--- a/src/frequenz/sdk/microgrid/__init__.py
+++ b/src/frequenz/sdk/microgrid/__init__.py
@@ -383,6 +383,7 @@ from ._data_pipeline import (
     producer,
     voltage_per_phase,
 )
+from ._power_managing import PowerManagerAlgorithm
 
 
 async def initialize(
@@ -390,6 +391,8 @@ async def initialize(
     resampler_config: ResamplerConfig,
     *,
     api_power_request_timeout: timedelta = timedelta(seconds=5.0),
+    # pylint: disable-next: line-too-long
+    battery_power_manager_algorithm: PowerManagerAlgorithm = PowerManagerAlgorithm.SHIFTING_MATRYOSHKA,  # noqa: E501
 ) -> None:
     """Initialize the microgrid connection manager and the data pipeline.
 
@@ -404,15 +407,19 @@ async def initialize(
             the microgrid API.  When requests to components timeout, they will
             be marked as blocked for a short duration, during which time they
             will be unavailable from the corresponding component pools.
+        battery_power_manager_algorithm: The power manager algorithm to use for
+            batteries.
     """
     await connection_manager.initialize(server_url)
     await _data_pipeline.initialize(
         resampler_config,
         api_power_request_timeout=api_power_request_timeout,
+        battery_power_manager_algorithm=battery_power_manager_algorithm,
     )
 
 
 __all__ = [
+    "PowerManagerAlgorithm",
     "initialize",
     "consumer",
     "grid",

--- a/src/frequenz/sdk/microgrid/_data_pipeline.py
+++ b/src/frequenz/sdk/microgrid/_data_pipeline.py
@@ -83,6 +83,7 @@ class _DataPipeline:  # pylint: disable=too-many-instance-attributes
         self,
         resampler_config: ResamplerConfig,
         api_power_request_timeout: timedelta = timedelta(seconds=5.0),
+        battery_power_manager_algorithm: PowerManagerAlgorithm = PowerManagerAlgorithm.SHIFTING_MATRYOSHKA,  # noqa: E501
     ) -> None:
         """Create a `DataPipeline` instance.
 
@@ -90,6 +91,8 @@ class _DataPipeline:  # pylint: disable=too-many-instance-attributes
             resampler_config: Config to pass on to the resampler.
             api_power_request_timeout: Timeout to use when making power requests to
                 the microgrid API.
+            battery_power_manager_algorithm: The power manager algorithm to use for
+                batteries.
         """
         self._resampler_config: ResamplerConfig = resampler_config
 
@@ -103,7 +106,7 @@ class _DataPipeline:  # pylint: disable=too-many-instance-attributes
         self._battery_power_wrapper = PowerWrapper(
             self._channel_registry,
             api_power_request_timeout=api_power_request_timeout,
-            power_manager_algorithm=PowerManagerAlgorithm.SHIFTING_MATRYOSHKA,
+            power_manager_algorithm=battery_power_manager_algorithm,
             default_power=DefaultPower.ZERO,
             component_class=Battery,
         )
@@ -514,6 +517,7 @@ _DATA_PIPELINE: _DataPipeline | None = None
 async def initialize(
     resampler_config: ResamplerConfig,
     api_power_request_timeout: timedelta = timedelta(seconds=5.0),
+    battery_power_manager_algorithm: PowerManagerAlgorithm = PowerManagerAlgorithm.SHIFTING_MATRYOSHKA,  # noqa: E501
 ) -> None:
     """Initialize a `DataPipeline` instance.
 
@@ -523,6 +527,8 @@ async def initialize(
             the microgrid API.  When requests to components timeout, they will
             be marked as blocked for a short duration, during which time they
             will be unavailable from the corresponding component pools.
+        battery_power_manager_algorithm: The power manager algorithm to use for
+            batteries.
 
     Raises:
         RuntimeError: if the DataPipeline is already initialized.
@@ -531,7 +537,9 @@ async def initialize(
 
     if _DATA_PIPELINE is not None:
         raise RuntimeError("DataPipeline is already initialized.")
-    _DATA_PIPELINE = _DataPipeline(resampler_config, api_power_request_timeout)
+    _DATA_PIPELINE = _DataPipeline(
+        resampler_config, api_power_request_timeout, battery_power_manager_algorithm
+    )
 
 
 def frequency() -> GridFrequency:

--- a/src/frequenz/sdk/microgrid/_data_pipeline.py
+++ b/src/frequenz/sdk/microgrid/_data_pipeline.py
@@ -20,13 +20,12 @@ from frequenz.channels import Broadcast, Sender
 from frequenz.client.common.microgrid.components import ComponentId
 from frequenz.client.microgrid.component import Battery, EvCharger, SolarInverter
 
-from frequenz.sdk.microgrid._power_managing._base_classes import Algorithm, DefaultPower
-
 from .._internal._channels import ChannelRegistry
 from ..actor._actor import Actor
 from ..timeseries import ResamplerConfig
 from ..timeseries._voltage_streamer import VoltageStreamer
 from ._data_sourcing import ComponentMetricRequest, DataSourcingActor
+from ._power_managing._base_classes import DefaultPower, PowerManagerAlgorithm
 from ._power_wrapper import PowerWrapper
 
 # A number of imports had to be done inside functions where they are used, to break
@@ -104,21 +103,21 @@ class _DataPipeline:  # pylint: disable=too-many-instance-attributes
         self._battery_power_wrapper = PowerWrapper(
             self._channel_registry,
             api_power_request_timeout=api_power_request_timeout,
-            power_manager_algorithm=Algorithm.SHIFTING_MATRYOSHKA,
+            power_manager_algorithm=PowerManagerAlgorithm.SHIFTING_MATRYOSHKA,
             default_power=DefaultPower.ZERO,
             component_class=Battery,
         )
         self._ev_power_wrapper = PowerWrapper(
             self._channel_registry,
             api_power_request_timeout=api_power_request_timeout,
-            power_manager_algorithm=Algorithm.MATRYOSHKA,
+            power_manager_algorithm=PowerManagerAlgorithm.MATRYOSHKA,
             default_power=DefaultPower.MAX,
             component_class=EvCharger,
         )
         self._pv_power_wrapper = PowerWrapper(
             self._channel_registry,
             api_power_request_timeout=api_power_request_timeout,
-            power_manager_algorithm=Algorithm.MATRYOSHKA,
+            power_manager_algorithm=PowerManagerAlgorithm.MATRYOSHKA,
             default_power=DefaultPower.MIN,
             # Using SolarInverter might be too specific, maybe we need to also pass
             # HybridInverter, see

--- a/src/frequenz/sdk/microgrid/_power_managing/__init__.py
+++ b/src/frequenz/sdk/microgrid/_power_managing/__init__.py
@@ -3,11 +3,11 @@
 
 """A power manager implementation."""
 
-from ._base_classes import Algorithm, Proposal, ReportRequest, _Report
+from ._base_classes import PowerManagerAlgorithm, Proposal, ReportRequest, _Report
 from ._power_managing_actor import PowerManagingActor
 
 __all__ = [
-    "Algorithm",
+    "PowerManagerAlgorithm",
     "PowerManagingActor",
     "Proposal",
     "_Report",

--- a/src/frequenz/sdk/microgrid/_power_managing/_base_classes.py
+++ b/src/frequenz/sdk/microgrid/_power_managing/_base_classes.py
@@ -213,7 +213,7 @@ class DefaultPower(enum.Enum):
     """The default power is the maximum power of the component."""
 
 
-class Algorithm(enum.Enum):
+class PowerManagerAlgorithm(enum.Enum):
     """The available algorithms for the power manager."""
 
     MATRYOSHKA = "matryoshka"

--- a/src/frequenz/sdk/microgrid/_power_managing/_power_managing_actor.py
+++ b/src/frequenz/sdk/microgrid/_power_managing/_power_managing_actor.py
@@ -23,9 +23,9 @@ from ...actor import Actor
 from ...timeseries._base_types import SystemBounds
 from .. import _data_pipeline, _power_distributing
 from ._base_classes import (
-    Algorithm,
     BaseAlgorithm,
     DefaultPower,
+    PowerManagerAlgorithm,
     Proposal,
     ReportRequest,
     _Report,
@@ -47,7 +47,7 @@ class PowerManagingActor(Actor):
         power_distributing_requests_sender: Sender[_power_distributing.Request],
         power_distributing_results_receiver: Receiver[_power_distributing.Result],
         channel_registry: ChannelRegistry,
-        algorithm: Algorithm,
+        algorithm: PowerManagerAlgorithm,
         default_power: DefaultPower,
         component_class: type[Battery | EvCharger | SolarInverter],
     ):
@@ -80,12 +80,12 @@ class PowerManagingActor(Actor):
         ] = {}
 
         match algorithm:
-            case Algorithm.MATRYOSHKA:
+            case PowerManagerAlgorithm.MATRYOSHKA:
                 self._algorithm: BaseAlgorithm = Matryoshka(
                     max_proposal_age=timedelta(seconds=60.0),
                     default_power=default_power,
                 )
-            case Algorithm.SHIFTING_MATRYOSHKA:
+            case PowerManagerAlgorithm.SHIFTING_MATRYOSHKA:
                 self._algorithm = ShiftingMatryoshka(
                     max_proposal_age=timedelta(seconds=60.0),
                     default_power=default_power,

--- a/src/frequenz/sdk/microgrid/_power_wrapper.py
+++ b/src/frequenz/sdk/microgrid/_power_wrapper.py
@@ -25,7 +25,7 @@ from ._power_distributing import (
     Request,
     Result,
 )
-from ._power_managing._base_classes import Algorithm, DefaultPower
+from ._power_managing._base_classes import DefaultPower, PowerManagerAlgorithm
 
 _logger = logging.getLogger(__name__)
 
@@ -38,7 +38,7 @@ class PowerWrapper:  # pylint: disable=too-many-instance-attributes
         channel_registry: ChannelRegistry,
         *,
         api_power_request_timeout: timedelta,
-        power_manager_algorithm: Algorithm,
+        power_manager_algorithm: PowerManagerAlgorithm,
         default_power: DefaultPower,
         component_class: type[Battery | EvCharger | SolarInverter],
     ):


### PR DESCRIPTION
With this, `SHIFTING_MATRYOSHKA` remains the default algorithm for
batteries, but can now be changed to the original `MATRYOSHKA`
algorithm when calling `microgrid.initialize()`.