### PR TITLE
Improve formula validation

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -14,4 +14,4 @@
 
 ## Bug Fixes
 
-<!-- Here goes notable bug fixes that are worth a special mention or explanation -->
+- Improved formula validation: Consistent error messages for invalid formulas and conventional span semantics.

--- a/src/frequenz/sdk/timeseries/formulas/_base_ast_node.py
+++ b/src/frequenz/sdk/timeseries/formulas/_base_ast_node.py
@@ -24,9 +24,6 @@ _MAX_SYNC_RETRIES = 10
 class AstNode(abc.ABC, Generic[QuantityT]):
     """An abstract syntax tree node representing a formula expression."""
 
-    span: tuple[int, int] | None = None
-    """The span (start, end) of the expression in the input string."""
-
     @abc.abstractmethod
     async def evaluate(self) -> Sample[QuantityT] | QuantityT | None:
         """Evaluate the expression and return its numerical value."""

--- a/src/frequenz/sdk/timeseries/formulas/_exceptions.py
+++ b/src/frequenz/sdk/timeseries/formulas/_exceptions.py
@@ -1,0 +1,53 @@
+# License: MIT
+# Copyright © 2026 Frequenz Energy-as-a-Service GmbH
+
+"""Exception classes for formulas parser and evaluator."""
+
+
+class FormulaError(Exception):
+    """Base class for exceptions in this module."""
+
+
+class FormulaSyntaxError(FormulaError):
+    """Exception raised for syntax errors in the formula."""
+
+    def __init__(
+        self, *, formula: str, span: tuple[int, int] | None, message: str
+    ) -> None:
+        """Initialize this instance."""
+        self._formula: str = formula
+        self._span: tuple[int, int] | None = span
+        self._message: str = message
+
+    def __str__(self) -> str:
+        """Return a string representation of the error.
+
+        The span (if present) will be used to highlight the error location.
+        For long formulas, the beginning and/or end will be truncated as needed.
+        """
+        if self._span is None:
+            return self._message
+
+        formula_line = self._formula
+        span_padding = " " * self._span[0]
+        span_highlight = "^" * (self._span[1] - self._span[0])
+        error_line = f"{span_padding}{span_highlight} {self._message}"
+
+        char_limit: int = 80 - 11  # Account for "  Formula: " prefix in final output
+
+        if len(error_line) > char_limit:
+            # Remove characters from the left to fit error line within char limit
+            num_chars_to_truncate = len(error_line) - char_limit
+            error_line = error_line[num_chars_to_truncate:]
+            # Shift formula line by the same amount and insert leading ellipsis
+            formula_line = f"... {formula_line[num_chars_to_truncate+4:]}"
+
+        if len(formula_line) > char_limit:
+            # Truncate the formula line, insert ellipsis
+            formula_line = f"{formula_line[:char_limit-4]} ..."
+
+        return (
+            "Formula syntax error:\n"
+            f"  Formula: {formula_line}\n"
+            f"           {error_line}"
+        )

--- a/src/frequenz/sdk/timeseries/formulas/_functions.py
+++ b/src/frequenz/sdk/timeseries/formulas/_functions.py
@@ -85,19 +85,14 @@ class Function(abc.ABC, Generic[QuantityT]):
         )
 
     @classmethod
-    def from_string(
-        cls, name: str, params: list[AstNode[QuantityT]]
-    ) -> Function[QuantityT]:
-        """Create a function instance from its name."""
-        match name.upper():
-            case "COALESCE":
-                return Coalesce(params)
-            case "MAX":
-                return Max(params)
-            case "MIN":
-                return Min(params)
-            case _:
-                raise ValueError(f"Unknown function name: {name}")
+    def function_class_by_name(cls, name: str) -> type[Function[QuantityT]] | None:
+        """Return the function class corresponding to the given name."""
+        known_functions: dict[str, type[Function[QuantityT]]] = {
+            "COALESCE": Coalesce,
+            "MAX": Max,
+            "MIN": Min,
+        }
+        return known_functions.get(name.upper())
 
 
 @dataclass

--- a/src/frequenz/sdk/timeseries/formulas/_lexer.py
+++ b/src/frequenz/sdk/timeseries/formulas/_lexer.py
@@ -11,6 +11,7 @@ from collections.abc import Iterator
 from typing_extensions import override
 
 from . import _token
+from ._exceptions import FormulaSyntaxError
 from ._peekable import Peekable
 
 
@@ -74,7 +75,11 @@ class Lexer(Iterator[_token.Token]):
             _ = next(self._iter)  # consume '#'
             comp_id = self._read_integer()
             if not comp_id:
-                raise ValueError(f"Expected integer after '#' at position {pos}")
+                raise FormulaSyntaxError(
+                    formula=self._formula,
+                    span=(pos + 1, pos + 2),
+                    message="Expected integer after '#'",
+                )
             end_pos = pos + len(comp_id) + 1  # account for '#'
             return _token.Component(
                 span=(pos, end_pos),
@@ -120,4 +125,8 @@ class Lexer(Iterator[_token.Token]):
             end_pos = pos + len(symbol)
             return _token.Symbol(span=(pos, end_pos), value=symbol)
 
-        raise ValueError(f"Unexpected character '{char}' at position {pos}")
+        raise FormulaSyntaxError(
+            formula=self._formula,
+            span=(pos, pos + 1),
+            message="Unexpected character",
+        )

--- a/src/frequenz/sdk/timeseries/formulas/_lexer.py
+++ b/src/frequenz/sdk/timeseries/formulas/_lexer.py
@@ -75,52 +75,49 @@ class Lexer(Iterator[_token.Token]):
             comp_id = self._read_integer()
             if not comp_id:
                 raise ValueError(f"Expected integer after '#' at position {pos}")
-            end_pos = pos + len(comp_id)
+            end_pos = pos + len(comp_id) + 1  # account for '#'
             return _token.Component(
-                span=(
-                    pos + 1,
-                    end_pos + 1,  # account for '#'
-                ),
+                span=(pos, end_pos),
                 id=comp_id,
                 value=self._formula[pos:end_pos],
             )
 
         if char == "+":
             _, char = next(self._iter)  # consume operator
-            return _token.Plus(span=(pos + 1, pos + 1), value=char)
+            return _token.Plus(span=(pos, pos + 1), value=char)
 
         if char == "-":
             _, char = next(self._iter)
-            return _token.Minus(span=(pos + 1, pos + 1), value=char)
+            return _token.Minus(span=(pos, pos + 1), value=char)
 
         if char == "*":
             _, char = next(self._iter)
-            return _token.Mul(span=(pos + 1, pos + 1), value=char)
+            return _token.Mul(span=(pos, pos + 1), value=char)
 
         if char == "/":
             _, char = next(self._iter)
-            return _token.Div(span=(pos + 1, pos + 1), value=char)
+            return _token.Div(span=(pos, pos + 1), value=char)
 
         if char == "(":
             _, char = next(self._iter)
-            return _token.OpenParen(span=(pos + 1, pos + 1), value=char)
+            return _token.OpenParen(span=(pos, pos + 1), value=char)
 
         if char == ")":
             _, char = next(self._iter)
-            return _token.CloseParen(span=(pos + 1, pos + 1), value=char)
+            return _token.CloseParen(span=(pos, pos + 1), value=char)
 
         if char == ",":
             _, char = next(self._iter)
-            return _token.Comma(span=(pos + 1, pos + 1), value=char)
+            return _token.Comma(span=(pos, pos + 1), value=char)
 
         if char.isdigit():
             num = self._read_number()
             end_pos = pos + len(num)
-            return _token.Number(span=(pos + 1, end_pos), value=num)
+            return _token.Number(span=(pos, end_pos), value=num)
 
         if char.isalpha():
             symbol = self._read_symbol()
             end_pos = pos + len(symbol)
-            return _token.Symbol(span=(pos + 1, end_pos), value=symbol)
+            return _token.Symbol(span=(pos, end_pos), value=symbol)
 
         raise ValueError(f"Unexpected character '{char}' at position {pos}")

--- a/src/frequenz/sdk/timeseries/formulas/_parser.py
+++ b/src/frequenz/sdk/timeseries/formulas/_parser.py
@@ -18,6 +18,7 @@ from frequenz.sdk.timeseries._base_types import QuantityT
 
 from . import _ast, _token
 from ._base_ast_node import AstNode
+from ._exceptions import FormulaSyntaxError
 from ._formula import Formula
 from ._functions import FunCall, Function
 from ._lexer import Lexer
@@ -65,11 +66,17 @@ class _Parser(Generic[QuantityT]):
     ):
         """Initialize the parser."""
         self._name: str = name
+        self._formula: str = formula
         self._lexer: Peekable[_token.Token] = Peekable(Lexer(formula))
         self._telemetry_fetcher: ResampledStreamFetcher = telemetry_fetcher
         self._create_method: Callable[[float], QuantityT] = create_method
 
     def _parse_term(self) -> AstNode[QuantityT] | None:
+        """Parse a term.
+
+        A term is any expression. It may contain binary operators,
+        bracketed expressions, function calls, literals and component IDs.
+        """
         factor = self._parse_factor()
         if factor is None:
             return None
@@ -80,8 +87,10 @@ class _Parser(Generic[QuantityT]):
             next_factor = self._parse_factor()
 
             if next_factor is None:
-                raise ValueError(
-                    f"Expected factor after operator at span: {token.span}"
+                raise FormulaSyntaxError(
+                    formula=self._formula,
+                    span=(token.span[1], token.span[1] + 1),
+                    message="Expected expression",
                 )
 
             if isinstance(token, _token.Plus):
@@ -94,6 +103,11 @@ class _Parser(Generic[QuantityT]):
         return factor
 
     def _parse_factor(self) -> AstNode[QuantityT] | None:
+        """Parse a factor.
+
+        A factor is any expression that does not contain
+        addition or subtraction outside of parentheses.
+        """
         unary = self._parse_unary()
 
         if unary is None:
@@ -104,7 +118,11 @@ class _Parser(Generic[QuantityT]):
             token = next(self._lexer)
             next_unary = self._parse_unary()
             if next_unary is None:
-                raise ValueError(f"Expected unary after operator at span: {token.span}")
+                raise FormulaSyntaxError(
+                    formula=self._formula,
+                    span=(token.span[1], token.span[1] + 1),
+                    message="Expected expression",
+                )
 
             if isinstance(token, _token.Mul):
                 unary = _ast.Mul(span=token.span, left=unary, right=next_unary)
@@ -116,13 +134,20 @@ class _Parser(Generic[QuantityT]):
         return unary
 
     def _parse_unary(self) -> AstNode[QuantityT] | None:
+        """Parse unary.
+
+        A unary is any expression that does not contain any binary
+        operators outside of parentheses.
+        """
         token: _token.Token | None = self._lexer.peek()
         if token is not None and isinstance(token, _token.Minus):
             token = next(self._lexer)
             primary: AstNode[QuantityT] | None = self._parse_primary()
             if primary is None:
-                raise ValueError(
-                    f"Expected primary expression after unary '-' at position {token.span}"
+                raise FormulaSyntaxError(
+                    formula=self._formula,
+                    span=(token.span[1], token.span[1] + 1),
+                    message="Expected expression",
                 )
 
             zero_const = _ast.Constant(span=token.span, value=self._create_method(0.0))
@@ -136,11 +161,19 @@ class _Parser(Generic[QuantityT]):
 
         expr: AstNode[QuantityT] | None = self._parse_term()
         if expr is None:
-            raise ValueError(f"Expected expression after '(' at position {oparen.span}")
+            raise FormulaSyntaxError(
+                formula=self._formula,
+                span=(oparen.span[1], oparen.span[1] + 1),
+                message="Expected expression",
+            )
 
         token: _token.Token | None = self._lexer.peek()
         if token is None or not isinstance(token, _token.CloseParen):
-            raise ValueError(f"Expected ')' after expression at position {expr.span}")
+            raise FormulaSyntaxError(
+                formula=self._formula,
+                span=oparen.span,
+                message="Unmatched parenthesis",
+            )
 
         _ = next(self._lexer)  # consume ')'
 
@@ -148,40 +181,73 @@ class _Parser(Generic[QuantityT]):
 
     def _parse_function_call(self) -> AstNode[QuantityT] | None:
         fn_name: _token.Token = next(self._lexer)
+        function_class: type[Function[QuantityT]] | None = (
+            Function.function_class_by_name(fn_name.value)
+        )
+
+        if function_class is None:
+            raise FormulaSyntaxError(
+                formula=self._formula,
+                span=fn_name.span,
+                message="Unknown function name",
+            )
+
         params: list[AstNode[QuantityT]] = []
 
         token: _token.Token | None = self._lexer.peek()
         if token is None or not isinstance(token, _token.OpenParen):
-            raise ValueError(
-                f"Expected '(' after function name at position {fn_name.span}"
+            raise FormulaSyntaxError(
+                formula=self._formula,
+                span=(fn_name.span[1], fn_name.span[1] + 1),
+                message="Expected '(' after function name",
             )
+        oparen = next(self._lexer)  # consume '('
 
-        _ = next(self._lexer)  # consume '('
         while True:
             param = self._parse_term()
             if param is None:
-                raise ValueError(
-                    f"Expected argument in function call at position {fn_name.span}"
+                raise FormulaSyntaxError(
+                    formula=self._formula,
+                    span=(token.span[1], token.span[1] + 1),
+                    message="Expected argument",
                 )
             params.append(param)
 
             token = self._lexer.peek()
-            if token is not None and isinstance(token, _token.Comma):
+            if token is None:
+                raise FormulaSyntaxError(
+                    formula=self._formula,
+                    span=oparen.span,
+                    message="Unmatched parenthesis",
+                )
+
+            if isinstance(token, _token.Comma):
                 _ = next(self._lexer)  # consume ','
                 continue
-            if token is not None and isinstance(token, _token.CloseParen):
+            if isinstance(token, _token.CloseParen):
                 _ = next(self._lexer)  # consume ')'
                 break
-            raise ValueError(
-                f"Expected ',' or ')' in function call at position {fn_name.span}"
+
+            raise FormulaSyntaxError(
+                formula=self._formula,
+                span=token.span,
+                message="Expected ',' or ')'",
             )
 
         return FunCall(
             span=fn_name.span,
-            function=Function.from_string(fn_name.value, params),
+            function=function_class(params),
         )
 
     def _parse_primary(self) -> AstNode[QuantityT] | None:
+        """Parse a primary.
+
+        A primary(expression) can be any of the following:
+        - A number literal
+        - A component ID
+        - A function call
+        - A bracketed expression
+        """
         token: _token.Token | None = self._lexer.peek()
         if token is None:
             return None
@@ -220,7 +286,20 @@ class _Parser(Generic[QuantityT]):
     def parse(self) -> Formula[QuantityT]:
         expr = self._parse_term()
         if expr is None:
-            raise ValueError("Empty formula.")
+            raise FormulaSyntaxError(
+                formula=self._formula,
+                span=None,
+                message="Empty formula",
+            )
+        # There should not be any tokens left
+        token = self._lexer.peek()
+        if token is not None:
+            raise FormulaSyntaxError(
+                formula=self._formula,
+                span=token.span,
+                message="Unexpected token",
+            )
+
         return Formula(
             name=self._name,
             root=expr,

--- a/src/frequenz/sdk/timeseries/formulas/_parser.py
+++ b/src/frequenz/sdk/timeseries/formulas/_parser.py
@@ -94,9 +94,9 @@ class _Parser(Generic[QuantityT]):
                 )
 
             if isinstance(token, _token.Plus):
-                factor = _ast.Add(span=token.span, left=factor, right=next_factor)
+                factor = _ast.Add(left=factor, right=next_factor)
             elif isinstance(token, _token.Minus):
-                factor = _ast.Sub(span=token.span, left=factor, right=next_factor)
+                factor = _ast.Sub(left=factor, right=next_factor)
 
             token = self._lexer.peek()
 
@@ -125,9 +125,9 @@ class _Parser(Generic[QuantityT]):
                 )
 
             if isinstance(token, _token.Mul):
-                unary = _ast.Mul(span=token.span, left=unary, right=next_unary)
+                unary = _ast.Mul(left=unary, right=next_unary)
             elif isinstance(token, _token.Div):
-                unary = _ast.Div(span=token.span, left=unary, right=next_unary)
+                unary = _ast.Div(left=unary, right=next_unary)
 
             token = self._lexer.peek()
 
@@ -150,8 +150,8 @@ class _Parser(Generic[QuantityT]):
                     message="Expected expression",
                 )
 
-            zero_const = _ast.Constant(span=token.span, value=self._create_method(0.0))
-            return _ast.Sub(span=token.span, left=zero_const, right=primary)
+            zero_const = _ast.Constant(value=self._create_method(0.0))
+            return _ast.Sub(left=zero_const, right=primary)
 
         return self._parse_primary()
 
@@ -234,10 +234,7 @@ class _Parser(Generic[QuantityT]):
                 message="Expected ',' or ')'",
             )
 
-        return FunCall(
-            span=fn_name.span,
-            function=function_class(params),
-        )
+        return FunCall(function=function_class(params))
 
     def _parse_primary(self) -> AstNode[QuantityT] | None:
         """Parse a primary.
@@ -260,7 +257,6 @@ class _Parser(Generic[QuantityT]):
         if isinstance(token, _token.Component):
             _ = next(self._lexer)  # consume token
             comp = _ast.TelemetryStream(
-                span=token.span,
                 source=f"#{token.id}",
                 metric_fetcher=make_component_stream_fetcher(
                     self._telemetry_fetcher, ComponentId(int(token.id))
@@ -271,9 +267,7 @@ class _Parser(Generic[QuantityT]):
 
         if isinstance(token, _token.Number):
             _ = next(self._lexer)
-            return _ast.Constant(
-                span=token.span, value=self._create_method(float(token.value))
-            )
+            return _ast.Constant(value=self._create_method(float(token.value)))
 
         if isinstance(token, _token.OpenParen):
             return self._parse_bracketed()

--- a/tests/timeseries/_formulas/test_formulas.py
+++ b/tests/timeseries/_formulas/test_formulas.py
@@ -17,6 +17,7 @@ from frequenz.client.common.microgrid.components import ComponentId
 from frequenz.quantities import Quantity
 
 from frequenz.sdk.timeseries import Sample
+from frequenz.sdk.timeseries.formulas._exceptions import FormulaSyntaxError
 from frequenz.sdk.timeseries.formulas._formula import Formula, FormulaBuilder
 from frequenz.sdk.timeseries.formulas._parser import parse
 from frequenz.sdk.timeseries.formulas._resampled_stream_fetcher import (
@@ -170,6 +171,16 @@ class TestFormulas:
             [
                 ([30.0, 3.0, 5.0], 2.0),
                 ([15.0, 3.0, 2.0], 2.5),
+            ],
+        )
+        # Test unary minus: Parser inserts a zero before it.
+        await self.run_test(
+            "-#2",
+            "[f](0.0 - #2)",
+            [2],
+            [
+                ([30.0], -30.0),
+                ([15.0], -15.0),
             ],
         )
 
@@ -331,6 +342,180 @@ class TestFormulas:
                 ([-2.0, 15.0, None], -2.0),
             ],
         )
+
+
+class TestFormulaValidation:
+    """Tests for Formula validation."""
+
+    @pytest.mark.parametrize(
+        ("formula_str", "parsed_formula_str"),
+        [
+            ("#1", "[f](#1)"),
+            ("-(1+#1)", "[f](0.0 - (1.0 + #1))"),
+            ("1*(2+3)", "[f](1.0 * (2.0 + 3.0))"),
+        ],
+    )
+    async def test_parser_validation(
+        self,
+        formula_str: str,
+        parsed_formula_str: str,
+    ) -> None:
+        """Test formula parser validation."""
+        try:
+            formula = parse(
+                name="f",
+                formula=formula_str,
+                create_method=Quantity,
+                telemetry_fetcher=MagicMock(spec=ResampledStreamFetcher),
+            )
+            assert str(formula) == parsed_formula_str
+        except FormulaSyntaxError:
+            assert False, "Parser should not raise an error for this formula"
+
+    @pytest.mark.parametrize(
+        ("formula_str", "expected_error_line"),
+        [
+            (
+                "1++",
+                "  ^ Expected expression",
+            ),
+            (
+                "1**",
+                "  ^ Expected expression",
+            ),
+            (
+                "--1",
+                " ^ Expected expression",
+            ),
+            (
+                "(",
+                " ^ Expected expression",
+            ),
+            (
+                "(1",
+                "^ Unmatched parenthesis",
+            ),
+            (
+                "max",
+                "   ^ Expected '(' after function name",
+            ),
+            (
+                "max()",
+                "    ^ Expected argument",
+            ),
+            (
+                "max(1(",
+                "     ^ Expected ',' or ')'",
+            ),
+            (
+                "max(1",
+                "   ^ Unmatched parenthesis",
+            ),
+            (
+                "foo",
+                "^^^ Unknown function name",
+            ),
+            (
+                "foo(1)",
+                "^^^ Unknown function name",
+            ),
+            (
+                "max(1,,2)",
+                "      ^ Expected argument",
+            ),
+            (
+                "1 2",
+                "  ^ Unexpected token",
+            ),
+            (
+                "1, 2",
+                " ^ Unexpected token",
+            ),
+            (
+                "max(1, 2,)",
+                "         ^ Expected argument",
+            ),
+            (
+                "max(1, 2))",
+                "         ^ Unexpected token",
+            ),
+            (
+                "max(1, 2),",
+                "         ^ Unexpected token",
+            ),
+        ],
+    )
+    async def test_parser_validation_errors(
+        self, formula_str: str, expected_error_line: str
+    ) -> None:
+        """Test formula parser validation."""
+        with pytest.raises(FormulaSyntaxError) as error:
+            _ = parse(
+                name="f",
+                formula=formula_str,
+                create_method=Quantity,
+                telemetry_fetcher=MagicMock(spec=ResampledStreamFetcher),
+            )
+
+        assert str(error.value) == (
+            "Formula syntax error:\n"
+            f"  Formula: {formula_str}\n"
+            f"           {expected_error_line}"
+        )
+
+    @pytest.mark.parametrize(
+        ("formula_str", "expected_error"),
+        [
+            # Long formula with error near start -> Ellipsize end
+            (
+                "max(coalesce(#1001, %1002, 0), coalesce(#1003, #1004, 0), coalesce(#1005, #1006, 0), coalesce(#1007, #1008, 0))",  # noqa: E501
+                "Formula syntax error:\n"
+                "  Formula: max(coalesce(#1001, %1002, 0), coalesce(#1003, #1004, 0), coalesc ...\n"
+                "                               ^ Unexpected character",
+            ),
+            # Long formula with error near the end -> Ellipsize start
+            (
+                "max(coalesce(#1001, #1002, 0), coalesce(#1003, #1004, 0), coalesce(#1005, #1006, 0), coalesce(#10.07, #1008, 0))",  # noqa: E501
+                "Formula syntax error:\n"
+                "  Formula: ... 0), coalesce(#1005, #1006, 0), coalesce(#10.07, #1008, 0))\n"
+                "                                                          ^ Unexpected character",
+            ),
+            # Very long formula with error in the middle -> Ellipsize both sides
+            (
+                "max(coalesce(#1001, #1002, 0), coalesce(#1003, #1004, 0), coalesce(#1005, #1006, 0), coalesce(#1007, #1008, 0)) :) "  # noqa: E501
+                "min(coalesce(#2001, #2002, 0), coalesce(#2003, #2004, 0), coalesce(#2005, #2006, 0), coalesce(#2007, #2008, 0))",  # noqa: E501
+                "Formula syntax error:\n"
+                "  Formula: ... 005, #1006, 0), coalesce(#1007, #1008, 0)) :) min(coalesce(#2 ...\n"
+                "                                                          ^ Unexpected character",
+            ),
+        ],
+    )
+    async def test_parser_validation_errors_in_long_formulas(
+        self, formula_str: str, expected_error: str
+    ) -> None:
+        """Test formula parser validation for long formulas."""
+        with pytest.raises(FormulaSyntaxError) as error:
+            _ = parse(
+                name="f",
+                formula=formula_str,
+                create_method=Quantity,
+                telemetry_fetcher=MagicMock(spec=ResampledStreamFetcher),
+            )
+
+        assert str(error.value) == expected_error
+        assert all(len(line) <= 80 for line in str(error.value).splitlines())
+
+    async def test_empty_formula(self) -> None:
+        """Test formula parser validation."""
+        with pytest.raises(FormulaSyntaxError) as error:
+            _ = parse(
+                name="f",
+                formula="",
+                create_method=Quantity,
+                telemetry_fetcher=MagicMock(spec=ResampledStreamFetcher),
+            )
+
+        assert str(error.value) == "Empty formula"
 
 
 class TestFormulaComposition:

--- a/tests/timeseries/_formulas/test_lexer.py
+++ b/tests/timeseries/_formulas/test_lexer.py
@@ -2,67 +2,122 @@
 # Copyright © 2025 Frequenz Energy-as-a-Service GmbH
 
 """Tests for the formula lexer."""
+import pytest
 
 from frequenz.sdk.timeseries.formulas import _token
+from frequenz.sdk.timeseries.formulas._exceptions import FormulaSyntaxError
 from frequenz.sdk.timeseries.formulas._lexer import Lexer
 
 
 def test_lexer() -> None:
-    """Test the Lexer reading integer tokens."""
+    """Test the Lexer reading different kinds of tokens."""
     formula = "#123 + coalesce(#1 / 10.0, 0.0)"
     lexer = Lexer(formula)
     component = next(lexer)
     assert isinstance(component, _token.Component)
     assert component.id == "123"
-    assert component.span == (1, 4)
+    assert component.value == "#123"
+    assert component.span == (0, 4)
 
     plus_op = next(lexer)
     assert isinstance(plus_op, _token.Plus)
     assert plus_op.value == "+"
-    assert plus_op.span == (6, 6)
+    assert plus_op.span == (5, 6)
 
-    number = next(lexer)
-    assert isinstance(number, _token.Symbol)
-    assert number.value == "coalesce"
-    assert number.span == (8, 15)
+    symbol = next(lexer)
+    assert isinstance(symbol, _token.Symbol)
+    assert symbol.value == "coalesce"
+    assert symbol.span == (7, 15)
 
     open_paren = next(lexer)
     assert isinstance(open_paren, _token.OpenParen)
     assert open_paren.value == "("
-    assert open_paren.span == (16, 16)
+    assert open_paren.span == (15, 16)
 
     component = next(lexer)
     assert isinstance(component, _token.Component)
     assert component.id == "1"
-    assert component.span == (17, 18)
+    assert component.value == "#1"
+    assert component.span == (16, 18)
 
     div_op = next(lexer)
     assert isinstance(div_op, _token.Div)
     assert div_op.value == "/"
-    assert div_op.span == (20, 20)
+    assert div_op.span == (19, 20)
 
     number = next(lexer)
     assert isinstance(number, _token.Number)
     assert number.value == "10.0"
-    assert number.span == (22, 25)
+    assert number.span == (21, 25)
 
     comma = next(lexer)
     assert isinstance(comma, _token.Comma)
     assert comma.value == ","
-    assert comma.span == (26, 26)
+    assert comma.span == (25, 26)
 
     number = next(lexer)
     assert isinstance(number, _token.Number)
     assert number.value == "0.0"
-    assert number.span == (28, 30)
+    assert number.span == (27, 30)
 
     close_paren = next(lexer)
     assert isinstance(close_paren, _token.CloseParen)
     assert close_paren.value == ")"
-    assert close_paren.span == (31, 31)
+    assert close_paren.span == (30, 31)
 
-    try:
-        _ = next(lexer)
-        assert False, "Expected StopIteration"
-    except StopIteration:
-        pass
+    with pytest.raises(StopIteration):
+        next(lexer)
+
+
+@pytest.mark.parametrize("whitespace", ["", " ", "\n", "\t"])
+def test_lexer_formula_is_only_whitespace(whitespace: str) -> None:
+    """Test handling of whitespace-only formula in the Lexer."""
+    lexer = Lexer(whitespace)
+    tokens = list(lexer)
+    assert len(tokens) == 0
+
+
+def test_lexer_invalid_component_id() -> None:
+    """Test handling of invalid component IDs in the Lexer."""
+    lexer = Lexer("#")
+    with pytest.raises(FormulaSyntaxError) as ex_info:
+        next(lexer)
+    error_lines = str(ex_info.value).splitlines()
+    assert error_lines == [
+        "Formula syntax error:",
+        "  Formula: #",
+        "            ^ Expected integer after '#'",
+    ]
+
+    lexer = Lexer("#abc")
+    with pytest.raises(FormulaSyntaxError) as ex_info:
+        next(lexer)
+    error_lines = str(ex_info.value).splitlines()
+    assert error_lines == [
+        "Formula syntax error:",
+        "  Formula: #abc",
+        "            ^ Expected integer after '#'",
+    ]
+
+    lexer = Lexer("#-1")
+    with pytest.raises(FormulaSyntaxError) as ex_info:
+        next(lexer)
+    error_lines = str(ex_info.value).splitlines()
+    assert error_lines == [
+        "Formula syntax error:",
+        "  Formula: #-1",
+        "            ^ Expected integer after '#'",
+    ]
+
+
+def test_lexer_unexpected_character() -> None:
+    """Test handling of unexpected characters in the Lexer."""
+    lexer = Lexer("123 $ 456")
+    with pytest.raises(FormulaSyntaxError) as ex_info:
+        list(lexer)
+    error_lines = str(ex_info.value).splitlines()
+    assert error_lines == [
+        "Formula syntax error:",
+        "  Formula: 123 $ 456",
+        "               ^ Unexpected character",
+    ]


### PR DESCRIPTION
This PR improves formula validation and adds test coverage for all parser and lexer validation errors.

### Changes

1. Switch to conventional token span start/end semantics: [start, end). Spans are only used internally now, though (see (2)).
2. Introduced `FormulaError` and `FormulaSyntaxError` classes. `FormulaSyntaxError.__str__()` produces a human-readable error message, highlighting the offending span in the context of the original formula. This should be fit for non-technical end users.
3. Removed `ASTNode.span` property as it was unused.
4. Added tests and adapted existing ones to the changes described above.