### PR TITLE
Override Formula.cancel() and .wait() rather than .stop()

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -17,3 +17,5 @@
 - Improved formula validation: Consistent error messages for invalid formulas and conventional span semantics.
 
 - This fixes a rare power distributor bug where some battery inverters becoming unreachable because of network outages would lead to excess power values getting set.  This is fixed by measuring the power of the unreachable inverters through their fallback meters and excluding that power from what is distributed to the other inverters.
+
+- Fixed stopping formulas: It will now also stop the evaluator and sub-formulas correctly.

--- a/src/frequenz/sdk/timeseries/formulas/_formula.py
+++ b/src/frequenz/sdk/timeseries/formulas/_formula.py
@@ -98,12 +98,20 @@ class Formula(BackgroundService, Generic[QuantityT]):
         self._evaluator.start()
 
     @override
-    async def stop(self, msg: str | None = None) -> None:
-        """Stop the formula evaluator."""
-        await BackgroundService.stop(self, msg)
+    def cancel(self, msg: str | None = None) -> None:
+        """Cancel the formula evaluator."""
+        super().cancel(msg)
         for sub_formula in self._sub_formulas:
-            await sub_formula.stop(msg)
-        await self._evaluator.stop(msg)
+            sub_formula.cancel(msg)
+        self._evaluator.cancel(msg)
+
+    @override
+    async def wait(self) -> None:
+        """Wait for the formula evaluator to finish."""
+        await super().wait()
+        for sub_formula in self._sub_formulas:
+            await sub_formula.wait()
+        await self._evaluator.wait()
 
     def __add__(
         self, other: FormulaBuilder[QuantityT] | QuantityT | Formula[QuantityT]


### PR DESCRIPTION
Addresses https://github.com/frequenz-floss/frequenz-sdk-python/issues/1327.

Before this change, stopping a Formula would not stop the evaluator or any sub-formulas. The BackgroundService base class calls cancel() and wait(), but these must be overridden correctly to also cancel/await the evaluator and sub-formulas.