### PR TITLE
docs: fix typo and formating issue

### DIFF
--- a/docs/user-guide/glossary.md
+++ b/docs/user-guide/glossary.md
@@ -173,7 +173,7 @@ They are generally placed in front of another [component](#component), e.g., an
 
 #### Sensor
 
-A device for [measuring](#measurement] ambient [metrics](#metric) (for example
+A device for [measuring](#measurement) ambient [metrics](#metric) (for example
 temperature, humidity, etc.).
 
 ### Component

--- a/src/frequenz/sdk/config/__init__.py
+++ b/src/frequenz/sdk/config/__init__.py
@@ -41,10 +41,10 @@ disable it you can pass `logging_config_key=None` to the `ConfigManager`.
 
 # Receiving configurations
 
-To receive configurations, you can create a receiver using the [`new_receiver()`][
-frequenz.sdk.config.ConfigManager.new_receiver] method. The receiver will receive
-configurations from the manager for a particular key, and validate and load the
-configurations to a dataclass using [`marshmallow_dataclass`][].
+To receive configurations, you can create a receiver using the
+[`new_receiver()`][frequenz.sdk.config.ConfigManager.new_receiver] method. The
+receiver will receive configurations from the manager for a particular key, and
+validate and load the configurations to a dataclass using [`marshmallow_dataclass`][].
 
 If the key is a sequence of strings, it will be treated as a nested key and the
 receiver will receive the configuration under the nested key. For example


### PR DESCRIPTION
Fixed md link typo with wrong parentheses and formatting issue of another link, where it displayed the source instead of formatting it to a link because of linebrake in link syntax