### PR TITLE
Hold last known power bounds during transient data outages

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -14,4 +14,10 @@
 
 ## Bug Fixes
 
-<!-- Here goes notable bug fixes that are worth a special mention or explanation -->
+- Transient component data outages (e.g. Modbus timeouts) no longer collapse
+  the reported system power bounds to `[0, 0]`.  Previously the
+  `PowerManagingActor` propagated `inclusion_bounds=None` through to the
+  Matryoshka allocation algorithm which clamped it to zero, causing all
+  downstream actors to drop their setpoints.  The last known good bounds are
+  now retained when the bounds calculator emits `None` due to stale data.
+  (Fixes [#1396](https://github.com/frequenz-floss/frequenz-sdk-python/pull/1396))

--- a/src/frequenz/sdk/microgrid/_power_managing/_power_managing_actor.py
+++ b/src/frequenz/sdk/microgrid/_power_managing/_power_managing_actor.py
@@ -128,15 +128,43 @@ class PowerManagingActor(Actor):
         """
         last_bounds: SystemBounds | None = None
         async for bounds in bounds_receiver:
-            if (
-                last_bounds is not None
-                and bounds.inclusion_bounds == last_bounds.inclusion_bounds
-            ):
+            if not self._should_update_bounds(bounds, last_bounds):
+                last_bounds = bounds
                 continue
             last_bounds = bounds
             self._system_bounds[component_ids] = bounds
             await self._send_updated_target_power(component_ids, None)
             await self._send_reports(component_ids)
+
+    @staticmethod
+    def _should_update_bounds(
+        new_bounds: SystemBounds,
+        last_bounds: SystemBounds | None,
+    ) -> bool:
+        """Decide whether the bounds tracker should propagate *new_bounds*.
+
+        This is a no-op if *new_bounds* is identical to *last_bounds*.  When
+        the system loses contact with a component (e.g.  a Modbus timeout) the
+        BoundsCalculator emits ``inclusion_bounds=None``.  If we already know
+        good bounds we hold them — "no data" is not the same as "zero power
+        available".
+        """
+        if last_bounds is None:
+            return True
+        if new_bounds.inclusion_bounds == last_bounds.inclusion_bounds:
+            return False
+        if (
+            new_bounds.inclusion_bounds is None
+            and last_bounds.inclusion_bounds is not None
+        ):
+            _logger.warning(
+                "PowerManagingActor: ignoring transient bounds outage. "
+                "Holding last known bounds [%s, %s]",
+                last_bounds.inclusion_bounds.lower,
+                last_bounds.inclusion_bounds.upper,
+            )
+            return False
+        return True
 
     def _add_system_bounds_tracker(self, component_ids: frozenset[ComponentId]) -> None:
         """Add a system bounds tracker for the given components.

--- a/tests/microgrid/_power_managing/test_power_managing_actor.py
+++ b/tests/microgrid/_power_managing/test_power_managing_actor.py
@@ -1,0 +1,89 @@
+# License: MIT
+# Copyright © 2024 Frequenz Energy-as-a-Service GmbH
+
+"""Tests for PowerManagingActor."""
+
+# pylint: disable=protected-access
+# We access _should_update_bounds directly (a static helper) rather than
+# going through the full async bounds tracker machinery.
+
+from datetime import datetime, timezone
+
+from frequenz.quantities import Power
+
+from frequenz.sdk.microgrid._power_managing._power_managing_actor import (
+    PowerManagingActor,
+)
+from frequenz.sdk.timeseries._base_types import Bounds, SystemBounds
+
+
+class TestPowerManagingActor:
+    """Tests for PowerManagingActor._should_update_bounds."""
+
+    def _bounds(
+        self,
+        lower_w: float | None,
+        upper_w: float | None,
+    ) -> SystemBounds:
+        """Create a SystemBounds with the given inclusion bounds."""
+        now = datetime.now(tz=timezone.utc)
+        inc = (
+            Bounds(Power.from_watts(lower_w), Power.from_watts(upper_w))
+            if lower_w is not None and upper_w is not None
+            else None
+        )
+        return SystemBounds(timestamp=now, inclusion_bounds=inc, exclusion_bounds=None)
+
+    def test_first_bounds_accepted(self) -> None:
+        """The very first bounds should always be accepted."""
+        b = self._bounds(-1.3e6, 1.3e6)
+        assert PowerManagingActor._should_update_bounds(b, None)
+
+    def test_identical_bounds_skipped(self) -> None:
+        """No-change updates are a no-op."""
+        b = self._bounds(-1.3e6, 1.3e6)
+        same = self._bounds(-1.3e6, 1.3e6)
+        assert not PowerManagingActor._should_update_bounds(same, b)
+
+    def test_changed_valid_bounds_accepted(self) -> None:
+        """A real change in bounds should be propagated."""
+        b1 = self._bounds(-1.3e6, 1.3e6)
+        b2 = self._bounds(-1.0e6, 1.0e6)
+        assert PowerManagingActor._should_update_bounds(b2, b1)
+
+    def test_transient_none_ignored(self) -> None:
+        """When data goes stale, inclusion_bounds=None must NOT overwrite valid bounds."""
+        valid = self._bounds(-1.3e6, 1.3e6)
+        none_bounds = self._bounds(None, None)
+        assert not PowerManagingActor._should_update_bounds(
+            none_bounds, valid
+        ), "transient None must not replace valid bounds"
+
+    def test_none_after_none_irrelevant(self) -> None:
+        """Repeated None-bounds are a no-op."""
+        none1 = self._bounds(None, None)
+        none2 = self._bounds(None, None)
+        assert not PowerManagingActor._should_update_bounds(none2, none1)
+
+    def test_valid_after_none_accepted(self) -> None:
+        """When data resumes, valid bounds must be accepted."""
+        none_bounds = self._bounds(None, None)
+        valid = self._bounds(-1.3e6, 1.3e6)
+        assert PowerManagingActor._should_update_bounds(valid, none_bounds)
+        assert PowerManagingActor._should_update_bounds(valid, None)
+
+    def test_real_zero_bounds_accepted(self) -> None:
+        """Bounds that are truly [0, 0] (not stale-data) must be propagated."""
+        valid = self._bounds(-1.3e6, 1.3e6)
+        zero = self._bounds(0.0, 0.0)
+        assert PowerManagingActor._should_update_bounds(
+            zero, valid
+        ), "real zero bounds must propagate even though they look like a collapse"
+
+    def test_almost_zero_bounds_accepted(self) -> None:
+        """Very small but non-zero bounds are still real data."""
+        valid = self._bounds(-1.3e6, 1.3e6)
+        tiny = self._bounds(-100.0, 100.0)
+        assert PowerManagingActor._should_update_bounds(
+            tiny, valid
+        ), "small-but-non-zero bounds must propagate"


### PR DESCRIPTION
When the microgrid API loses contact with a component (e.g. a Modbus timeout), the `PowerBoundsCalculator` emits `SystemBounds` with `inclusion_bounds=None`. The `PowerManagingActor`'s bounds tracker propagated this `None` value to the Matryoshka allocation algorithm, which clamped it to `[0, 0]` (via the `else: Power.zero()` branch in `_calc_targets`). All downstream actors then saw zero available power and dropped their setpoints to 0 W, even though the hardware was capable of full power and the telemetry interruption lasted only a few seconds.

The root cause is a semantic mismatch: "no data" is not the same as "zero power available". Treating them as equivalent means a short telemetry glitch collapses the energy throughput of an entire site.

**Fix**

`_should_update_bounds()` returns `False` when `inclusion_bounds` becomes `None` after having been valid. The bounds tracker holds the last known good bounds and only updates when real data resumes. Transient telemetry outages no longer collapse power allocations.

**Testing**

The logic is extracted into the static helper `PowerManagingActor._should_update_bounds()` with 8 unit tests that cover:

- first-ever bounds accepted
- identical bounds skipped (no-op dedup)
- genuine bound changes propagated
- `inclusion_bounds=None` after valid bounds — ignored
- `inclusion_bounds=None` -> `None` — still ignored
- valid bounds after `None` — accepted
- real `[0, 0]` bounds from actual sensor data — still propagated (the guard only blocks the `None` -> `[0, 0]` path)
