### PR TITLE
Update microgrid client to v0.18.3+

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -11,3 +11,4 @@ Along with the new `tick_delay` resampler config option, this release also inclu
 ## Bug Fixes
 
 * Accept `ComponentDataSamples` that only carry state changes (the state changes were dropped before).
+* Update microgrid client to v0.18.3+, which fixes a problem with missing steam boilers on formula generation.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
   # Make sure to update the mkdocs.yml file when
   # changing the version
   # (plugins.mkdocstrings.handlers.python.import)
-  "frequenz-client-microgrid >= 0.18.1, < 0.19.0",
+  "frequenz-client-microgrid >= 0.18.3, < 0.19.0",
   "frequenz-microgrid-component-graph >= 0.4, < 0.5",
   "frequenz-client-common >= 0.3.6, < 0.4.0",
   "frequenz-channels >= 1.6.1, < 2.0.0",


### PR DESCRIPTION
Previous versions are missing steam boiler support and cause problems in the formula generation step.