### PR TITLE
Fix unreachable-power formula leak in the power distributor

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,8 +10,9 @@
 
 ## New Features
 
-<!-- Here goes the main new features and examples or instructions on how to use them -->
+* The PV inverter manager now accounts for the power measured on unreachable PV inverters when distributing power, so the reachable inverters compensate for it (matching the battery manager's behavior).
 
 ## Bug Fixes
 
-<!-- Here goes notable bug fixes that are worth a special mention or explanation -->
+* Fixed a resource leak in the power distributor: the formulas created for unreachable batteries were never stopped, so CPU usage slowly climbed over time until the application was restarted.
+* Fixed the grid reactive-power formula being recreated and leaked on every access instead of being reused from the cache.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,6 +7,7 @@
 ## Upgrading
 
 * Update microgrid client to v0.18.3+, which fixes a problem with missing steam boilers on formula generation.
+* The PV inverter manager now subtracts the power measured on unreachable PV inverters from the distribution target, so the power sent to the reachable inverters can change when some requested PV inverters are unreachable.
 
 ## New Features
 

--- a/src/frequenz/sdk/microgrid/_data_pipeline.py
+++ b/src/frequenz/sdk/microgrid/_data_pipeline.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import logging
 import typing
+import uuid
 from collections import abc
 from dataclasses import dataclass
 from datetime import timedelta
@@ -27,6 +28,9 @@ from ..timeseries._voltage_streamer import VoltageStreamer
 from ._data_sourcing import ComponentMetricRequest, DataSourcingActor
 from ._power_managing._base_classes import DefaultPower, PowerManagerAlgorithm
 from ._power_wrapper import PowerWrapper
+
+if typing.TYPE_CHECKING:
+    from ..timeseries.formulas._formula_pool import FormulaPool
 
 # A number of imports had to be done inside functions where they are used, to break
 # import cycles.
@@ -183,6 +187,31 @@ class _DataPipeline:  # pylint: disable=too-many-instance-attributes
                 resampler_subscription_sender=self._resampling_request_sender(),
             )
         return self._logical_meter
+
+    def new_formula_pool(self, namespace: str) -> FormulaPool:
+        """Create a new, empty formula pool.
+
+        The caller owns the returned pool and is responsible for stopping it.
+
+        Args:
+            namespace: A label describing what the pool is for; a unique suffix is
+                appended so its resampler subscriptions don't collide with other
+                pools that share the channel registry.
+
+        Returns:
+            A new, empty formula pool.
+        """
+        # Imported here (not at module level) to avoid an import cycle, mirroring
+        # `logical_meter()` above.
+        from ..timeseries.formulas._formula_pool import (  # pylint: disable=import-outside-toplevel
+            FormulaPool,
+        )
+
+        return FormulaPool(
+            f"{namespace}-{uuid.uuid4()}",
+            self._channel_registry,
+            self._resampling_request_sender(),
+        )
 
     def consumer(self) -> Consumer:
         """Return the consumption measuring point of the microgrid."""
@@ -555,6 +584,19 @@ def voltage_per_phase() -> VoltageStreamer:
 def logical_meter() -> LogicalMeter:
     """Return the logical meter of the microgrid."""
     return _get().logical_meter()
+
+
+def _new_formula_pool(namespace: str) -> FormulaPool:
+    """Create a new, empty formula pool owned by the caller.
+
+    Args:
+        namespace: A label describing what the pool is for (a unique suffix is
+            appended).
+
+    Returns:
+        A new, empty formula pool.
+    """
+    return _get().new_formula_pool(namespace)
 
 
 def consumer() -> Consumer:

--- a/src/frequenz/sdk/microgrid/_power_distributing/_component_managers/_battery_manager.py
+++ b/src/frequenz/sdk/microgrid/_power_distributing/_component_managers/_battery_manager.py
@@ -14,11 +14,9 @@ from frequenz.channels import LatestValueCache, Receiver, Sender
 from frequenz.client.common.microgrid.components import ComponentId
 from frequenz.client.microgrid import ApiClientError, OperationOutOfRange
 from frequenz.client.microgrid.component import Battery, Inverter
-from frequenz.client.microgrid.metrics import Metric
 from frequenz.quantities import Power
 from typing_extensions import override
 
-from ....timeseries import Sample
 from ... import connection_manager
 from ..._old_component_data import BatteryData, InverterData
 from .._component_pool_status_tracker import ComponentPoolStatusTracker
@@ -146,6 +144,7 @@ class BatteryManager(ComponentManager):  # pylint: disable=too-many-instance-att
             api_power_request_timeout: Timeout to use when making power requests to
                 the microgrid API.
         """
+        super().__init__()
         self._results_sender = results_sender
         self._api_power_request_timeout = api_power_request_timeout
         self._batteries = connection_manager.get().component_graph.components(
@@ -162,20 +161,6 @@ class BatteryManager(ComponentManager):  # pylint: disable=too-many-instance-att
 
         self._battery_caches: dict[ComponentId, LatestValueCache[BatteryData]] = {}
         self._inverter_caches: dict[ComponentId, LatestValueCache[InverterData]] = {}
-
-        self._unreachable_battery_powers: dict[
-            frozenset[ComponentId],
-            tuple[collections.abc.Set[ComponentId], LatestValueCache[Sample[Power]]],
-        ] = {}
-        """Map from battery sets to data from inaccessible battery subset.
-
-        When batteries are inaccessible, for example, due to network issues and can't be
-        controlled, they might still be producing or consuming power.  This power needs
-        to be considered when distributing power to the other batteries.
-
-        So for each battery set, we track of the inaccessible subset of this battery set
-        and the result of the power formulas for the inaccessible subset here.
-        """
 
         self._component_pool_status_tracker = ComponentPoolStatusTracker(
             component_ids=set(self._battery_ids),
@@ -219,6 +204,7 @@ class BatteryManager(ComponentManager):  # pylint: disable=too-many-instance-att
         for inv_cache in self._inverter_caches.values():
             await inv_cache.stop()
         await self._component_pool_status_tracker.stop()
+        await self._stop_all_unreachable_power_subscriptions()
 
     @override
     async def distribute_power(self, request: Request) -> None:
@@ -536,76 +522,12 @@ class BatteryManager(ComponentManager):  # pylint: disable=too-many-instance-att
 
         return InvBatPair(AggregatedBatteryData(battery_data), inverter_data)
 
-    async def _subscribe_to_unreachable_battery_power(
-        self,
-        requested_battery_ids: collections.abc.Set[ComponentId],
-        working_battery_ids: collections.abc.Set[ComponentId],
-    ) -> None:
-        requested_battery_ids = frozenset(requested_battery_ids)
-        unreachable_battery_ids = requested_battery_ids - working_battery_ids
-
-        if not unreachable_battery_ids:
-            if unreachable_power := self._unreachable_battery_powers.pop(
-                requested_battery_ids, None
-            ):
-                _logger.debug(
-                    "All batteries are reachable, stopping unreachable battery power "
-                    + "subscription for batteries %s",
-                    self._str_ids(requested_battery_ids),
-                )
-                await unreachable_power[1].stop()
-            return
-
-        if unreachable_power := self._unreachable_battery_powers.get(
-            requested_battery_ids
-        ):
-            if unreachable_power[0] == unreachable_battery_ids:
-                return
-            _logger.debug(
-                "Unreachable battery set for batteries %s changed from %s to %s, "
-                + "restarting subscription",
-                self._str_ids(requested_battery_ids),
-                self._str_ids(unreachable_power[0]),
-                self._str_ids(unreachable_battery_ids),
-            )
-            await unreachable_power[1].stop()
-
-        formula = connection_manager.get().component_graph.battery_formula(
-            unreachable_battery_ids
-        )
-        _logger.debug(
-            "Subscribing to unreachable battery power for batteries %s with formula: %s",
-            self._str_ids(unreachable_battery_ids),
-            formula,
-        )
-
-        # This is to avoid a circular import.  Pylint doesn't detect that this
-        # is not a circular import, so we need to disable the warning also.
-        #
-        # pylint: disable-next=import-outside-toplevel,cyclic-import
-        from ... import (
-            logical_meter,
-        )
-
-        formula_cache = LatestValueCache(
-            logical_meter()
-            .start_formula(formula, Metric.AC_ACTIVE_POWER)
-            .new_receiver()
-            .map(
-                lambda sample: Sample[Power](
-                    sample.timestamp,
-                    (
-                        Power.from_watts(sample.value.base_value)
-                        if sample.value is not None
-                        else None
-                    ),
-                )
-            )
-        )
-        self._unreachable_battery_powers[requested_battery_ids] = (
-            unreachable_battery_ids,
-            formula_cache,
-        )
+    @override
+    def _unreachable_power_formula(
+        self, component_ids: collections.abc.Set[ComponentId]
+    ) -> str:
+        """Return the formula for the active power of the given batteries."""
+        return connection_manager.get().component_graph.battery_formula(component_ids)
 
     async def _get_components_data(
         self, batteries: collections.abc.Set[ComponentId]
@@ -629,7 +551,7 @@ class BatteryManager(ComponentManager):  # pylint: disable=too-many-instance-att
             batteries
         )
 
-        await self._subscribe_to_unreachable_battery_power(
+        await self._subscribe_to_unreachable_power(
             batteries,
             working_batteries,
         )
@@ -676,16 +598,9 @@ class BatteryManager(ComponentManager):  # pylint: disable=too-many-instance-att
             assert len(data.inverter) > 0
             pairs_data.append(data)
 
-        unreachable_power: Power | None = None
-        if unreachable_power_cache := self._unreachable_battery_powers.get(
-            frozenset(batteries)
-        ):
-            if unreachable_power_cache[1].has_value():
-                unreachable_power = unreachable_power_cache[1].get().value
-
         return BatteryComponentsData(
             inv_bat_pairs=pairs_data,
-            unreachable_power=unreachable_power,
+            unreachable_power=self._unreachable_power(batteries),
         )
 
     def _str_ids(self, ids: collections.abc.Set[ComponentId]) -> str:

--- a/src/frequenz/sdk/microgrid/_power_distributing/_component_managers/_component_manager.py
+++ b/src/frequenz/sdk/microgrid/_power_distributing/_component_managers/_component_manager.py
@@ -1,34 +1,92 @@
 # License: MIT
 # Copyright © 2022 Frequenz Energy-as-a-Service GmbH
 
-"""Manage batteries and inverters for the power distributor."""
+"""Manage the data streams for the components of the power distributor."""
 
 import abc
 import collections.abc
+import logging
+import typing
 
-from frequenz.channels import Sender
+from frequenz.channels import LatestValueCache
 from frequenz.client.common.microgrid.components import ComponentId
+from frequenz.client.microgrid.metrics import Metric
+from frequenz.quantities import Power, Quantity
 
-from .._component_status import ComponentPoolStatus
+from ....timeseries import Sample
 from ..request import Request
-from ..result import Result
+
+if typing.TYPE_CHECKING:
+    from ....timeseries.formulas._formula_pool import FormulaPool
+
+_logger = logging.getLogger(__name__)
+
+
+def _quantity_sample_to_power(sample: Sample[Quantity]) -> Sample[Power]:
+    """Convert a generic quantity sample from a formula into a power sample.
+
+    Args:
+        sample: The sample produced by an unreachable-power formula.
+
+    Returns:
+        The same sample with its value expressed as `Power`.
+    """
+    return Sample[Power](
+        sample.timestamp,
+        (
+            Power.from_watts(sample.value.base_value)
+            if sample.value is not None
+            else None
+        ),
+    )
+
+
+class _UnreachablePower(typing.NamedTuple):
+    """A live subscription to the power of an unreachable subset of components."""
+
+    component_ids: collections.abc.Set[ComponentId]
+    """The inaccessible components whose power this subscription tracks."""
+
+    formula: str
+    """The formula string the pooled formula was created from.
+
+    Stored so teardown can stop and evict exactly that formula from the owned pool
+    by its string, instead of recomputing it (which would couple correct eviction
+    to the formula generator staying deterministic).
+    """
+
+    cache: LatestValueCache[Sample[Power]]
+    """A latest-value cache of the formula's result."""
 
 
 class ComponentManager(abc.ABC):
     """Abstract class to manage the data streams for components."""
 
-    @abc.abstractmethod
-    def __init__(
-        self,
-        component_pool_status_sender: Sender[ComponentPoolStatus],
-        results_sender: Sender[Result],
-    ):
-        """Initialize the component data manager.
+    def __init__(self) -> None:
+        """Initialize the state shared by all component managers.
 
-        Args:
-            component_pool_status_sender: Channel for sending information about which
-                components are expected to be working.
-            results_sender: Channel for sending the results of power distribution.
+        Subclasses must call `super().__init__()`.
+        """
+        self._unreachable_power_subscriptions: dict[
+            frozenset[ComponentId], _UnreachablePower
+        ] = {}
+        """Maps a requested component set to its unreachable subset's power.
+
+        When components are inaccessible, for example due to network issues, they
+        can't be controlled but might still be producing or consuming power.  That
+        power is measured by a formula and subtracted from the distribution target
+        so the reachable components compensate for it.  So for each requested set we
+        track the inaccessible subset, the formula string, and a latest-value cache
+        of the formula's result for that subset.
+        """
+
+        self._unreachable_power_pool: "FormulaPool | None" = None
+        """A formula pool owned by this manager for the unreachable-power formulas.
+
+        Created lazily on the first subscription (so managers that never subscribe
+        pay nothing).  Owning the pool keeps these formulas isolated from the shared
+        logical meter and lets the manager stop all of them together, bounding the
+        leak to the manager's own lifetime.
         """
 
     @abc.abstractmethod
@@ -45,11 +103,154 @@ class ComponentManager(abc.ABC):
 
         Args:
             request: Request to get the distribution for.
-
-        Returns:
-            Result of the distribution.
         """
 
     @abc.abstractmethod
     async def stop(self) -> None:
         """Stop the component data manager."""
+
+    def _unreachable_power_formula(
+        self, component_ids: collections.abc.Set[ComponentId]
+    ) -> str:
+        """Return a formula string for the active power of the given components.
+
+        Managers that subscribe to unreachable power must override this to return
+        the component-graph formula for their component type (e.g. `battery_formula`
+        or `pv_formula`).
+
+        Args:
+            component_ids: The components to build the power formula for.
+
+        Returns:
+            A formula string for the active power of the given components.
+
+        Raises:
+            NotImplementedError: If the manager subscribes to unreachable power
+                without overriding this method.
+        """
+        raise NotImplementedError(
+            f"{type(self).__name__} subscribed to unreachable power without "
+            "providing an unreachable-power formula."
+        )
+
+    async def _subscribe_to_unreachable_power(
+        self,
+        requested_ids: collections.abc.Set[ComponentId],
+        working_ids: collections.abc.Set[ComponentId],
+    ) -> None:
+        """Track the power of the unreachable subset of the requested components.
+
+        Idempotent per requested set: re-subscribes only when the unreachable subset
+        changes, and tears the subscription down once nothing is unreachable anymore.
+
+        Args:
+            requested_ids: The components the current request targets.
+            working_ids: The subset of `requested_ids` that is currently reachable.
+        """
+        requested = frozenset(requested_ids)
+        unreachable = requested - working_ids
+
+        existing = self._unreachable_power_subscriptions.get(requested)
+        if not unreachable:
+            if existing is not None:
+                _logger.debug(
+                    "All requested components are reachable again; stopping the "
+                    "unreachable-power subscription for %s.",
+                    sorted(requested),
+                )
+                del self._unreachable_power_subscriptions[requested]
+                await self._stop_unreachable_power_subscription(existing)
+            return
+        if existing is not None:
+            if existing.component_ids == unreachable:
+                return
+            _logger.debug(
+                "Unreachable subset of %s changed to %s; restarting its power "
+                "subscription.",
+                sorted(requested),
+                sorted(unreachable),
+            )
+            del self._unreachable_power_subscriptions[requested]
+            await self._stop_unreachable_power_subscription(existing)
+
+        if self._unreachable_power_pool is None:
+            # Imported here, and the pool created lazily, to avoid an import cycle
+            # with the data pipeline (which imports the power distributor).
+            #
+            # pylint: disable-next=import-outside-toplevel,cyclic-import
+            from ..._data_pipeline import _new_formula_pool
+
+            self._unreachable_power_pool = _new_formula_pool(
+                "unreachable-component-power"
+            )
+
+        formula = self._unreachable_power_formula(unreachable)
+        _logger.debug(
+            "Subscribing to the power of unreachable components %s with formula: %s",
+            sorted(unreachable),
+            formula,
+        )
+        cache = LatestValueCache(
+            self._unreachable_power_pool.from_string(formula, Metric.AC_POWER_ACTIVE)
+            .new_receiver()
+            .map(_quantity_sample_to_power)
+        )
+        self._unreachable_power_subscriptions[requested] = _UnreachablePower(
+            unreachable, formula, cache
+        )
+
+    def _unreachable_power(
+        self, requested_ids: collections.abc.Set[ComponentId]
+    ) -> Power | None:
+        """Return the latest power measured on the unreachable components.
+
+        Args:
+            requested_ids: The components the request targets.
+
+        Returns:
+            The latest cached power of the unreachable subset, or `None` if there is
+            no subscription for this set or no value has arrived yet.
+        """
+        subscription = self._unreachable_power_subscriptions.get(
+            frozenset(requested_ids)
+        )
+        if subscription is not None and subscription.cache.has_value():
+            return subscription.cache.get().value
+        return None
+
+    async def _stop_unreachable_power_subscription(
+        self, subscription: _UnreachablePower
+    ) -> None:
+        """Tear down one unreachable-power subscription.
+
+        The subscription must already have been removed from
+        `_unreachable_power_subscriptions` so the shared-formula check below is
+        accurate.
+
+        Args:
+            subscription: The subscription to stop.
+        """
+        try:
+            # try/finally so the formula is stopped even if stopping the cache fails
+            # — otherwise the formula would leak.
+            await subscription.cache.stop()
+        finally:
+            # The pool caches one formula per distinct formula string and keeps it
+            # (and its evaluating actor) running for the life of the manager, so stop
+            # it once no remaining subscription references the same formula.
+            if self._unreachable_power_pool is not None and not any(
+                other.formula == subscription.formula
+                for other in self._unreachable_power_subscriptions.values()
+            ):
+                await self._unreachable_power_pool.stop_string_formula(
+                    subscription.formula, Metric.AC_POWER_ACTIVE
+                )
+
+    async def _stop_all_unreachable_power_subscriptions(self) -> None:
+        """Stop every unreachable-power subscription and the owned formula pool."""
+        for subscription in self._unreachable_power_subscriptions.values():
+            await subscription.cache.stop()
+        self._unreachable_power_subscriptions.clear()
+        if self._unreachable_power_pool is not None:
+            await self._unreachable_power_pool.stop()
+            self._unreachable_power_pool = None

--- a/src/frequenz/sdk/microgrid/_power_distributing/_component_managers/_ev_charger_manager/_ev_charger_manager.py
+++ b/src/frequenz/sdk/microgrid/_power_distributing/_component_managers/_ev_charger_manager/_ev_charger_manager.py
@@ -57,6 +57,7 @@ class EVChargerManager(ComponentManager):
             api_power_request_timeout: Timeout to use when making power requests to
                 the microgrid API.
         """
+        super().__init__()
         self._results_sender = results_sender
         self._api_power_request_timeout = api_power_request_timeout
         self._ev_charger_ids = self._get_ev_charger_ids()

--- a/src/frequenz/sdk/microgrid/_power_distributing/_component_managers/_pv_inverter_manager/_pv_inverter_manager.py
+++ b/src/frequenz/sdk/microgrid/_power_distributing/_component_managers/_pv_inverter_manager/_pv_inverter_manager.py
@@ -46,6 +46,7 @@ class PVManager(ComponentManager):
             api_power_request_timeout: Timeout to use when making power requests to
                 the microgrid API.
         """
+        super().__init__()
         self._results_sender = results_sender
         self._api_power_request_timeout = api_power_request_timeout
         self._pv_inverter_ids = self._get_pv_inverter_ids()
@@ -90,6 +91,7 @@ class PVManager(ComponentManager):
         )
         if self._component_pool_status_tracker:
             await self._component_pool_status_tracker.stop()
+        await self._stop_all_unreachable_power_subscriptions()
 
     @override
     async def distribute_power(self, request: Request) -> None:
@@ -119,10 +121,21 @@ class PVManager(ComponentManager):
                 "Cannot distribute power to PV inverters without any inverters"
             )
 
-        working_components: list[ComponentId] = []
-        for inv_id in self._component_pool_status_tracker.get_working_components(
+        working = self._component_pool_status_tracker.get_working_components(
             request.component_ids
-        ):
+        )
+        await self._subscribe_to_unreachable_power(request.component_ids, working)
+        unreachable_power = self._unreachable_power(request.component_ids)
+        if unreachable_power is not None:
+            remaining_power -= unreachable_power
+            _logger.debug(
+                "Excluding %s measured on unreachable PV inverters from the power to "
+                "distribute on working PV inverters.",
+                unreachable_power,
+            )
+
+        working_components: list[ComponentId] = []
+        for inv_id in working:
             if self._component_data_caches[inv_id].has_value():
                 working_components.append(inv_id)
             else:
@@ -185,6 +198,13 @@ class PVManager(ComponentManager):
             component_category="PV inverter",
         )
         await self._results_sender.send(result)
+
+    @override
+    def _unreachable_power_formula(
+        self, component_ids: collections.abc.Set[ComponentId]
+    ) -> str:
+        """Return the formula for the active power of the given PV inverters."""
+        return connection_manager.get().component_graph.pv_formula(component_ids)
 
     def _get_pv_inverter_ids(self) -> collections.abc.Set[ComponentId]:
         """Return the IDs of all PV inverters present in the component graph."""

--- a/src/frequenz/sdk/timeseries/formulas/_formula_pool.py
+++ b/src/frequenz/sdk/timeseries/formulas/_formula_pool.py
@@ -136,7 +136,7 @@ class FormulaPool:
         Returns:
             A formula that evaluates the given formula.
         """
-        if channel_key in self.power_formulas:
+        if channel_key in self._reactive_power_formulas:
             return self._reactive_power_formulas[channel_key]
 
         if formula_str == "0.0":

--- a/src/frequenz/sdk/timeseries/formulas/_formula_pool.py
+++ b/src/frequenz/sdk/timeseries/formulas/_formula_pool.py
@@ -61,7 +61,7 @@ class FormulaPool:
             resampler_subscription_sender
         )
 
-        self._string_formulas: dict[str, Formula[Quantity]] = {}
+        self._string_formulas: dict[tuple[str, Metric], Formula[Quantity]] = {}
         self.power_formulas: dict[str, Formula[Power]] = {}
         self._reactive_power_formulas: dict[str, Formula[ReactivePower]] = {}
         self._current_formulas: dict[str, Formula3Phase[Current]] = {}
@@ -84,16 +84,16 @@ class FormulaPool:
         Returns:
             A Formula that streams values with the formulas applied.
         """
-        channel_key = formula_str + str(metric.value)
-        if channel_key in self._string_formulas:
-            return self._string_formulas[channel_key]
+        key = (formula_str, metric)
+        if key in self._string_formulas:
+            return self._string_formulas[key]
         formula = parse(
-            name=channel_key,
+            name=f"{formula_str}:{metric.name}",
             formula=formula_str,
             telemetry_fetcher=self._telemetry_fetcher(metric),
             create_method=Quantity,
         )
-        self._string_formulas[channel_key] = formula
+        self._string_formulas[key] = formula
         return formula
 
     def from_power_formula(self, channel_key: str, formula_str: str) -> Formula[Power]:
@@ -258,8 +258,8 @@ class FormulaPool:
             formula_str: The formula string passed to `from_string`.
             metric: The metric passed to `from_string`.
         """
-        channel_key = formula_str + str(metric.value)
-        formula = self._string_formulas.pop(channel_key, None)
+        key = (formula_str, metric)
+        formula = self._string_formulas.pop(key, None)
         if formula is not None:
             await formula.stop()
 

--- a/src/frequenz/sdk/timeseries/formulas/_formula_pool.py
+++ b/src/frequenz/sdk/timeseries/formulas/_formula_pool.py
@@ -248,6 +248,12 @@ class FormulaPool:
 
     async def stop(self) -> None:
         """Stop all formulas."""
+        # Snapshot with list(): `await sf.stop()` yields, and a concurrent
+        # `from_string` could otherwise mutate the dict mid-iteration.
+        for sf in list(self._string_formulas.values()):
+            await sf.stop()
+        self._string_formulas.clear()
+
         for pf in self.power_formulas.values():
             await pf.stop()
         self.power_formulas.clear()

--- a/src/frequenz/sdk/timeseries/formulas/_formula_pool.py
+++ b/src/frequenz/sdk/timeseries/formulas/_formula_pool.py
@@ -246,6 +246,23 @@ class FormulaPool:
 
         return formula
 
+    async def stop_string_formula(self, formula_str: str, metric: Metric) -> None:
+        """Stop and evict a formula previously created with `from_string`.
+
+        Callers that create short-lived formulas (e.g. one per changing set of
+        components) must call this when the formula is no longer needed —
+        otherwise the underlying formula-evaluating actor keeps running and the
+        pool's cache grows without bound.
+
+        Args:
+            formula_str: The formula string passed to `from_string`.
+            metric: The metric passed to `from_string`.
+        """
+        channel_key = formula_str + str(metric.value)
+        formula = self._string_formulas.pop(channel_key, None)
+        if formula is not None:
+            await formula.stop()
+
     async def stop(self) -> None:
         """Stop all formulas."""
         # Snapshot with list(): `await sf.stop()` yields, and a concurrent

--- a/src/frequenz/sdk/timeseries/formulas/_formula_pool.py
+++ b/src/frequenz/sdk/timeseries/formulas/_formula_pool.py
@@ -5,6 +5,7 @@
 
 import logging
 import sys
+from typing import TypeVar
 
 from frequenz.channels import Sender
 from frequenz.client.microgrid.metrics import Metric
@@ -15,12 +16,16 @@ from frequenz.sdk.timeseries.formulas._resampled_stream_fetcher import (
 )
 
 from ..._internal._channels import ChannelRegistry
+from ...actor import BackgroundService
 from ...microgrid._data_sourcing import ComponentMetricRequest
 from ._formula import Formula
 from ._formula_3_phase import Formula3Phase
 from ._parser import parse
 
 _logger = logging.getLogger(__name__)
+
+_KeyT = TypeVar("_KeyT")
+_FormulaT = TypeVar("_FormulaT", bound=BackgroundService)
 
 
 NON_EXISTING_COMPONENT_ID = sys.maxsize
@@ -259,33 +264,45 @@ class FormulaPool:
             metric: The metric passed to `from_string`.
         """
         key = (formula_str, metric)
-        formula = self._string_formulas.pop(key, None)
-        if formula is not None:
-            await formula.stop()
+        formula = self._string_formulas.get(key)
+        if formula is None:
+            return
+        # Stop before evicting: if stop() is cancelled or raises, the handle stays
+        # in the pool so cleanup can be retried instead of the evaluating actor
+        # leaking with no way to reach it.
+        await formula.stop()
+        # Evict only the formula we actually stopped, in case a concurrent
+        # from_string() replaced the entry while stop() was awaiting.
+        if self._string_formulas.get(key) is formula:
+            del self._string_formulas[key]
 
     async def stop(self) -> None:
         """Stop all formulas."""
-        # Snapshot with list(): `await sf.stop()` yields, and a concurrent
-        # `from_string` could otherwise mutate the dict mid-iteration.
-        for sf in list(self._string_formulas.values()):
-            await sf.stop()
-        self._string_formulas.clear()
+        await self._stop_all(self._string_formulas)
+        await self._stop_all(self.power_formulas)
+        await self._stop_all(self._reactive_power_formulas)
+        await self._stop_all(self._power_3_phase_formulas)
+        await self._stop_all(self._current_3_phase_formulas)
 
-        for pf in self.power_formulas.values():
-            await pf.stop()
-        self.power_formulas.clear()
+    @staticmethod
+    async def _stop_all(formulas: dict[_KeyT, _FormulaT]) -> None:
+        """Stop and evict every formula in a cache.
 
-        for rpf in self._reactive_power_formulas.values():
-            await rpf.stop()
-        self._reactive_power_formulas.clear()
+        Iterates a snapshot of the keys and removes each entry only after its
+        `stop()` completes. A formula added concurrently (e.g. by `from_string`
+        while this awaits) is not in the snapshot, so it is left in the cache
+        rather than being dropped without being stopped.
 
-        for p3pf in self._power_3_phase_formulas.values():
-            await p3pf.stop()
-        self._power_3_phase_formulas.clear()
-
-        for c3pf in self._current_3_phase_formulas.values():
-            await c3pf.stop()
-        self._current_3_phase_formulas.clear()
+        Args:
+            formulas: The formula cache to drain.
+        """
+        for key in list(formulas):
+            formula = formulas.get(key)
+            if formula is None:
+                continue  # already evicted by a concurrent teardown
+            await formula.stop()
+            if formulas.get(key) is formula:
+                del formulas[key]
 
     def _telemetry_fetcher(self, metric: Metric) -> ResampledStreamFetcher:
         """Create a ResampledStreamFetcher for the given metric.

--- a/tests/microgrid/power_distributing/test_unreachable_power.py
+++ b/tests/microgrid/power_distributing/test_unreachable_power.py
@@ -1,0 +1,287 @@
+# License: MIT
+# Copyright © 2025 Frequenz Energy-as-a-Service GmbH
+
+"""Tests for the power distributor's unreachable-power handling."""
+
+from __future__ import annotations
+
+from collections import abc
+from datetime import timedelta
+from typing import cast
+from unittest.mock import AsyncMock
+
+import pytest
+from frequenz.channels import Broadcast, LatestValueCache, Receiver
+from frequenz.client.common.microgrid.components import ComponentId
+from frequenz.client.microgrid.metrics import Metric
+from frequenz.quantities import Power, Quantity
+from pytest_mock import MockerFixture
+
+from frequenz.sdk.microgrid._old_component_data import InverterData
+from frequenz.sdk.microgrid._power_distributing import ComponentPoolStatus
+from frequenz.sdk.microgrid._power_distributing._component_managers._component_manager import (
+    ComponentManager,
+    _UnreachablePower,
+)
+from frequenz.sdk.microgrid._power_distributing._component_managers._pv_inverter_manager._pv_inverter_manager import (  # noqa: E501
+    PVManager,
+)
+from frequenz.sdk.microgrid._power_distributing._component_pool_status_tracker import (
+    ComponentPoolStatusTracker,
+)
+from frequenz.sdk.microgrid._power_distributing.request import Request
+from frequenz.sdk.microgrid._power_distributing.result import Result, Success
+from frequenz.sdk.timeseries import Sample
+from frequenz.sdk.timeseries.formulas._formula_pool import FormulaPool
+
+from ...timeseries.mock_microgrid import MockMicrogrid
+
+# The tests drive the managers through their internal hooks and caches.
+# pylint: disable=protected-access
+
+_PV_MODULE = (
+    "frequenz.sdk.microgrid._power_distributing._component_managers"
+    "._pv_inverter_manager._pv_inverter_manager"
+)
+
+
+def _formula_for(component_ids: abc.Set[ComponentId]) -> str:
+    """Return a deterministic formula string for a set of components."""
+    return "power:" + ",".join(str(c) for c in sorted(component_ids))
+
+
+class _PoolFormula:
+    """A pooled-formula stub backed by a real broadcast channel."""
+
+    def __init__(self) -> None:
+        self._channel = Broadcast[Sample[Quantity]](name="unreachable-stub")
+
+    def new_receiver(self) -> Receiver[Sample[Quantity]]:
+        """Return a receiver for the formula's (empty) output stream."""
+        return self._channel.new_receiver()
+
+
+class _RecordingPool:
+    """A `FormulaPool` stub that records its lifecycle calls."""
+
+    def __init__(self) -> None:
+        self.created: list[str] = []
+        self.stopped: list[str] = []
+        self.stop_all_count = 0
+
+    def from_string(self, formula_str: str, metric: Metric) -> _PoolFormula:
+        """Record the creation and return a feedable stub formula."""
+        # pylint: disable=unused-argument
+        self.created.append(formula_str)
+        return _PoolFormula()
+
+    async def stop_string_formula(self, formula_str: str, metric: Metric) -> None:
+        """Record that a single string formula was stopped."""
+        # pylint: disable=unused-argument
+        self.stopped.append(formula_str)
+
+    async def stop(self) -> None:
+        """Record that the whole pool was stopped."""
+        self.stop_all_count += 1
+
+
+class _MechanismManager(ComponentManager):
+    """A minimal manager that exercises the shared unreachable-power mechanism."""
+
+    def component_ids(self) -> abc.Set[ComponentId]:
+        """Return no components; unused by these tests."""
+        return set()
+
+    async def start(self) -> None:
+        """Do nothing; unused by these tests."""
+
+    async def distribute_power(self, request: Request) -> None:
+        """Do nothing; unused by these tests."""
+        # pylint: disable=unused-argument
+
+    async def stop(self) -> None:
+        """Stop the unreachable-power subscriptions and owned pool."""
+        await self._stop_all_unreachable_power_subscriptions()
+
+    def _unreachable_power_formula(self, component_ids: abc.Set[ComponentId]) -> str:
+        """Return a deterministic formula string for the given components."""
+        return _formula_for(component_ids)
+
+
+class TestUnreachablePowerMechanism:
+    """Tests for the shared `ComponentManager` unreachable-power logic."""
+
+    async def test_subscription_restarts_when_unreachable_set_changes(
+        self, mocker: MockerFixture
+    ) -> None:
+        """Subscriptions are restarted on set changes and torn down when reachable."""
+        pool = _RecordingPool()
+        mocker.patch(
+            "frequenz.sdk.microgrid._data_pipeline._new_formula_pool",
+            return_value=pool,
+        )
+        manager = _MechanismManager()
+        requested = {ComponentId(1), ComponentId(2), ComponentId(3)}
+
+        # First request: only component 3 is unreachable.
+        await manager._subscribe_to_unreachable_power(
+            requested, {ComponentId(1), ComponentId(2)}
+        )
+        assert pool.created == [_formula_for({ComponentId(3)})]
+        assert not pool.stopped
+
+        # Re-subscribing with the same unreachable subset is a no-op.
+        await manager._subscribe_to_unreachable_power(
+            requested, {ComponentId(1), ComponentId(2)}
+        )
+        assert pool.created == [_formula_for({ComponentId(3)})]
+
+        # The unreachable subset grows to {2, 3}: the old formula is stopped and a
+        # new one is created.
+        await manager._subscribe_to_unreachable_power(requested, {ComponentId(1)})
+        assert pool.stopped == [_formula_for({ComponentId(3)})]
+        assert pool.created == [
+            _formula_for({ComponentId(3)}),
+            _formula_for({ComponentId(2), ComponentId(3)}),
+        ]
+
+        # Everything is reachable again: the subscription is torn down.
+        await manager._subscribe_to_unreachable_power(requested, requested)
+        assert pool.stopped == [
+            _formula_for({ComponentId(3)}),
+            _formula_for({ComponentId(2), ComponentId(3)}),
+        ]
+        assert not manager._unreachable_power_subscriptions
+
+        # Manager shutdown stops the owned formula pool.
+        await manager.stop()
+        assert pool.stop_all_count == 1
+
+    async def test_failed_cache_stop_still_stops_formula(
+        self, mocker: MockerFixture
+    ) -> None:
+        """A failing cache teardown must not leave the formula running."""
+        pool = _RecordingPool()
+        manager = _MechanismManager()
+        manager._unreachable_power_pool = cast(FormulaPool, pool)
+
+        failing_cache = mocker.MagicMock(spec=LatestValueCache)
+        failing_cache.stop = mocker.AsyncMock(side_effect=RuntimeError("cache boom"))
+        formula = _formula_for({ComponentId(2)})
+        subscription = _UnreachablePower(
+            component_ids={ComponentId(2)},
+            formula=formula,
+            cache=cast(LatestValueCache[Sample[Power]], failing_cache),
+        )
+
+        with pytest.raises(RuntimeError, match="cache boom"):
+            await manager._stop_unreachable_power_subscription(subscription)
+
+        # Despite the cache failure, the formula was stopped via the finally block.
+        assert pool.stopped == [formula]
+
+
+def _pv_cache(
+    mocker: MockerFixture, lower_bound_w: float
+) -> LatestValueCache[InverterData]:
+    """Build a PV inverter data cache with a fixed inclusion lower bound."""
+    cache = mocker.MagicMock(spec=LatestValueCache)
+    cache.has_value.return_value = True
+    data = mocker.MagicMock(spec=InverterData)
+    data.active_power_inclusion_lower_bound = lower_bound_w
+    cache.get.return_value = data
+    return cast(LatestValueCache[InverterData], cache)
+
+
+async def _make_pv_manager(
+    mocker: MockerFixture,
+    *,
+    working: abc.Set[ComponentId],
+    lower_bound_w: float,
+) -> tuple[PVManager, AsyncMock]:
+    """Build a PV manager with mocked status tracking, caches and API calls."""
+    tracker = mocker.MagicMock(spec=ComponentPoolStatusTracker)
+    tracker.get_working_components.return_value = working
+    tracker.stop = mocker.AsyncMock()
+    mocker.patch(f"{_PV_MODULE}.ComponentPoolStatusTracker", return_value=tracker)
+
+    status_channel = Broadcast[ComponentPoolStatus](name="pv_status")
+    results_channel = Broadcast[Result](name="pv_results")
+    manager = PVManager(
+        component_pool_status_sender=status_channel.new_sender(),
+        results_sender=results_channel.new_sender(),
+        api_power_request_timeout=timedelta(seconds=1),
+    )
+    manager._component_data_caches = {
+        inv: _pv_cache(mocker, lower_bound_w) for inv in working
+    }
+    set_power = mocker.patch(
+        f"{_PV_MODULE}._set_component_power",
+        new=mocker.AsyncMock(return_value=mocker.MagicMock(spec=Success)),
+    )
+    return manager, set_power
+
+
+class TestPVUnreachablePowerDistribution:
+    """Tests for how the PV manager applies measured unreachable power."""
+
+    async def test_subtracts_unreachable_power_from_target(
+        self, mocker: MockerFixture
+    ) -> None:
+        """Measured unreachable PV power is subtracted from the reachable target."""
+        mockgrid = MockMicrogrid(grid_meter=True, mocker=mocker)
+        mockgrid.add_solar_inverters(3)
+        async with mockgrid:
+            pv_ids = set(mockgrid.pv_inverter_ids)
+            working = set(sorted(pv_ids)[:2])
+            manager, set_power = await _make_pv_manager(
+                mocker, working=working, lower_bound_w=-500.0
+            )
+            mocker.patch.object(
+                manager, "_subscribe_to_unreachable_power", mocker.AsyncMock()
+            )
+            mocker.patch.object(
+                manager, "_unreachable_power", return_value=Power.from_watts(-300.0)
+            )
+
+            await manager.distribute_power(
+                Request(power=Power.from_watts(-1000.0), component_ids=pv_ids)
+            )
+
+        kwargs = set_power.call_args.kwargs
+        assert kwargs["target_power"].isclose(Power.from_watts(-1000.0))
+        allocated = Power.zero()
+        for power in kwargs["allocations"].values():
+            allocated += power
+        # 1000 W requested minus the 300 W already produced by the unreachable
+        # inverter leaves 700 W to split across the two reachable inverters.
+        assert allocated.isclose(Power.from_watts(-700.0))
+
+    async def test_unreachable_power_exceeding_target(
+        self, mocker: MockerFixture
+    ) -> None:
+        """When unreachable production exceeds the target, nothing is requested."""
+        mockgrid = MockMicrogrid(grid_meter=True, mocker=mocker)
+        mockgrid.add_solar_inverters(3)
+        async with mockgrid:
+            pv_ids = set(mockgrid.pv_inverter_ids)
+            working = set(sorted(pv_ids)[:2])
+            manager, set_power = await _make_pv_manager(
+                mocker, working=working, lower_bound_w=-500.0
+            )
+            mocker.patch.object(
+                manager, "_subscribe_to_unreachable_power", mocker.AsyncMock()
+            )
+            mocker.patch.object(
+                manager, "_unreachable_power", return_value=Power.from_watts(-1200.0)
+            )
+
+            await manager.distribute_power(
+                Request(power=Power.from_watts(-1000.0), component_ids=pv_ids)
+            )
+
+        kwargs = set_power.call_args.kwargs
+        # The unreachable inverters already over-produce, so the reachable inverters
+        # are asked for nothing and the surplus is reported as remaining power.
+        assert all(power == Power.zero() for power in kwargs["allocations"].values())
+        assert kwargs["remaining_power"].isclose(Power.from_watts(200.0))

--- a/tests/timeseries/_formulas/test_formula_pool.py
+++ b/tests/timeseries/_formulas/test_formula_pool.py
@@ -1,0 +1,169 @@
+# License: MIT
+# Copyright © 2025 Frequenz Energy-as-a-Service GmbH
+
+"""Tests for the formula pool's caching and teardown behavior."""
+
+import asyncio
+from typing import cast
+
+import pytest
+from frequenz.channels import Broadcast
+from frequenz.client.microgrid.metrics import Metric
+from frequenz.quantities import Quantity
+
+from frequenz.sdk._internal._channels import ChannelRegistry
+from frequenz.sdk.microgrid._data_sourcing import ComponentMetricRequest
+from frequenz.sdk.timeseries.formulas._formula import Formula
+from frequenz.sdk.timeseries.formulas._formula_pool import FormulaPool
+
+# The tests inspect the pool's caches directly to assert eviction.
+# pylint: disable=protected-access
+
+
+def _make_pool() -> FormulaPool:
+    """Create a formula pool wired to inert, real channels."""
+    request_channel = Broadcast[ComponentMetricRequest](name="resampler-requests")
+    return FormulaPool(
+        "test-pool",
+        ChannelRegistry(name="test-registry"),
+        request_channel.new_sender(),
+    )
+
+
+class _StubFormula:
+    """A stand-in for a pooled formula that records and can stall/fail `stop()`."""
+
+    def __init__(self) -> None:
+        self.stop_count = 0
+        self.entered = asyncio.Event()
+        """Set when `stop()` is entered, so a test can await mid-teardown."""
+        self.release = asyncio.Event()
+        """A blocking `stop()` waits on this before returning."""
+        self.block = False
+        self.error: BaseException | None = None
+
+    async def stop(self) -> None:
+        """Record the call, optionally block, then optionally raise."""
+        self.stop_count += 1
+        self.entered.set()
+        if self.block:
+            await self.release.wait()
+        if self.error is not None:
+            raise self.error
+
+
+def _as_formula(stub: _StubFormula) -> Formula[Quantity]:
+    """Cast a stub to the type the string-formula cache stores."""
+    return cast(Formula[Quantity], stub)
+
+
+class TestFormulaPool:
+    """Tests for `FormulaPool`."""
+
+    async def test_from_string_distinguishes_colliding_keys(self) -> None:
+        """`from_string` keys on `(formula, metric)`, not a lossy concatenation."""
+        pool = _make_pool()
+
+        # These two (formula, metric) pairs both collapse to "#123" under the old
+        # `formula_str + str(metric.value)` scheme, yet are distinct formulas.
+        assert "#12" + str(Metric.DC_POWER.value) == "#1" + str(
+            Metric.AC_POWER_APPARENT_PHASE_1.value
+        )
+
+        first = pool.from_string("#12", Metric.DC_POWER)
+        second = pool.from_string("#1", Metric.AC_POWER_APPARENT_PHASE_1)
+
+        assert first is not second
+        assert len(pool._string_formulas) == 2
+        # Each pair still resolves to its own cached formula on repeat.
+        assert pool.from_string("#12", Metric.DC_POWER) is first
+        assert pool.from_string("#1", Metric.AC_POWER_APPARENT_PHASE_1) is second
+
+        await pool.stop()
+
+    async def test_stop_stops_and_evicts_string_formulas(self) -> None:
+        """`stop()` stops every string formula and clears the cache."""
+        pool = _make_pool()
+        stubs = {
+            ("a", Metric.AC_POWER_ACTIVE): _StubFormula(),
+            ("b", Metric.DC_POWER): _StubFormula(),
+        }
+        for key, stub in stubs.items():
+            pool._string_formulas[key] = _as_formula(stub)
+
+        await pool.stop()
+
+        assert all(stub.stop_count == 1 for stub in stubs.values())
+        assert not pool._string_formulas
+
+    async def test_stop_string_formula_stops_only_the_requested_one(self) -> None:
+        """`stop_string_formula` stops and evicts just the requested formula."""
+        pool = _make_pool()
+        keep, drop = _StubFormula(), _StubFormula()
+        keep_key = ("keep", Metric.AC_POWER_ACTIVE)
+        drop_key = ("drop", Metric.AC_POWER_ACTIVE)
+        pool._string_formulas[keep_key] = _as_formula(keep)
+        pool._string_formulas[drop_key] = _as_formula(drop)
+
+        await pool.stop_string_formula("drop", Metric.AC_POWER_ACTIVE)
+
+        assert drop.stop_count == 1
+        assert drop_key not in pool._string_formulas
+        assert keep.stop_count == 0
+        assert keep_key in pool._string_formulas
+
+    async def test_stop_string_formula_keeps_handle_when_stop_fails(self) -> None:
+        """A failed `stop()` leaves the formula in the pool so cleanup can retry."""
+        pool = _make_pool()
+        stub = _StubFormula()
+        stub.error = RuntimeError("boom")
+        key = ("formula", Metric.AC_POWER_ACTIVE)
+        pool._string_formulas[key] = _as_formula(stub)
+
+        with pytest.raises(RuntimeError, match="boom"):
+            await pool.stop_string_formula("formula", Metric.AC_POWER_ACTIVE)
+
+        assert stub.stop_count == 1
+        assert key in pool._string_formulas
+
+    async def test_stop_keeps_formula_added_during_teardown(self) -> None:
+        """A formula added while `stop()` awaits is not dropped without stopping."""
+        pool = _make_pool()
+        blocker = _StubFormula()
+        blocker.block = True
+        blocker_key = ("blocker", Metric.AC_POWER_ACTIVE)
+        pool._string_formulas[blocker_key] = _as_formula(blocker)
+
+        stopping = asyncio.create_task(pool.stop())
+        # Wait until stop() is awaiting the blocker's stop(), i.e. mid-teardown.
+        await blocker.entered.wait()
+
+        # A concurrent from_string() adds an entry after stop()'s key snapshot.
+        added_key = ("#9", Metric.AC_POWER_ACTIVE)
+        added = pool.from_string("#9", Metric.AC_POWER_ACTIVE)
+
+        blocker.release.set()
+        await stopping
+
+        # The blocker was stopped and evicted; the late addition survived (it must
+        # not be cleared without being stopped).
+        assert blocker.stop_count == 1
+        assert blocker_key not in pool._string_formulas
+        assert added_key in pool._string_formulas
+        assert pool.from_string("#9", Metric.AC_POWER_ACTIVE) is added
+
+        await pool.stop()
+
+    async def test_from_reactive_power_formula_is_cached(self) -> None:
+        """Repeated `from_reactive_power_formula` calls reuse the cached formula."""
+        pool = _make_pool()
+
+        first = pool.from_reactive_power_formula("grid_reactive_power", "#1")
+        second = pool.from_reactive_power_formula("grid_reactive_power", "#1")
+
+        assert first is second
+        assert len(pool._reactive_power_formulas) == 1
+        # Regression: reactive formulas must not leak into the active-power cache.
+        assert not pool.power_formulas
+
+        await pool.stop()


### PR DESCRIPTION
The power distributor runs a formula for each set of unreachable components.  They were created on the shared logical-meter pool, which never evicts unused formulas.

On teardown only the cache was stopped, not the formula — so a formula-evaluating actor leaked per distinct set, and CPU climbed over time until a restart.

## Changes

* `FormulaPool`: `stop()` now also stops string formulas; new `stop_string_formula()` stops + evicts a single one.
* Each `ComponentManager` lazily owns a dedicated `FormulaPool` (new `_DataPipeline.new_formula_pool`) and stops its formulas on teardown, via a per-type `_unreachable_power_formula` hook. Battery and PV use it.
* Fix `from_reactive_power_formula` checking the wrong cache dict, which re-created and leaked the grid reactive-power formula on every access.

## Breaking

* PV distribution now subtracts the power of unreachable PV inverters from the target, so PV results differ when some inverters are unreachable.