### PR TITLE
Fix the wheel build by updating setuptools-scm to 10.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 [build-system]
 requires = [
   "setuptools == 82.0.1",
-  "setuptools_scm[toml] == 10.0.5",
+  "setuptools_scm[toml] == 10.2.0",
   "frequenz-repo-config[lib] == 0.18.0",
 ]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
`setuptools-scm == 10.0.5` asks for `vcs-versioning >= 1.0.0.dev0` with no upper bound.  `vcs-versioning` 2.x came out at the end of June 2026, and with it the build of the wheel from the sdist fails: in the unpacked sdist there is no git repository, and reading the version from `PKG-INFO` no longer works.  So `python -Im build` fails with `LookupError: setuptools-scm was unable to detect version`.

`setuptools-scm == 10.2.0` asks for `vcs-versioning >= 2.0.0.dev0, < 3`, so it works with the new version again.