### PR TITLE
Require quantities 1.0.2 for marshmallow 4

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,6 +10,8 @@
 
 <!-- Here goes notes on how to upgrade from previous versions, including deprecations and what they should be replaced with -->
 
+- The minimum versions are now `frequenz-quantities` 1.0.3 and `marshmallow` 4.0.0, enabling marshmallow 4 support without breaking strict documentation builds.
+
 ## New Features
 
 <!-- Here goes the main new features and examples or instructions on how to use them -->

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,10 +33,10 @@ dependencies = [
   "frequenz-microgrid-component-graph >= 0.5.0, < 0.6",
   "frequenz-client-common >= 0.3.6, < 0.5.0",
   "frequenz-channels >= 1.6.1, < 2.0.0",
-  "frequenz-quantities[marshmallow] >= 1.0.0, < 2.0.0",
+  "frequenz-quantities[marshmallow] >= 1.0.3, < 2.0.0",
   "numpy >= 2.1.0, < 3",
   "typing_extensions >= 4.14.1, < 5",
-  "marshmallow >= 3.19.0, < 5",
+  "marshmallow >= 4.0.0, < 5",
   "marshmallow_dataclass >= 8.7.1, < 9",
   "more-itertools >= 10.8.0, < 12",
 ]


### PR DESCRIPTION
Require the marshmallow 4-compatible quantities release.

Update configuration validation tests for marshmallow 4.